### PR TITLE
BIP67: Ensure whilst sorting only compressed public keys are used

### DIFF
--- a/qa/rpc-tests/sort_multisig.py
+++ b/qa/rpc-tests/sort_multisig.py
@@ -15,6 +15,51 @@ class SortMultisigTest(BitcoinTestFramework):
         self.setup_clean_chain = True
 
     def run_test(self):
+        self.run_simple_test()
+        self.run_demonstrate_sorting()
+        self.test_compressed_keys_forbidden()
+
+    def run_demonstrate_sorting(self):
+        pub1 = "022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da"
+        pub2 = "03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9"
+        pub3 = "021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18"
+
+        sorted = self.nodes[0].createmultisig(2, [pub3,pub1,pub2,])
+
+        self.test_if_result_matches(2, [pub1,pub2,pub3], True, sorted["address"])
+        self.test_if_result_matches(2, [pub1,pub3,pub2], True, sorted["address"])
+        self.test_if_result_matches(2, [pub2,pub3,pub1], True, sorted["address"])
+        self.test_if_result_matches(2, [pub2,pub1,pub3], True, sorted["address"])
+        self.test_if_result_matches(2, [pub3,pub1,pub2], True, sorted["address"])
+        self.test_if_result_matches(2, [pub3,pub2,pub1], True, sorted["address"])
+
+        self.test_if_result_matches(2, [pub1,pub2,pub3], False, sorted["address"])
+        self.test_if_result_matches(2, [pub1,pub3,pub2], False, sorted["address"])
+        self.test_if_result_matches(2, [pub2,pub3,pub1], False, sorted["address"])
+        self.test_if_result_matches(2, [pub2,pub1,pub3], False, sorted["address"])
+        self.test_if_result_matches(2, [pub3,pub2,pub1], False, sorted["address"])
+
+    def test_if_result_matches(self, m, keys, sort, against):
+        result = self.nodes[0].createmultisig(m, keys, {"sort": sort})
+        assert_equal(sort, result["address"] == against)
+
+    def test_compressed_keys_forbidden(self):
+        pub1 = "02fdf7e1b65a477a7815effde996a03a7d94cbc46f7d14c05ef38425156fc92e22"
+        pub2 = "04823336da95f0b4cf745839dff26992cef239ad2f08f494e5b57c209e4f3602d5526bc251d480e3284d129f736441560e17f3a7eb7ed665fdf0158f44550b926c"
+        rs = "522102fdf7e1b65a477a7815effde996a03a7d94cbc46f7d14c05ef38425156fc92e224104823336da95f0b4cf745839dff26992cef239ad2f08f494e5b57c209e4f3602d5526bc251d480e3284d129f736441560e17f3a7eb7ed665fdf0158f44550b926c52ae"
+        pubs = [pub1,pub2]
+
+        default = self.nodes[0].createmultisig(2, pubs)
+        assert_equal(rs, default["redeemScript"])
+
+        unsorted = self.nodes[0].createmultisig(2, pubs, {"sort": False})
+        assert_equal(rs, unsorted["redeemScript"])
+        assert_equal(default["address"], unsorted["address"])
+        assert_equal(default["redeemScript"], unsorted["redeemScript"])
+
+        assert_raises_jsonrpc(-1, "Compressed key required for BIP67: 04823336da95f0b4cf745839dff26992cef239ad2f08f494e5b57c209e4f3602d5526bc251d480e3284d129f736441560e17f3a7eb7ed665fdf0158f44550b926c", self.nodes[0].createmultisig, 2, pubs, {"sort": True})
+
+    def run_simple_test(self):
         pub1 = "022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da"
         pub2 = "03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9"
         pub3 = "021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18"

--- a/qa/rpc-tests/wallet-accounts.py
+++ b/qa/rpc-tests/wallet-accounts.py
@@ -7,6 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     start_node,
     assert_equal,
+    assert_raises_jsonrpc,
     connect_nodes_bi,
 )
 
@@ -43,6 +44,23 @@ class WalletAccountsTest(BitcoinTestFramework):
         assert_equal(sorted_default, sorted_false)
         assert_equal("2N6dne8yzh13wsRJxCcMgCYNeN9fxKWNHt8", sorted_default)
         assert_equal("2MsJ2YhGewgDPGEQk4vahGs4wRikJXpRRtU", sorted_true)
+
+    def test_sort_multisig_with_uncompressed_hash160(self, node):
+        node.importpubkey("02632b12f4ac5b1d1b72b2a3b508c19172de44f6f46bcee50ba33f3f9291e47ed0")
+        node.importpubkey("04dd4fe618a8ad14732f8172fe7c9c5e76dd18c2cc501ef7f86e0f4e285ca8b8b32d93df2f4323ebb02640fa6b975b2e63ab3c9d6979bc291193841332442cc6ad")
+        address = "2MxvEpFdXeEDbnz8MbRwS23kDZC8tzQ9NjK"
+
+        addresses = [
+            "msDoRfEfZQFaQNfAEWyqf69H99yntZoBbG",
+            "myrfasv56W7579LpepuRy7KFhVhaWsJYS8",
+        ]
+        default = self.nodes[0].addmultisigaddress(2, addresses)
+        assert_equal(address, default)
+
+        unsorted = self.nodes[0].addmultisigaddress(2, addresses, {"sort": False})
+        assert_equal(address, unsorted)
+
+        assert_raises_jsonrpc(-1, "Compressed key required for BIP67: myrfasv56W7579LpepuRy7KFhVhaWsJYS8", node.addmultisigaddress, 2, addresses, {"sort": True})
 
     def run_test (self):
         node = self.nodes[0]
@@ -110,6 +128,7 @@ class WalletAccountsTest(BitcoinTestFramework):
         for account in accounts:
             assert_equal(node.getbalance(account), 50)
         self.test_sort_multisig(node)
+        self.test_sort_multisig_with_uncompressed_hash160(node)
 
 if __name__ == '__main__':
     WalletAccountsTest().main ()

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -285,6 +285,8 @@ CScript _createmultisig_redeemScript(CWallet * const pwallet, const UniValue& pa
             }
             if (!vchPubKey.IsFullyValid())
                 throw runtime_error(" Invalid public key: "+ks);
+            if (fSorted && !vchPubKey.IsCompressed())
+                throw runtime_error(" Compressed key required for BIP67: "+ks);
             pubkeys[i] = vchPubKey;
         }
 
@@ -296,6 +298,8 @@ CScript _createmultisig_redeemScript(CWallet * const pwallet, const UniValue& pa
             CPubKey vchPubKey(ParseHex(ks));
             if (!vchPubKey.IsFullyValid())
                 throw runtime_error(" Invalid public key: "+ks);
+            if (fSorted && !vchPubKey.IsCompressed())
+                throw runtime_error(" Compressed key required for BIP67: "+ks);
             pubkeys[i] = vchPubKey;
         }
         else


### PR DESCRIPTION
Adds a check that keys are compressed before proceeding with sorting. I had forgotten this check in my first branch, here's hoping not many people tried an uncompressed key :/