### PR TITLE
remove annoying log line from GetWalletNameFromJSONRPCRequest

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -136,7 +136,6 @@ std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& reques
     have_requested_wallet = GetWalletNameFromJSONRPCRequest(request, requested_wallet_name);
 
     std::shared_ptr<CWallet> pwallet;
-    LogPrintf("uri=%s wres=%s wreq=%s\n", request.URI, have_wallet_restriction?authorized_wallet_name:"(n/a)", have_requested_wallet?requested_wallet_name:"(n/a)");
 
     if (!have_wallet_restriction) {
         // Any wallet is permitted; select by endpoint, or use the sole wallet


### PR DESCRIPTION
There is an annoying log line on `GetWalletNameFromJSONRPCRequest` that is clogging the logs:

![](https://user-images.githubusercontent.com/1653275/92630421-396a9280-f2a6-11ea-9860-fe07347bcb9f.png)

I don't understand why it is needed, and since there is no other similar or related log lines I removed it.