### PR TITLE
Increase `MAX_OP_RETURN_RELAY` default to 83 bytes to align with Bitcoin Core

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -33,10 +33,10 @@ public:
 };
 
 /**
- * Default setting for -datacarriersize. 40 bytes of data, +1 for OP_RETURN,
- * +1 for the pushdata opcode.
+ * Default setting for -datacarriersize. 80 bytes of data, +1 for OP_RETURN,
+ * +2 for the pushdata opcode.
  */
-static constexpr unsigned int MAX_OP_RETURN_RELAY{42};
+static constexpr unsigned int MAX_OP_RETURN_RELAY{83};
 /** Default for -datacarrierfullcount */
 static constexpr bool DEFAULT_DATACARRIER_FULLCOUNT{true};
 


### PR DESCRIPTION
Revert `MAX_OP_RETURN_RELAY` to realign with #Bitcoin Core.

Looks like you inadvertently reduced #Bitcoin Core's data carrier size which had that side effect of censoring #PayNyms and #CoinJoin:

https://sourcegraph.com/github.com/bitcoinknots/bitcoin/-/commit/b7eb294a25378a3cb1c3db193f7b58109a321906?visible=10

<!--
*** Please remove the following help text before submitting: ***

Before opening a pull request to Bitcoin Knots, please first consider if it
is appropriate for Bitcoin Core and, if so, rebase it and [open a pull request](https://github.com/bitcoin/bitcoin/compare)
there first! Bitcoin Core has a strict and slow review process, but since
Knots is more relaxed, feel free to request a merge of your Core PR into
Knots even while it's waiting on Core.

-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Knots user experience or Bitcoin Knots developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are typically welcome.
* Refactoring changes are never accepted in Knots, and must be performed in
  Bitcoin Core.
-->
