### PR TITLE
Add stdint headers

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -29,6 +29,7 @@
 
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 static const int CLIENT_VERSION =
                              10000 * CLIENT_VERSION_MAJOR


### PR DESCRIPTION
Unable to complete the compilation on Alpine Linux.

```
In file included from dbwrapper.cpp:5:
In file included from ./dbwrapper.h:8:
./clientversion.h:49:14: error: unknown type name 'int64_t'
   49 | static const int64_t SECONDS_PER_YEAR = 31558060;
      |              ^
./clientversion.h:51:14: error: unknown type name 'int64_t'
   51 | static const int64_t DEFAULT_SOFTWARE_EXPIRY = ((COPYRIGHT_YEAR - POSIX_EPOCH_YEAR) * SECONDS_PER_YEAR) + (SECONDS_PER_YEAR * 2);
      |              ^
./clientversion.h:53:28: error: unknown type name 'int64_t'
   53 | bool IsThisSoftwareExpired(int64_t nTime);
      |                            ^
  CXX      libbitcoin_node_a-flatfile.o
3 errors generated.
```

This should enable support for various integer types like `int64_t` on certain systems, like Alpine.