### PR TITLE
fix: typo in development process documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Development generally takes place as part of [Bitcoin Core](https://github.com/b
 Knots for each release.
 
 Even if your pull request to Core is closed, or if your feature is not
-suitable for Core (eg, because it builds on a features not supported in Core;
+suitable for Core (eg, because it builds on a feature not supported in Core;
 relies on centralised services; etc), it may still be eligible for inclusion
 in Bitcoin Knots. In this case, a pull request may be opened on the
 [Knots GitHub](https://github.com/bitcoinknots/bitcoin) for review and consideration.


### PR DESCRIPTION
Corrected the typo "features" in the development process section of the documentation. Changed "eg, because it builds on a *features* not supported in Core;" to "e.g., because it builds on a *feature* not supported in Core;".

<!--
*** Please remove the following help text before submitting: ***

Before opening a pull request to Bitcoin Knots, please first consider if it
is appropriate for Bitcoin Core and, if so, rebase it and [open a pull request](https://github.com/bitcoin/bitcoin/compare)
there first! Bitcoin Core has a strict and slow review process, but since
Knots is more relaxed, feel free to request a merge of your Core PR into
Knots even while it's waiting on Core.

-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Knots user experience or Bitcoin Knots developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are typically welcome.
* Refactoring changes are never accepted in Knots, and must be performed in
  Bitcoin Core.
-->
