### PR TITLE
unlock signet miner max-interval parameter

### DIFF
--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -308,8 +308,8 @@ def do_generate(args):
             return 1
         my_blocks = (start-1, stop, total)
 
-    if args.max_interval < 960:
-        logging.error("--max-interval must be at least 960 (16 minutes)")
+    if args.max_interval < 1:
+        logging.error("--max-interval must be at least 1 second")
         return 1
 
     ultimate_target = nbits_to_target(int(args.nbits,16))


### PR DESCRIPTION
Since Knots implemented the `signetblocktime` option that [Core rejected](https://github.com/bitcoin/bitcoin/pull/27446), I think it would make sense that it also unlocked the `--max-interval` flag in the miner script, so that it can mine blocks continuously on shorter intervals.

I've tested this for a few minutes with `signetblocktime=1` on Knots and `--max-interval=1` on the miner at my [signet playground](https://github.com/BcnBitcoinOnly/signet-playground), and seems to run stable.