### PR TITLE
Policy: warn if `-minrelaytxfee` is too high

### DIFF
--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -110,7 +110,10 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
     }
 
     if (argsman.IsArgSet("-minrelaytxfee")) {
-        if (std::optional<CAmount> min_relay_feerate = ParseMoney(argsman.GetArg("-minrelaytxfee", ""))) {
+        std::optional<CAmount> min_relay_feerate = ParseMoney(argsman.GetArg("-minrelaytxfee", ""));
+        if (min_relay_feerate >= 100000000 && (std::string(1, std::string(argsman.GetArg("-minrelaytxfee", "")).at(0)) != "f")) {
+            return util::Error{_("-minrelaytxfee is very high! Prefix with f to force this fee rate")};
+        } else if (min_relay_feerate) {
             // High fee check is done afterward in CWallet::Create()
             mempool_opts.min_relay_feerate = CFeeRate{min_relay_feerate.value()};
         } else {

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -55,7 +55,8 @@ std::optional<CAmount> ParseMoney(const std::string& money_string)
     std::string strWhole;
     int64_t nUnits = 0;
     const char* p = str.c_str();
-    for (; *p; p++)
+    int position =0;
+    for (; *p; p++, position++)
     {
         if (*p == '.')
         {
@@ -70,9 +71,11 @@ std::optional<CAmount> ParseMoney(const std::string& money_string)
         }
         if (IsSpace(*p))
             return std::nullopt;
-        if (!IsDigit(*p))
-            return std::nullopt;
+        if (!(position == 0 && *p == 'f')) {
+            if (!IsDigit(*p))
+                return std::nullopt;
         strWhole.insert(strWhole.end(), *p);
+        }
     }
     if (*p) {
         return std::nullopt;


### PR DESCRIPTION
Stop `bitcoind` if the value of `-minrelaytxfee` is superior or equal to `1`. Can be forced with a prefix (i.e `f1`)