### PR TITLE
crypto/sha256: Use pragmas to enforce necessary intrinsics for GCC and Clang

### DIFF
--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -164,8 +164,15 @@ if(NOT MSVC)
 
   # Check for SSE4.1 intrinsics.
   set(SSE41_CXXFLAGS -msse4.1)
-  check_cxx_source_compiles_with_flags("
+  check_cxx_source_compiles_with_flags([[
     #include <immintrin.h>
+
+    #if defined(__clang__)
+    #pragma clang attribute push(__attribute__((__target__("sse4.1"))), apply_to = function)
+    __attribute__((__target__("arch=skylake-avx512")))
+    #elif defined(__GNUC__)
+    #pragma GCC target ("sse4.1")
+    #endif
 
     int main()
     {
@@ -174,30 +181,50 @@ if(NOT MSVC)
       __m128i r = _mm_blend_epi16(a, b, 0xFF);
       return _mm_extract_epi32(r, 3);
     }
-    " HAVE_SSE41
+
+    #if defined(__clang__)
+    #pragma clang attribute pop
+    #endif
+    ]] HAVE_SSE41
     CXXFLAGS ${SSE41_CXXFLAGS}
   )
   set(ENABLE_SSE41 ${HAVE_SSE41})
 
   # Check for AVX2 intrinsics.
   set(AVX2_CXXFLAGS -mavx -mavx2)
-  check_cxx_source_compiles_with_flags("
+  check_cxx_source_compiles_with_flags([[
     #include <immintrin.h>
+
+    #if defined(__clang__)
+    #pragma clang attribute push(__attribute__((__target__("avx,avx2"))), apply_to = function)
+    #elif defined(__GNUC__)
+    #pragma GCC target ("avx,avx2")
+    #endif
 
     int main()
     {
       __m256i l = _mm256_set1_epi32(0);
       return _mm256_extract_epi32(l, 7);
     }
-    " HAVE_AVX2
+
+    #if defined(__clang__)
+    #pragma clang attribute pop
+    #endif
+    ]] HAVE_AVX2
     CXXFLAGS ${AVX2_CXXFLAGS}
   )
   set(ENABLE_AVX2 ${HAVE_AVX2})
 
   # Check for x86 SHA-NI intrinsics.
   set(X86_SHANI_CXXFLAGS -msse4 -msha)
-  check_cxx_source_compiles_with_flags("
+  check_cxx_source_compiles_with_flags([[
     #include <immintrin.h>
+
+    #if defined(__clang__)
+    #pragma clang attribute push(__attribute__((__target__("sse4,sse4.1,sha"))), apply_to = function)
+    #elif defined(__GNUC__)
+    #pragma GCC target ("sse4,sse4.1,sha")
+    #endif
 
     int main()
     {
@@ -206,15 +233,25 @@ if(NOT MSVC)
       __m128i k = _mm_set1_epi32(2);
       return _mm_extract_epi32(_mm_sha256rnds2_epu32(i, j, k), 0);
     }
-    " HAVE_X86_SHANI
+
+    #if defined(__clang__)
+    #pragma clang attribute pop
+    #endif
+    ]] HAVE_X86_SHANI
     CXXFLAGS ${X86_SHANI_CXXFLAGS}
   )
   set(ENABLE_X86_SHANI ${HAVE_X86_SHANI})
 
   # Check for ARMv8 SHA-NI intrinsics.
   set(ARM_SHANI_CXXFLAGS -march=armv8-a+crypto)
-  check_cxx_source_compiles_with_flags("
+  check_cxx_source_compiles_with_flags([[
     #include <arm_neon.h>
+
+    #if defined(__clang__)
+    #pragma clang attribute push(__attribute__((__target__("armv8-a+crypto"))), apply_to = function)
+    #elif defined(__GNUC__)
+    #pragma GCC target ("armv8-a+crypto")
+    #endif
 
     int main()
     {
@@ -224,7 +261,11 @@ if(NOT MSVC)
       vsha256su0q_u32(a, b);
       vsha256su1q_u32(a, b, c);
     }
-    " HAVE_ARM_SHANI
+
+    #if defined(__clang__)
+    #pragma clang attribute pop
+    #endif
+    ]] HAVE_ARM_SHANI
     CXXFLAGS ${ARM_SHANI_CXXFLAGS}
   )
   set(ENABLE_ARM_SHANI ${HAVE_ARM_SHANI})

--- a/src/crypto/sha256_avx2.cpp
+++ b/src/crypto/sha256_avx2.cpp
@@ -10,6 +10,12 @@
 #include <attributes.h>
 #include <crypto/common.h>
 
+#if defined(__clang__)
+#pragma clang attribute push(__attribute__((__target__("avx,avx2"))), apply_to = function)
+#elif defined(__GNUC__)
+#pragma GCC target ("avx,avx2")
+#endif
+
 namespace sha256d64_avx2 {
 namespace {
 
@@ -325,5 +331,9 @@ void Transform_8way(unsigned char* out, const unsigned char* in)
 }
 
 }
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#endif
 
 #endif

--- a/src/crypto/sha256_sse41.cpp
+++ b/src/crypto/sha256_sse41.cpp
@@ -10,6 +10,12 @@
 #include <attributes.h>
 #include <crypto/common.h>
 
+#if defined(__clang__)
+#pragma clang attribute push(__attribute__((__target__("sse4.1"))), apply_to = function)
+#elif defined(__GNUC__)
+#pragma GCC target ("sse4.1")
+#endif
+
 namespace sha256d64_sse41 {
 namespace {
 
@@ -317,5 +323,9 @@ void Transform_4way(unsigned char* out, const unsigned char* in)
 }
 
 }
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#endif
 
 #endif

--- a/src/crypto/sha256_x86_shani.cpp
+++ b/src/crypto/sha256_x86_shani.cpp
@@ -13,6 +13,12 @@
 
 #include <attributes.h>
 
+#if defined(__clang__)
+#pragma clang attribute push(__attribute__((__target__("sse4,sse4.1,sha"))), apply_to = function)
+#elif defined(__GNUC__)
+#pragma GCC target ("sse4,sse4.1,sha")
+#endif
+
 namespace {
 
 alignas(__m128i) const uint8_t MASK[16] = {0x03, 0x02, 0x01, 0x00, 0x07, 0x06, 0x05, 0x04, 0x0b, 0x0a, 0x09, 0x08, 0x0f, 0x0e, 0x0d, 0x0c};
@@ -354,5 +360,9 @@ void Transform_2way(unsigned char* out, const unsigned char* in)
 }
 
 }
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#endif
 
 #endif


### PR DESCRIPTION
CMake port of https://github.com/bitcoin/bitcoin/pull/13789

Instead of disabling optimised crypto, bypass the user-provided CXXFLAGS (which still instruct the compiler how to handle unconditional code) when possible and check at runtime.