### PR TITLE
Restore linking to libmingwthrd

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -187,6 +187,7 @@ target_link_libraries(bitcoin_common
     secp256k1
     Boost::headers
     $<TARGET_NAME_IF_EXISTS:USDT::headers>
+    $<$<PLATFORM_ID:Windows>:mingwthrd>
     $<$<PLATFORM_ID:Windows>:ws2_32>
 )
 


### PR DESCRIPTION
CMake port of https://github.com/bitcoin/bitcoin/pull/18427

Possibly necessary to get threadsafe stdlib behaviours
