### PR TITLE
qt: Fix crash in block view during IBD

### DIFF
--- a/src/qt/blockview.cpp
+++ b/src/qt/blockview.cpp
@@ -91,7 +91,9 @@ public:
 
 void GuiBlockView::updateBestBlock(const int height)
 {
-    m_block_chooser->setItemText(1, tr("Newest block (%1)").arg(height));
+    QMetaObject::invokeMethod(m_block_chooser, [this, height]() {
+        m_block_chooser->setItemText(1, tr("Newest block (%1)").arg(height));
+    }, Qt::QueuedConnection);
 }
 
 GuiBlockView::GuiBlockView(const PlatformStyle *platformStyle, const NetworkStyle *networkStyle, QWidget *parent) :


### PR DESCRIPTION
Fixes a crash that occurs when the block view window is open during initial block download (IBD). The crash happens due to a memory alignment issue in Qt's string handling when updating the block height from a non-main thread.

The issue occurs in `GuiBlockView::updateBestBlock` where string formatting is performed on the b-scheduler thread instead of the main GUI thread. This is unsafe as Qt's string handling and GUI operations must be performed on the main thread.

The fix uses `QMetaObject::invokeMethod` with `Qt::QueuedConnection` to ensure the string formatting and GUI update happens on the main thread, preventing the memory alignment issue.

This is a follow-up to commit d69357d and fixes issue #105

Tested by:
- Opening block view during IBD
- Verifying block height updates work correctly
- Confirming no crashes occur during IBD
