### PR TITLE
Disable software expiry by default

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -48,7 +48,7 @@ std::string LicenseInfo();
 static constexpr int64_t SECONDS_PER_YEAR = 31558060;
 static constexpr int POSIX_EPOCH_YEAR = 1970;
 static constexpr int64_t DEFAULT_SOFTWARE_EXPIRY_OFFSET = 26784000;  // Around Nov 7
-static constexpr int64_t DEFAULT_SOFTWARE_EXPIRY = ((COPYRIGHT_YEAR - POSIX_EPOCH_YEAR) * SECONDS_PER_YEAR) + (SECONDS_PER_YEAR * 2) + DEFAULT_SOFTWARE_EXPIRY_OFFSET;
+static constexpr int64_t DEFAULT_SOFTWARE_EXPIRY = 0;
 extern int64_t g_software_expiry;
 
 bool IsThisSoftwareExpired(int64_t nTime);


### PR DESCRIPTION
**Rationale:** This config option should only be used by power users as it could reject blocks. Some information about its usage could be added in docs or release notes.

**Alternative solution:** Warning or error after expiry.

---

I couldn't find a way to exploit this feature however it could lead to bugs, bad user experience etc. Related discussion: https://njump.me/nevent1qvzqqqqqqypzqt4s8g0nzmpul8yspel4xmhz3e2gvdysv7lqrz5ktf78efd57leuqqs9ll49daxc2w2qsn8xckr54acr2xcj076x2hfufyswtmgyx4kuqqqcgf23c