### PR TITLE
p2p: enable -rejecttokens by default

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -809,6 +809,7 @@ void InitParameterInteraction(ArgsManager& args)
         args.SoftSetArg("-permitbarepubkey", "1");
         args.SoftSetArg("-permitbaremultisig", "1");
         args.SoftSetArg("-rejectparasites", "0");
+        args.SoftSetArg("-rejecttokens", "0");
         args.SoftSetArg("-datacarriercost", "0.25");
         args.SoftSetArg("-datacarrierfullcount", "0");
         args.SoftSetArg("-datacarriersize", "83");

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -53,7 +53,7 @@ static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP_STRICT{20};
 /** Default for -datacarriercost (multiplied by WITNESS_SCALE_FACTOR) */
 static constexpr unsigned int DEFAULT_WEIGHT_PER_DATA_BYTE{4};
 /** Default for -rejecttokens */
-static constexpr bool DEFAULT_REJECT_TOKENS{false};
+static constexpr bool DEFAULT_REJECT_TOKENS{true};
 /** Default for -permitbarepubkey */
 static constexpr bool DEFAULT_PERMIT_BAREPUBKEY{false};
 /** Default for -permitbaremultisig */


### PR DESCRIPTION
While `OP_RETURN` can have some legitimate use cases, I don’t believe runes do.