### PR TITLE
Bugfix: RPC/Server: Handle edge cases around compatibility parameters

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -440,6 +440,14 @@ static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, c
         // object, and then pushing the accumulated options as the next
         // positional argument.
         if (named_only) {
+            if (options.empty()) {
+                if (options.isNull()) continue;
+                if (positional_args && positional_args.mapped()->size() > (size_t)hole) {
+                    // some alternative to options is specified positionally; we can't use options at all
+                    options = UniValue::VNULL;
+                    continue;
+                }
+            }
             if (fr != argsIn.end()) {
                 if (options.exists(fr->first)) {
                     throw JSONRPCError(RPC_INVALID_PARAMETER, "Parameter " + fr->first + " specified multiple times");
@@ -496,6 +504,9 @@ static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, c
     }
     // If there are still arguments in the argsIn map, this is an error.
     if (!argsIn.empty()) {
+        if (options.isNull()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot specify both 'options' and named parameter " + argsIn.begin()->first);
+        }
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Unknown named parameter " + argsIn.begin()->first);
     }
     // Return request with named arguments transformed to positional arguments

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -418,6 +418,13 @@ static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, c
     int hole = 0;
     int initial_hole_size = 0;
     const std::string* initial_param = nullptr;
+    auto positional_args{argsIn.extract("args")};
+    if (!positional_args) {
+        // nothing to do
+    } else if (!positional_args.mapped()->isArray()) {
+        argsIn.insert(std::move(positional_args));
+        positional_args = {};
+    }
     UniValue options{UniValue::VOBJ};
     for (const auto& [argNamePattern, named_only]: argNames) {
         std::vector<std::string> vargNames = SplitString(argNamePattern, '|');
@@ -476,8 +483,7 @@ static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, c
     // arguments and add named arguments after. This is a convenience for
     // clients that want to pass a combination of named and positional
     // arguments as described in doc/JSON-RPC-interface.md#parameter-passing
-    auto positional_args{argsIn.extract("args")};
-    if (positional_args && positional_args.mapped()->isArray()) {
+    if (positional_args) {
         if (initial_hole_size < (int)positional_args.mapped()->size() && initial_param) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Parameter " + *initial_param + " specified twice both as positional and named argument");
         }

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(rpc_namedonlyparams)
 
     // Make sure options object specified through args array conflicts.
     BOOST_CHECK_EXCEPTION(TransformParams(JSON(R"({"args": [1, 2, {"opt1": 10}], "opt2": 20})"), arg_names), UniValue,
-                          HasJSON(R"({"code":-8,"message":"Parameter options specified twice both as positional and named argument"})"));
+                          HasJSON(R"({"code":-8,"message":"Cannot specify both 'options' and named parameter opt2"})"));
 }
 
 BOOST_AUTO_TEST_CASE(rpc_rawparams)


### PR DESCRIPTION
This is needed to correctly handle backwards-compatibility cases where positional and named parameters are mixed, yet the options position is taken up by a compatibility value.

Instead of trying to build an options object, we need to in that circumstance pretend there is no "options" parameter, and let the subsequent compatibility positional args collect the named params.