### PR TITLE
rpc: Export corepolicy settings for headless deployments (dumpsettings/setsettings)

### DIFF
--- a/contrib/completions/bash/bitcoin-cli.bash
+++ b/contrib/completions/bash/bitcoin-cli.bash
@@ -90,7 +90,7 @@ _bitcoin_cli() {
             _filedir
             return 0
             ;;
-        getrawmempool|setnetworkactive|setscriptthreadsenabled)
+        dumpsettings|getrawmempool|setnetworkactive|setscriptthreadsenabled)
             COMPREPLY=( $( compgen -W "false true" -- "$cur" ) )
             return 0
             ;;

--- a/contrib/completions/zsh/bitcoin-cli.zsh
+++ b/contrib/completions/zsh/bitcoin-cli.zsh
@@ -89,7 +89,7 @@ _bitcoin-cli() {
             _files
             return 0
             ;;
-        getrawmempool|setnetworkactive|setscriptthreadsenabled)
+        dumpsettings|getrawmempool|setnetworkactive|setscriptthreadsenabled)
             _values 'arg' 'false' 'true'
             return 0
             ;;

--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -202,6 +202,22 @@ or the state of the mempool by an RPC that returned before this RPC. For
 example, a wallet transaction that was BIP-125-replaced in the mempool prior to
 this RPC may not yet be reflected as such in this RPC response.
 
+## Corepolicy settings
+
+Headless deployments can read and change the node's corepolicy/mempool settings
+(the same options offered by the GUI) with two RPCs:
+
+- `dumpsettings ( detailed )` returns the current settings as `name: value`. With
+  `detailed=true`, each entry includes the value, its type, and help text, so a
+  configuration UI can be generated from the node instead of being hard-coded.
+- `setsettings {"name": value, ...}` validates the whole batch first (nothing is
+  applied if any value is invalid), then applies and persists the valid changes.
+  Each per-setting result reports whether that change needs a restart to take effect.
+
+Setting names match the corresponding `bitcoin.conf` option names. Run
+`bitcoin-cli help dumpsettings` / `help setsettings` for details, and
+`bitcoin-cli dumpsettings true` for the full list with types and help text.
+
 ## Limitations
 
 There is a known issue in the JSON-RPC interface that can cause a node to crash if

--- a/doc/release-notes-k154.md
+++ b/doc/release-notes-k154.md
@@ -1,0 +1,22 @@
+Settings export over RPC
+------------------------
+
+Bitcoin Knots now exposes its corepolicy/mempool settings over RPC, so headless
+deployments (Start9, Umbrel, etc.) can read and change the same policy options the
+GUI offers, without a graphical interface.
+
+Two RPC commands are added:
+
+- `dumpsettings ( detailed )`: return the current corepolicy/mempool settings as a
+  JSON object of `name: value`. With `detailed=true`, each entry instead reports the
+  value together with its type and the setting's help text, so a headless UI can be
+  built from the node itself instead of hard-coding the option list per release.
+- `setsettings {"name": value, ...}`: update one or more settings. The whole batch is
+  validated first; if any value is invalid, none are applied. Valid changes take
+  effect on the running node where possible and are persisted for restart. A
+  per-setting result reports whether a restart is required (for example `spkreuse`).
+
+RPC and the GUI now change these settings through the same internal interface, so the
+two stay consistent. Setting names match the corresponding `bitcoin.conf` option names.
+
+See `doc/JSON-RPC-interface.md` for usage details.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -305,6 +305,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   rpc/rawtransaction.cpp
   rpc/server.cpp
   rpc/server_util.cpp
+  rpc/settings.cpp
   rpc/signmessage.cpp
   rpc/txoutproof.cpp
   script/sigcache.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -276,6 +276,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/mempool_persist_args.cpp
   node/miner.cpp
   node/mini_miner.cpp
+  node/policy_settings.cpp
   node/peerman_args.cpp
   node/psbt.cpp
   node/timeoffsets.cpp

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -272,6 +272,18 @@ std::optional<unsigned int> ArgsManager::GetArgFlags(const std::string& name) co
     return std::nullopt;
 }
 
+std::optional<std::string> ArgsManager::GetArgHelpText(const std::string& name) const
+{
+    LOCK(cs_args);
+    for (const auto& arg_map : m_available_args) {
+        const auto search = arg_map.second.find(name);
+        if (search != arg_map.second.end()) {
+            return search->second.m_help_text;
+        }
+    }
+    return std::nullopt;
+}
+
 fs::path ArgsManager::GetPathArg(std::string arg, const fs::path& default_value) const
 {
     if (IsArgNegated(arg)) return fs::path{};

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -409,6 +409,11 @@ protected:
     std::optional<unsigned int> GetArgFlags(const std::string& name) const;
 
     /**
+     * Return the registered help text for a known arg (e.g. "-foo"), or nullopt.
+     */
+    std::optional<std::string> GetArgHelpText(const std::string& name) const;
+
+    /**
      * Get settings file path, or return false if read-write settings were
      * disabled with -nosettings.
      */

--- a/src/node/policy_settings.cpp
+++ b/src/node/policy_settings.cpp
@@ -1,0 +1,417 @@
+// Copyright (c) 2026 The Bitcoin Knots developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/policy_settings.h>
+
+#include <common/args.h>
+#include <common/settings.h>
+#include <consensus/amount.h>
+#include <consensus/consensus.h>
+#include <kernel/mempool_options.h>
+#include <node/context.h>
+#include <node/mempool_args.h>
+#include <policy/feerate.h>
+#include <policy/policy.h>
+#include <policy/settings.h>
+#include <sync.h>
+#include <tinyformat.h>
+#include <txmempool.h>
+#include <util/moneystr.h>
+#include <util/result.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+#include <validation.h>
+
+#include <chrono>
+#include <optional>
+
+using common::SettingsValue;
+
+namespace node {
+
+namespace {
+
+// Coerced/validated form of an incoming value, filled per setting type.
+struct Normalized {
+    bool b{false};
+    int64_t i{0};
+    CAmount amount{0};      // for Amount: satoshis-per-kvB
+    int64_t hundredths{0};  // for Number (fixed-point, 2 decimals)
+    std::string s;
+};
+
+// Persist to settings.json (mirrors interfaces::Node::updateRwSetting).
+[[nodiscard]] bool PersistJson(ArgsManager& args, const std::string& key, const SettingsValue& value)
+{
+    args.LockSettings([&](common::Settings& settings) {
+        if (value.isNull()) {
+            settings.rw_settings.erase(key);
+        } else {
+            settings.rw_settings[key] = value;
+        }
+    });
+    return args.WriteSettingsFile();
+}
+
+CTxMemPool* MemPool(NodeContext& node) { return node.mempool.get(); }
+
+[[nodiscard]] bool CoerceBool(const UniValue& v, bool& out)
+{
+    if (v.isBool()) { out = v.get_bool(); return true; }
+    if (v.isNum()) { out = v.getInt<int>() != 0; return true; }
+    if (v.isStr()) {
+        const std::string& s = v.get_str();
+        if (s == "1" || s == "true") { out = true; return true; }
+        if (s == "0" || s == "false") { out = false; return true; }
+    }
+    return false;
+}
+
+[[nodiscard]] bool CoerceInt(const UniValue& v, int64_t& out)
+{
+    if (v.isNum()) { out = v.getInt<int64_t>(); return true; }
+    if (v.isStr()) { return ParseInt64(v.get_str(), &out); }
+    return false;
+}
+
+// Reverse of the -mempoolreplacement / -mempooltruc string parsers (matches the
+// GUI's CanonicalMempoolReplacement / CanonicalMempoolTRUC).
+std::string RbfPolicyToString(RBFPolicy p)
+{
+    switch (p) {
+    case RBFPolicy::Never:  return "never";
+    case RBFPolicy::OptIn:  return "fee,optin";
+    case RBFPolicy::Always: return "fee,-optin";
+    }
+    return "fee,-optin";
+}
+
+std::string TrucPolicyToString(TRUCPolicy p)
+{
+    switch (p) {
+    case TRUCPolicy::Reject:  return "reject";
+    case TRUCPolicy::Accept:  return "accept";
+    case TRUCPolicy::Enforce: return "enforce";
+    }
+    return "accept";
+}
+
+std::string PermitEphemeralToString(const kernel::MemPoolOptions& o)
+{
+    if (!(o.permitephemeral_anchor || o.permitephemeral_send || o.permitephemeral_dust)) return "reject";
+    return std::string(o.permitephemeral_anchor ? "" : "-") + "anchor," +
+           (o.permitephemeral_send ? "" : "-") + "send," +
+           (o.permitephemeral_dust ? "" : "-") + "dust";
+}
+
+// Registry, ordered for stable output. Grouped by category for readability.
+const std::vector<PolicySettingDef> g_registry{
+    // mempool
+    {"maxmempool", PolicySettingType::Int},
+    {"mempoolexpiry", PolicySettingType::Int},
+    {"mempoolreplacement", PolicySettingType::String},
+    {"mempooltruc", PolicySettingType::String},
+    {"minrelaytxfee", PolicySettingType::Amount},
+    {"incrementalrelayfee", PolicySettingType::Amount},
+    {"minrelaycoinblocks", PolicySettingType::Int},
+    {"minrelaymaturity", PolicySettingType::Int},
+    {"limitancestorcount", PolicySettingType::Int},
+    {"limitancestorsize", PolicySettingType::Int},
+    {"limitdescendantcount", PolicySettingType::Int},
+    {"limitdescendantsize", PolicySettingType::Int},
+    // policy toggles
+    {"rejectparasites", PolicySettingType::Bool},
+    {"rejecttokens", PolicySettingType::Bool},
+    {"subdustfeepenalty", PolicySettingType::Bool},
+    {"acceptnonstdtxn", PolicySettingType::Bool},
+    {"acceptunknownwitness", PolicySettingType::Bool},
+    {"permitbaremultisig", PolicySettingType::Bool},
+    {"permitbarepubkey", PolicySettingType::Bool},
+    {"permitbareanchor", PolicySettingType::Bool},
+    {"permitbaredatacarrier", PolicySettingType::Bool},
+    {"permitephemeral", PolicySettingType::String},
+    {"spkreuse", PolicySettingType::String, /*restart_required=*/true},
+    // data carrier
+    {"datacarriersize", PolicySettingType::Int},
+    {"acceptnonstddatacarrier", PolicySettingType::Bool},
+    {"datacarriercost", PolicySettingType::Number},
+    // sigops / script
+    {"bytespersigop", PolicySettingType::Int},
+    {"bytespersigopstrict", PolicySettingType::Int},
+    {"maxscriptsize", PolicySettingType::Int},
+    {"maxtxlegacysigops", PolicySettingType::Int},
+    // dust
+    {"dustrelayfee", PolicySettingType::Amount},
+    {"dustdynamic", PolicySettingType::String},
+};
+
+// Validate + coerce an incoming value for the given setting. No side effects.
+util::Result<Normalized> Normalize(const PolicySettingDef& def, const UniValue& value)
+{
+    Normalized n;
+    switch (def.type) {
+    case PolicySettingType::Bool:
+        if (!CoerceBool(value, n.b)) return util::Error{Untranslated(strprintf("%s must be a boolean", def.name))};
+        return n;
+    case PolicySettingType::Int:
+        if (!CoerceInt(value, n.i)) return util::Error{Untranslated(strprintf("%s must be an integer", def.name))};
+        if (n.i < 0) return util::Error{Untranslated(strprintf("%s must not be negative", def.name))};
+        if (n.i > def.max) return util::Error{Untranslated(strprintf("%s must not be greater than %d", def.name, def.max))};
+        return n;
+    case PolicySettingType::Amount: {
+        const std::string s = value.isNum() ? value.getValStr() : (value.isStr() ? value.get_str() : "");
+        std::optional<CAmount> parsed = ParseMoney(s);
+        if (!parsed) return util::Error{Untranslated(strprintf("%s is not a valid amount", def.name))};
+        n.amount = *parsed;
+        return n;
+    }
+    case PolicySettingType::Number: {
+        const std::string s = value.isNum() ? value.getValStr() : (value.isStr() ? value.get_str() : "");
+        if (!ParseFixedPoint(s, 2, &n.hundredths) || n.hundredths < 0) {
+            return util::Error{Untranslated(strprintf("%s is not a valid number", def.name))};
+        }
+        return n;
+    }
+    case PolicySettingType::String:
+        if (!value.isStr()) return util::Error{Untranslated(strprintf("%s must be a string", def.name))};
+        n.s = value.get_str();
+        // Per-setting string validation, reusing the startup parsers.
+        if (def.name == "mempooltruc") {
+            if (n.s != "reject" && n.s != "accept" && n.s != "enforce") {
+                return util::Error{Untranslated("mempooltruc must be one of: reject, accept, enforce")};
+            }
+        } else if (def.name == "spkreuse") {
+            if (n.s != "conflict" && n.s != "allow") {
+                return util::Error{Untranslated("spkreuse must be one of: conflict, allow")};
+            }
+        } else if (def.name == "dustdynamic") {
+            auto parsed = ParseDustDynamicOpt(n.s, /*max_fee_estimate_blocks=*/1008);
+            if (!parsed) return util::Error{util::ErrorString(parsed)};
+        } else if (def.name == "permitephemeral") {
+            // Validate by applying to a throwaway options struct.
+            kernel::MemPoolOptions probe;
+            ApplyPermitEphemeralOption(SettingsValue(n.s), probe);
+        }
+        // mempoolreplacement accepts any comma list; parsed leniently at startup.
+        return n;
+    }
+    return util::Error{Untranslated("unknown setting type")};
+}
+
+} // namespace
+
+const std::vector<PolicySettingDef>& PolicySettingRegistry() { return g_registry; }
+
+const PolicySettingDef* FindPolicySetting(std::string_view name)
+{
+    for (const auto& def : g_registry) {
+        if (def.name == name) return &def;
+    }
+    return nullptr;
+}
+
+util::Result<void> ValidatePolicySetting(std::string_view name, const UniValue& value)
+{
+    const PolicySettingDef* def = FindPolicySetting(name);
+    if (!def) return util::Error{Untranslated(strprintf("unknown setting: %s", name))};
+    auto norm = Normalize(*def, value);
+    if (!norm) return util::Error{util::ErrorString(norm)};
+    return {};
+}
+
+util::Result<UniValue> ReadPolicySetting(NodeContext& node, std::string_view name)
+{
+    const PolicySettingDef* def = FindPolicySetting(name);
+    if (!def) return util::Error{Untranslated(strprintf("unknown setting: %s", name))};
+
+    ArgsManager& args = *Assert(node.args);
+    CTxMemPool* pool = MemPool(node);
+    const std::string n{name};
+
+    // Settings not backed by live mempool options.
+    if (n == "datacarriercost") return UniValue(double(g_weight_per_data_byte) / WITNESS_SCALE_FACTOR);
+    if (n == "bytespersigop") return UniValue((int64_t)nBytesPerSigOp);
+    if (n == "bytespersigopstrict") return UniValue((int64_t)nBytesPerSigOpStrict);
+    if (n == "maxscriptsize") return UniValue((int64_t)g_script_size_policy_limit);
+    if (n == "spkreuse") return UniValue(args.GetArg("-spkreuse", "allow"));
+
+    if (!pool) return util::Error{Untranslated("mempool not available")};
+    const kernel::MemPoolOptions& o = pool->m_opts;
+
+    if (n == "maxmempool") return UniValue((int64_t)(o.max_size_bytes / 1'000'000));
+    if (n == "mempoolexpiry") return UniValue((int64_t)std::chrono::duration_cast<std::chrono::hours>(o.expiry).count());
+    if (n == "mempoolreplacement") return UniValue(RbfPolicyToString(o.rbf_policy));
+    if (n == "mempooltruc") return UniValue(TrucPolicyToString(o.truc_policy));
+    if (n == "minrelaytxfee") return UniValue(UniValue::VNUM, FormatMoney(o.min_relay_feerate.GetFeePerK()));
+    if (n == "incrementalrelayfee") return UniValue(UniValue::VNUM, FormatMoney(o.incremental_relay_feerate.GetFeePerK()));
+    if (n == "minrelaycoinblocks") return UniValue((int64_t)o.minrelaycoinblocks);
+    if (n == "minrelaymaturity") return UniValue((int64_t)o.minrelaymaturity);
+    if (n == "limitancestorcount") return UniValue((int64_t)o.limits.ancestor_count);
+    if (n == "limitancestorsize") return UniValue((int64_t)(o.limits.ancestor_size_vbytes / 1'000));
+    if (n == "limitdescendantcount") return UniValue((int64_t)o.limits.descendant_count);
+    if (n == "limitdescendantsize") return UniValue((int64_t)(o.limits.descendant_size_vbytes / 1'000));
+    if (n == "rejectparasites") return UniValue(o.reject_parasites);
+    if (n == "rejecttokens") return UniValue(o.reject_tokens);
+    if (n == "subdustfeepenalty") return UniValue(o.subdustfeepenalty);
+    if (n == "acceptnonstdtxn") return UniValue(!o.require_standard);
+    if (n == "acceptunknownwitness") return UniValue(o.acceptunknownwitness);
+    if (n == "permitbaremultisig") return UniValue(o.permit_bare_multisig);
+    if (n == "permitbarepubkey") return UniValue(o.permit_bare_pubkey);
+    if (n == "permitbareanchor") return UniValue(o.permitbareanchor);
+    if (n == "permitbaredatacarrier") return UniValue(o.permitbaredatacarrier);
+    if (n == "permitephemeral") return UniValue(PermitEphemeralToString(o));
+    if (n == "datacarriersize") return UniValue((int64_t)o.max_datacarrier_bytes.value_or(0));
+    if (n == "acceptnonstddatacarrier") return UniValue(o.accept_non_std_datacarrier);
+    if (n == "maxtxlegacysigops") return UniValue((int64_t)o.maxtxlegacysigops);
+    if (n == "dustrelayfee") return UniValue(UniValue::VNUM, FormatMoney(o.dust_relay_feerate_floor.GetFeePerK()));
+    // dustdynamic is read from the persisted setting string (matches the GUI); we
+    // persist it on every change, so this reflects the current value.
+    if (n == "dustdynamic") return UniValue(args.GetArg("-dustdynamic", DEFAULT_DUST_DYNAMIC));
+
+    return util::Error{Untranslated(strprintf("unhandled setting: %s", name))};
+}
+
+util::Result<void> UpdatePolicySetting(NodeContext& node, std::string_view name, const UniValue& value)
+{
+    const PolicySettingDef* def = FindPolicySetting(name);
+    if (!def) return util::Error{Untranslated(strprintf("unknown setting: %s", name))};
+
+    auto norm = Normalize(*def, value);
+    if (!norm) return util::Error{util::ErrorString(norm)};
+    const Normalized& nv = *norm;
+
+    ArgsManager& args = *Assert(node.args);
+    CTxMemPool* pool = MemPool(node);
+    const std::string n{name};
+
+    // Persist helpers. Only the settings.json path can report a write failure;
+    // ModifyRWConfigFile() has no status to propagate.
+    auto json = [&](const std::string& key, const SettingsValue& v) -> util::Result<void> {
+        if (!PersistJson(args, key, v)) return util::Error{Untranslated(strprintf("failed to write settings file for %s", key))};
+        return {};
+    };
+    auto rwconf = [&](const std::string& key, const std::string& v) { args.ModifyRWConfigFile(key, v); };
+
+    // ---- Globals (no mempool required) ----
+    if (n == "datacarriercost") {
+        g_weight_per_data_byte = (unsigned int)((nv.hundredths * WITNESS_SCALE_FACTOR + 99) / 100);
+        return json("datacarriercost", UniValue(double(nv.hundredths) / 100.0));
+    }
+    if (n == "bytespersigop") { nBytesPerSigOp = (unsigned int)nv.i; rwconf("bytespersigop", strprintf("%d", nv.i)); return {}; }
+    if (n == "bytespersigopstrict") { nBytesPerSigOpStrict = (unsigned int)nv.i; rwconf("bytespersigopstrict", strprintf("%d", nv.i)); return {}; }
+    if (n == "maxscriptsize") { g_script_size_policy_limit = (unsigned int)nv.i; return json("maxscriptsize", UniValue(nv.i)); }
+    if (n == "spkreuse") { rwconf("spkreuse", nv.s); return {}; } // restart-required; no live field
+
+    if (!pool) return util::Error{Untranslated("mempool not available")};
+    kernel::MemPoolOptions& o = pool->m_opts;
+
+    // ---- Mempool size / expiry (with live trim on shrink) ----
+    if (n == "maxmempool" || n == "mempoolexpiry") {
+        bool shrink;
+        if (n == "maxmempool") {
+            const int64_t old = o.max_size_bytes;
+            o.max_size_bytes = nv.i * 1'000'000;
+            shrink = o.max_size_bytes < old;
+            args.ForceSetArg("-maxmempool", strprintf("%d", nv.i));
+            rwconf("maxmempool", strprintf("%d", nv.i));
+        } else {
+            const auto old = o.expiry;
+            o.expiry = std::chrono::hours{nv.i};
+            shrink = o.expiry < old;
+            args.ForceSetArg("-mempoolexpiry", strprintf("%d", nv.i));
+            rwconf("mempoolexpiry", strprintf("%d", nv.i));
+        }
+        if (shrink && node.chainman) {
+            LOCK(cs_main);
+            LOCK(pool->cs);
+            LimitMempoolSize(*pool, node.chainman->ActiveChainstate().CoinsTip());
+        }
+        return {};
+    }
+
+    // ---- Ancestor/descendant limits ----
+    if (n == "limitancestorcount") { o.limits.ancestor_count = nv.i; args.ForceSetArg("-limitancestorcount", strprintf("%d", nv.i)); rwconf("limitancestorcount", strprintf("%d", nv.i)); return {}; }
+    if (n == "limitancestorsize") { o.limits.ancestor_size_vbytes = nv.i * 1'000; args.ForceSetArg("-limitancestorsize", strprintf("%d", nv.i)); rwconf("limitancestorsize", strprintf("%d", nv.i)); return {}; }
+    if (n == "limitdescendantcount") { o.limits.descendant_count = nv.i; args.ForceSetArg("-limitdescendantcount", strprintf("%d", nv.i)); rwconf("limitdescendantcount", strprintf("%d", nv.i)); return {}; }
+    if (n == "limitdescendantsize") { o.limits.descendant_size_vbytes = nv.i * 1'000; args.ForceSetArg("-limitdescendantsize", strprintf("%d", nv.i)); rwconf("limitdescendantsize", strprintf("%d", nv.i)); return {}; }
+
+    // ---- Fee rates (satoshis-per-kvB via ParseMoney) ----
+    if (n == "minrelaytxfee") { o.min_relay_feerate = CFeeRate(nv.amount); rwconf("minrelaytxfee", FormatMoney(nv.amount)); return {}; }
+    if (n == "incrementalrelayfee") { o.incremental_relay_feerate = CFeeRate(nv.amount); rwconf("incrementalrelayfee", FormatMoney(nv.amount)); return {}; }
+    if (n == "dustrelayfee") {
+        const CFeeRate feerate{nv.amount};
+        o.dust_relay_feerate_floor = feerate;
+        if (o.dust_relay_feerate < feerate || !o.dust_relay_target) {
+            o.dust_relay_feerate = feerate;
+        } else {
+            pool->UpdateDynamicDustFeerate();
+        }
+        rwconf("dustrelayfee", FormatMoney(nv.amount));
+        return {};
+    }
+
+    // ---- Simple integer m_opts, persisted to settings.json ----
+    if (n == "minrelaycoinblocks") { o.minrelaycoinblocks = nv.i; return json("minrelaycoinblocks", UniValue(nv.i)); }
+    if (n == "minrelaymaturity") { o.minrelaymaturity = nv.i; return json("minrelaymaturity", UniValue(nv.i)); }
+    if (n == "maxtxlegacysigops") { o.maxtxlegacysigops = nv.i; return json("maxtxlegacysigops", UniValue(nv.i)); }
+
+    // ---- Boolean policy toggles ----
+    if (n == "rejectparasites") { o.reject_parasites = nv.b; return json("rejectparasites", UniValue(nv.b)); }
+    if (n == "rejecttokens") { o.reject_tokens = nv.b; return json("rejecttokens", UniValue(nv.b)); }
+    if (n == "subdustfeepenalty") { o.subdustfeepenalty = nv.b; return json("subdustfeepenalty", UniValue(nv.b)); }
+    if (n == "acceptunknownwitness") { o.acceptunknownwitness = nv.b; return json("acceptunknownwitness", UniValue(nv.b)); }
+    if (n == "permitbarepubkey") { o.permit_bare_pubkey = nv.b; return json("permitbarepubkey", UniValue(nv.b)); }
+    if (n == "permitbareanchor") { o.permitbareanchor = nv.b; return json("permitbareanchor", UniValue(nv.b)); }
+    if (n == "permitbaredatacarrier") { o.permitbaredatacarrier = nv.b; return json("permitbaredatacarrier", UniValue(nv.b)); }
+    if (n == "acceptnonstddatacarrier") { o.accept_non_std_datacarrier = nv.b; return json("acceptnonstddatacarrier", UniValue(nv.b)); }
+    if (n == "acceptnonstdtxn") { o.require_standard = !nv.b; rwconf("acceptnonstdtxn", strprintf("%d", nv.b)); return {}; }
+    if (n == "permitbaremultisig") { o.permit_bare_multisig = nv.b; rwconf("permitbaremultisig", strprintf("%d", nv.b)); return {}; }
+
+    // ---- Data carrier size (toggles the datacarrier bool key) ----
+    if (n == "datacarriersize") {
+        if (nv.i > 0) {
+            if (!o.max_datacarrier_bytes.has_value()) rwconf("datacarrier", "1");
+            rwconf("datacarriersize", strprintf("%d", nv.i));
+            o.max_datacarrier_bytes = (unsigned)nv.i;
+        } else {
+            rwconf("datacarrier", "0");
+            o.max_datacarrier_bytes = std::nullopt;
+        }
+        return {};
+    }
+
+    // ---- Special string settings ----
+    if (n == "mempoolreplacement") {
+        // Match the startup token parser (see ApplyArgsManOptions in mempool_args.cpp).
+        std::optional<bool> optin;
+        bool fee{false};
+        for (const auto& opt : util::SplitString(nv.s, ",+")) {
+            if (opt == "optin") optin = true;
+            else if (opt == "-optin") optin = false;
+            else if (opt == "fee") fee = true;
+        }
+        o.rbf_policy = optin.value_or(false) ? RBFPolicy::OptIn : (fee ? RBFPolicy::Always : RBFPolicy::Never);
+        args.ModifyRWConfigFile("mempoolreplacement", nv.s);
+        return json("mempoolfullrbf", UniValue(o.rbf_policy == RBFPolicy::Always ? "1" : "0"));
+    }
+    if (n == "mempooltruc") {
+        o.truc_policy = (nv.s == "reject") ? TRUCPolicy::Reject : (nv.s == "enforce") ? TRUCPolicy::Enforce : TRUCPolicy::Accept;
+        return json("mempooltruc", UniValue(nv.s));
+    }
+    if (n == "permitephemeral") {
+        ApplyPermitEphemeralOption(SettingsValue(nv.s), o);
+        return json("permitephemeral", UniValue(nv.s));
+    }
+    if (n == "dustdynamic") {
+        auto parsed = ParseDustDynamicOpt(nv.s, /*max_fee_estimate_blocks=*/1008);
+        if (!parsed) return util::Error{util::ErrorString(parsed)};
+        o.dust_relay_target = parsed->first;
+        o.dust_relay_multiplier = parsed->second;
+        return json("dustdynamic", UniValue(nv.s));
+    }
+
+    return util::Error{Untranslated(strprintf("unhandled setting: %s", name))};
+}
+
+} // namespace node

--- a/src/node/policy_settings.h
+++ b/src/node/policy_settings.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 The Bitcoin Knots developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_POLICY_SETTINGS_H
+#define BITCOIN_NODE_POLICY_SETTINGS_H
+
+#include <univalue.h>
+#include <util/result.h>
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace node {
+struct NodeContext;
+
+enum class PolicySettingType { Bool, Int, Amount, Number, String };
+
+//! One row per bitcoind config-named corepolicy/mempool setting exposed over RPC.
+struct PolicySettingDef {
+    std::string name;                //!< bitcoind config option name (e.g. "permitbarepubkey")
+    PolicySettingType type;
+    bool restart_required{false};    //!< true when a change only takes effect after restart (spkreuse)
+    //! Upper bound for Int settings; keeps the unsigned/scaled assignments below from wrapping.
+    int64_t max{std::numeric_limits<uint32_t>::max()};
+};
+
+//! Ordered registry of all settings exposed by dumpsettings/setsettings.
+const std::vector<PolicySettingDef>& PolicySettingRegistry();
+const PolicySettingDef* FindPolicySetting(std::string_view name);
+
+//! Read a setting's current live value (from mempool options / policy globals).
+util::Result<UniValue> ReadPolicySetting(NodeContext& node, std::string_view name);
+
+//! Validate (coerce and range/format check) a value for a setting without any
+//! side effects. Used to make setsettings validate the whole batch before applying.
+util::Result<void> ValidatePolicySetting(std::string_view name, const UniValue& value);
+
+//! Validate and apply a setting change: mutate live policy state and write it to
+//! the store the GUI uses for that setting (settings.json or the read-write
+//! config file). Returns an error if the value is invalid or persistence failed.
+util::Result<void> UpdatePolicySetting(NodeContext& node, std::string_view name, const UniValue& value);
+
+} // namespace node
+
+#endif // BITCOIN_NODE_POLICY_SETTINGS_H

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -27,6 +27,7 @@
 #include <node/chainstatemanager_args.h>
 #include <node/context.h>
 #include <node/mempool_args.h> // for ParseDustDynamicOpt
+#include <node/policy_settings.h>
 #include <outputtype.h>
 #include <policy/settings.h>
 #include <util/moneystr.h> // for FormatMoney
@@ -823,8 +824,19 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
 {
     auto changed = [&] { return value.isValid() && value != getOption(option, suffix); };
     auto update = [&](const common::SettingsValue& value) { return UpdateRwSetting(node(), option, suffix, value); };
-
     bool successful = true; /* set to false on parse error */
+
+    // Apply a corepolicy/mempool setting through the shared node-side interface
+    // that setsettings/dumpsettings also use, so RPC and GUI change settings via
+    // the same code. Config-named (not GUI-inverted); invert at the call site.
+    auto apply_policy = [&](std::string_view name, const common::SettingsValue& v) {
+        if (!changed()) return;
+        if (auto result = node::UpdatePolicySetting(*node().context(), name, v); !result) {
+            qWarning() << "OptionsModel::setOption:" << QString::fromStdString(util::ErrorString(result).original);
+            successful = false;
+        }
+    };
+
     QSettings settings;
 
     switch (option) {
@@ -1123,38 +1135,11 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
         break;
     }
     case mempoolreplacement:
-    {
-        if (changed()) {
-            QString nv = value.toString();
-            if (nv == "never") {
-                node().mempool().m_opts.rbf_policy = RBFPolicy::Never;
-                node().updateRwSetting("mempoolfullrbf", "0");
-            } else if (nv == "fee,optin") {
-                node().mempool().m_opts.rbf_policy = RBFPolicy::OptIn;
-                node().updateRwSetting("mempoolfullrbf", "0");
-            } else {  // "fee,-optin"
-                node().mempool().m_opts.rbf_policy = RBFPolicy::Always;
-                node().updateRwSetting("mempoolfullrbf", "1");
-            }
-            gArgs.ModifyRWConfigFile("mempoolreplacement", nv.toStdString());
-        }
+        apply_policy("mempoolreplacement", UniValue(value.toString().toStdString()));
         break;
-    }
     case mempooltruc:
-    {
-        if (changed()) {
-            QString nv = value.toString();
-            if (nv == "reject") {
-                node().mempool().m_opts.truc_policy = TRUCPolicy::Reject;
-            } else if (nv == "accept") {
-                node().mempool().m_opts.truc_policy = TRUCPolicy::Accept;
-            } else if (nv == "enforce") {
-                node().mempool().m_opts.truc_policy = TRUCPolicy::Enforce;
-            }
-            node().updateRwSetting("mempooltruc", nv.toStdString());
-        }
+        apply_policy("mempooltruc", UniValue(value.toString().toStdString()));
         break;
-    }
     case maxorphantx:
     {
         if (changed()) {
@@ -1171,283 +1156,100 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
         break;
     }
     case maxmempool:
-    {
-        if (changed()) {
-            long long nOldValue = node().mempool().m_opts.max_size_bytes;
-            long long nNv = value.toLongLong();
-            std::string strNv = value.toString().toStdString();
-            node().mempool().m_opts.max_size_bytes = nNv * 1'000'000;
-            gArgs.ForceSetArg("-maxmempool", strNv);
-            gArgs.ModifyRWConfigFile("maxmempool", strNv);
-            if (nNv < nOldValue) {
-                LOCK(cs_main);
-                auto node_ctx = node().context();
-                assert(node_ctx && node_ctx->mempool && node_ctx->chainman);
-                auto& active_chainstate = node_ctx->chainman->ActiveChainstate();
-                LOCK(node_ctx->mempool->cs);
-                LimitMempoolSize(*node_ctx->mempool, active_chainstate.CoinsTip());
-            }
-        }
+        apply_policy("maxmempool", UniValue((int64_t)value.toLongLong()));
         break;
-    }
     case incrementalrelayfee:
-        if (changed()) {
-            CAmount nNv = value.toLongLong();
-            gArgs.ModifyRWConfigFile("incrementalrelayfee", FormatMoney(nNv));
-            node().mempool().m_opts.incremental_relay_feerate = CFeeRate(nNv);
-        }
+        apply_policy("incrementalrelayfee", UniValue(FormatMoney(value.toLongLong())));
         break;
     case mempoolexpiry:
-    {
-        if (changed()) {
-            const auto old_value = node().mempool().m_opts.expiry;
-            const std::chrono::hours new_value{value.toLongLong()};
-            std::string strNv = value.toString().toStdString();
-            node().mempool().m_opts.expiry = new_value;
-            gArgs.ForceSetArg("-mempoolexpiry", strNv);
-            gArgs.ModifyRWConfigFile("mempoolexpiry", strNv);
-            if (new_value < old_value) {
-                LOCK(cs_main);
-                auto node_ctx = node().context();
-                assert(node_ctx && node_ctx->mempool && node_ctx->chainman);
-                auto& active_chainstate = node_ctx->chainman->ActiveChainstate();
-                LOCK(node_ctx->mempool->cs);
-                LimitMempoolSize(*node_ctx->mempool, active_chainstate.CoinsTip());
-            }
-        }
+        apply_policy("mempoolexpiry", UniValue((int64_t)value.toLongLong()));
         break;
-    }
     case rejectunknownscripts:
-    {
-        if (changed()) {
-            const bool fNewValue = value.toBool();
-            node().mempool().m_opts.require_standard = fNewValue;
-            // This option is inverted in the config:
-            gArgs.ModifyRWConfigFile("acceptnonstdtxn", strprintf("%d", ! fNewValue));
-        }
+        // Inverted: GUI "reject unknown scripts" == config "acceptnonstdtxn" off.
+        apply_policy("acceptnonstdtxn", UniValue(!value.toBool()));
         break;
-    }
     case rejectunknownwitness:
-        if (changed()) {
-            // This option is inverted
-            const bool new_value = ! value.toBool();
-            node().updateRwSetting("acceptunknownwitness" + suffix, new_value);
-            node().mempool().m_opts.acceptunknownwitness = new_value;
-        }
+        apply_policy("acceptunknownwitness", UniValue(!value.toBool()));
         break;
     case rejectparasites:
-    {
-        if (changed()) {
-            const bool nv = value.toBool();
-            node().mempool().m_opts.reject_parasites = nv;
-            node().updateRwSetting("rejectparasites", nv);
-        }
+        apply_policy("rejectparasites", UniValue(value.toBool()));
         break;
-    }
     case rejecttokens:
-    {
-        if (changed()) {
-            const bool nv = value.toBool();
-            node().mempool().m_opts.reject_tokens = nv;
-            node().updateRwSetting("rejecttokens", nv);
-        }
+        apply_policy("rejecttokens", UniValue(value.toBool()));
         break;
-    }
     case subdustfeepenalty:
-    {
-        if (changed()) {
-            const bool nv = value.toBool();
-            node().mempool().m_opts.subdustfeepenalty = nv;
-            node().updateRwSetting("subdustfeepenalty", nv);
-        }
+        apply_policy("subdustfeepenalty", UniValue(value.toBool()));
         break;
-    }
     case rejectspkreuse:
         if (changed()) {
             const bool fNewValue = value.toBool();
-            gArgs.ModifyRWConfigFile("spkreuse", fNewValue ? "conflict" : "allow");
+            apply_policy("spkreuse", UniValue(fNewValue ? "conflict" : "allow"));
             f_rejectspkreuse = fNewValue;
             setRestartRequired(true);
         }
         break;
     case minrelaytxfee:
-        if (changed()) {
-            CAmount nNv = value.toLongLong();
-            gArgs.ModifyRWConfigFile("minrelaytxfee", FormatMoney(nNv));
-            node().mempool().m_opts.min_relay_feerate = CFeeRate(nNv);
-        }
+        apply_policy("minrelaytxfee", UniValue(FormatMoney(value.toLongLong())));
         break;
     case minrelaycoinblocks:
-        if (changed()) {
-            uint64_t nNv = value.toLongLong();
-            update(nNv);
-            node().mempool().m_opts.minrelaycoinblocks = nNv;
-        }
+        apply_policy("minrelaycoinblocks", UniValue((int64_t)value.toLongLong()));
         break;
     case minrelaymaturity:
-        if (changed()) {
-            int nNv = value.toInt();
-            update(nNv);
-            node().mempool().m_opts.minrelaymaturity = nNv;
-        }
+        apply_policy("minrelaymaturity", UniValue((int64_t)value.toInt()));
         break;
     case bytespersigop:
-        if (changed()) {
-            gArgs.ModifyRWConfigFile("bytespersigop", value.toString().toStdString());
-            nBytesPerSigOp = value.toLongLong();
-        }
+        apply_policy("bytespersigop", UniValue((int64_t)value.toLongLong()));
         break;
     case bytespersigopstrict:
-        if (changed()) {
-            gArgs.ModifyRWConfigFile("bytespersigopstrict", value.toString().toStdString());
-            nBytesPerSigOpStrict = value.toLongLong();
-        }
+        apply_policy("bytespersigopstrict", UniValue((int64_t)value.toLongLong()));
         break;
     case limitancestorcount:
-        if (changed()) {
-            long long nNv = value.toLongLong();
-            std::string strNv = value.toString().toStdString();
-            node().mempool().m_opts.limits.ancestor_count = nNv;
-            gArgs.ForceSetArg("-limitancestorcount", strNv);
-            gArgs.ModifyRWConfigFile("limitancestorcount", strNv);
-        }
+        apply_policy("limitancestorcount", UniValue((int64_t)value.toLongLong()));
         break;
     case limitancestorsize:
-        if (changed()) {
-            long long nNv = value.toLongLong();
-            std::string strNv = value.toString().toStdString();
-            node().mempool().m_opts.limits.ancestor_size_vbytes = nNv * 1'000;
-            gArgs.ForceSetArg("-limitancestorsize", strNv);
-            gArgs.ModifyRWConfigFile("limitancestorsize", strNv);
-        }
+        apply_policy("limitancestorsize", UniValue((int64_t)value.toLongLong()));
         break;
     case limitdescendantcount:
-        if (changed()) {
-            long long nNv = value.toLongLong();
-            std::string strNv = value.toString().toStdString();
-            node().mempool().m_opts.limits.descendant_count = nNv;
-            gArgs.ForceSetArg("-limitdescendantcount", strNv);
-            gArgs.ModifyRWConfigFile("limitdescendantcount", strNv);
-        }
+        apply_policy("limitdescendantcount", UniValue((int64_t)value.toLongLong()));
         break;
     case limitdescendantsize:
-        if (changed()) {
-            long long nNv = value.toLongLong();
-            std::string strNv = value.toString().toStdString();
-            node().mempool().m_opts.limits.descendant_size_vbytes = nNv * 1'000;
-            gArgs.ForceSetArg("-limitdescendantsize", strNv);
-            gArgs.ModifyRWConfigFile("limitdescendantsize", strNv);
-        }
+        apply_policy("limitdescendantsize", UniValue((int64_t)value.toLongLong()));
         break;
     case rejectbarepubkey:
-        if (changed()) {
-            // The config and internal option is inverted
-            const bool nv = ! value.toBool();
-            node().mempool().m_opts.permit_bare_pubkey = nv;
-            node().updateRwSetting("permitbarepubkey", nv);
-        }
+        apply_policy("permitbarepubkey", UniValue(!value.toBool()));
         break;
     case rejectbaremultisig:
-        if (changed()) {
-            // The config and internal option is inverted
-            const bool fNewValue = ! value.toBool();
-            node().mempool().m_opts.permit_bare_multisig = fNewValue;
-            gArgs.ModifyRWConfigFile("permitbaremultisig", strprintf("%d", fNewValue));
-        }
+        apply_policy("permitbaremultisig", UniValue(!value.toBool()));
         break;
     case permitephemeral:
-    {
-        if (changed()) {
-            std::string nv = value.toString().toStdString();
-            ApplyPermitEphemeralOption(nv, node().mempool().m_opts);
-            update(nv);
-        }
+        apply_policy("permitephemeral", UniValue(value.toString().toStdString()));
         break;
-    }
     case rejectbareanchor:
-        if (changed()) {
-            // The config and internal option is inverted
-            const bool nv = ! value.toBool();
-            node().mempool().m_opts.permitbareanchor = nv;
-            node().updateRwSetting("permitbareanchor", nv);
-        }
+        apply_policy("permitbareanchor", UniValue(!value.toBool()));
         break;
     case rejectbaredatacarrier:
-        if (changed()) {
-            // The config and internal option is inverted
-            const bool nv = ! value.toBool();
-            node().mempool().m_opts.permitbaredatacarrier = nv;
-            node().updateRwSetting("permitbaredatacarrier", nv);
-        }
+        apply_policy("permitbaredatacarrier", UniValue(!value.toBool()));
         break;
     case maxscriptsize:
-        if (changed()) {
-            const auto nv = value.toLongLong();
-            update(nv);
-            ::g_script_size_policy_limit = nv;
-        }
+        apply_policy("maxscriptsize", UniValue((int64_t)value.toLongLong()));
         break;
     case maxtxlegacysigops:
-        if (changed()) {
-            const auto nv = value.toLongLong();
-            update(nv);
-            node().mempool().m_opts.maxtxlegacysigops = nv;
-        }
+        apply_policy("maxtxlegacysigops", UniValue((int64_t)value.toLongLong()));
         break;
     case datacarriercost:
-        if (changed()) {
-            const double nNewSize = value.toDouble();
-            update(nNewSize);
-            ::g_weight_per_data_byte = nNewSize * WITNESS_SCALE_FACTOR;
-        }
+        apply_policy("datacarriercost", UniValue(value.toString().toStdString()));
         break;
     case datacarriersize:
-        if (changed()) {
-            const int nNewSize = value.toInt();
-            const bool fNewEn = (nNewSize > 0);
-            if (fNewEn) {
-                if (!node().mempool().m_opts.max_datacarrier_bytes.has_value()) {
-                    gArgs.ModifyRWConfigFile("datacarrier", strprintf("%d", fNewEn));
-                }
-                gArgs.ModifyRWConfigFile("datacarriersize", value.toString().toStdString());
-                node().mempool().m_opts.max_datacarrier_bytes = nNewSize;
-            } else {
-                gArgs.ModifyRWConfigFile("datacarrier", "0");
-                node().mempool().m_opts.max_datacarrier_bytes = std::nullopt;
-            }
-        }
+        apply_policy("datacarriersize", UniValue((int64_t)value.toInt()));
         break;
     case rejectnonstddatacarrier:
-        if (changed()) {
-            // This option is inverted
-            const bool new_value = ! value.toBool();
-            node().updateRwSetting("acceptnonstddatacarrier" + suffix, new_value);
-            node().mempool().m_opts.accept_non_std_datacarrier = new_value;
-        }
+        apply_policy("acceptnonstddatacarrier", UniValue(!value.toBool()));
         break;
     case dustrelayfee:
-        if (changed()) {
-            CAmount nNv = value.toLongLong();
-            gArgs.ModifyRWConfigFile("dustrelayfee", FormatMoney(nNv));
-            CFeeRate feerate{nNv};
-            node().mempool().m_opts.dust_relay_feerate_floor = feerate;
-            if (node().mempool().m_opts.dust_relay_feerate < feerate || !node().mempool().m_opts.dust_relay_target) {
-                node().mempool().m_opts.dust_relay_feerate = feerate;
-            } else {
-                node().mempool().UpdateDynamicDustFeerate();
-            }
-        }
+        apply_policy("dustrelayfee", UniValue(FormatMoney(value.toLongLong())));
         break;
     case dustdynamic:
-        if (changed()) {
-            const std::string newvalue_str = value.toString().toStdString();
-            const util::Result<std::pair<int32_t, int>> parsed = ParseDustDynamicOpt(newvalue_str, 1008 /* FIXME: get from estimator */);
-            assert(parsed);  // FIXME: what to do if it fails to parse?
-            // FIXME: save -prev-<type> for each type
-            update(newvalue_str);
-            node().mempool().m_opts.dust_relay_target = parsed->first;
-            node().mempool().m_opts.dust_relay_multiplier = parsed->second;
-        }
+        apply_policy("dustdynamic", UniValue(value.toString().toStdString()));
         break;
     case blockmintxfee:
         if (changed()) {

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -322,6 +322,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "psbtbumpfee", 1, "original_change_index"},
     { "logging", 0, "include" },
     { "logging", 1, "exclude" },
+    { "dumpsettings", 0, "detailed" },
+    { "setsettings", 0, "settings" },
     { "disconnectnode", 1, "nodeid" },
     { "upgradewallet", 0, "version" },
     { "gethdkeys", 0, "active_only" },

--- a/src/rpc/register.h
+++ b/src/rpc/register.h
@@ -23,6 +23,7 @@ void RegisterSignMessageRPCCommands(CRPCTable&);
 void RegisterSignerRPCCommands(CRPCTable &tableRPC);
 void RegisterTxoutProofRPCCommands(CRPCTable&);
 void RegisterStatsRPCCommands(CRPCTable&);
+void RegisterSettingsRPCCommands(CRPCTable&);
 
 static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
 {
@@ -40,6 +41,7 @@ static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
 #endif // ENABLE_EXTERNAL_SIGNER
     RegisterTxoutProofRPCCommands(t);
     RegisterStatsRPCCommands(t);
+    RegisterSettingsRPCCommands(t);
 }
 
 #endif // BITCOIN_RPC_REGISTER_H

--- a/src/rpc/settings.cpp
+++ b/src/rpc/settings.cpp
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 The Bitcoin Knots developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/args.h>
+#include <node/context.h>
+#include <node/policy_settings.h>
+#include <rpc/server.h>
+#include <rpc/server_util.h>
+#include <rpc/util.h>
+#include <tinyformat.h>
+#include <univalue.h>
+#include <util/result.h>
+#include <util/string.h>
+
+#include <string>
+#include <vector>
+
+using node::NodeContext;
+using node::PolicySettingDef;
+using node::PolicySettingType;
+
+static std::string SettingTypeName(PolicySettingType type)
+{
+    switch (type) {
+    case PolicySettingType::Bool: return "bool";
+    case PolicySettingType::Int: return "int";
+    case PolicySettingType::Amount: return "amount";
+    case PolicySettingType::Number: return "number";
+    case PolicySettingType::String: return "string";
+    }
+    return "string";
+}
+
+static RPCHelpMan dumpsettings()
+{
+    return RPCHelpMan{"dumpsettings",
+        "\nExport the node's corepolicy/mempool settings as JSON.\n"
+        "Intended for headless deployments that replicate the GUI settings interface over RPC.\n",
+        {
+            {"detailed", RPCArg::Type::BOOL, RPCArg::Default{false}, "Include per-setting metadata (type and help text) instead of just the value"},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::OBJ_DYN, "settings", "map of setting name to value (or, when detailed, to a metadata object)",
+                    {
+                        {RPCResult::Type::STR, "setting", "the current value (bool/number/string), or a metadata object when detailed"},
+                    }},
+            },
+            /*skip_type_check=*/true},
+        RPCExamples{
+            HelpExampleCli("dumpsettings", "")
+            + HelpExampleCli("dumpsettings", "true")
+            + HelpExampleRpc("dumpsettings", "true")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            const bool detailed = !request.params[0].isNull() && request.params[0].get_bool();
+
+            NodeContext& node = EnsureAnyNodeContext(request.context);
+            const ArgsManager& args = EnsureAnyArgsman(request.context);
+
+            UniValue settings(UniValue::VOBJ);
+            for (const PolicySettingDef& def : node::PolicySettingRegistry()) {
+                auto value = node::ReadPolicySetting(node, def.name);
+                if (!value) continue; // e.g. mempool disabled
+                if (!detailed) {
+                    settings.pushKV(def.name, *value);
+                    continue;
+                }
+                UniValue meta(UniValue::VOBJ);
+                meta.pushKV("value", *value);
+                meta.pushKV("type", SettingTypeName(def.type));
+                if (def.restart_required) meta.pushKV("restart_required", true);
+                if (auto help = args.GetArgHelpText("-" + def.name)) meta.pushKV("help", *help);
+                settings.pushKV(def.name, meta);
+            }
+
+            UniValue result(UniValue::VOBJ);
+            result.pushKV("settings", settings);
+            return result;
+        },
+    };
+}
+
+static RPCHelpMan setsettings()
+{
+    return RPCHelpMan{"setsettings",
+        "\nUpdate one or more corepolicy/mempool settings.\n"
+        "All settings are validated first; if any value is invalid, none are applied.\n"
+        "Valid changes are applied to the running node and persisted for restart.\n",
+        {
+            {"settings", RPCArg::Type::OBJ_USER_KEYS, RPCArg::Optional::NO, "Object with setting names as keys and new values as values",
+                {
+                    {"setting", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "A setting name (see dumpsettings) and its new value"},
+                }},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::OBJ_DYN, "results", "map of setting name to result", {
+                    {RPCResult::Type::OBJ, "", "", {
+                        {RPCResult::Type::BOOL, "applied", "whether the change was applied"},
+                        {RPCResult::Type::BOOL, "restart_required", /*optional=*/true, "whether a restart is required to take effect (only when applied)"},
+                        {RPCResult::Type::STR, "error", /*optional=*/true, "why the change failed (only when not applied)"},
+                    }},
+                }},
+            },
+            /*skip_type_check=*/true},
+        RPCExamples{
+            HelpExampleCli("setsettings", "'{\"rejectparasites\": true, \"maxmempool\": 500}'")
+            + HelpExampleRpc("setsettings", "{\"rejectparasites\": true}")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            const UniValue& settings = request.params[0].get_obj();
+            const std::vector<std::string> keys = settings.getKeys();
+
+            NodeContext& node = EnsureAnyNodeContext(request.context);
+
+            // Pass 1: reject unknown keys and validate every value with no side effects.
+            std::vector<std::string> errors;
+            for (const std::string& key : keys) {
+                if (!node::FindPolicySetting(key)) {
+                    errors.push_back(strprintf("%s: unknown setting", key));
+                    continue;
+                }
+                auto check = node::ValidatePolicySetting(key, settings[key]);
+                if (!check) errors.push_back(strprintf("%s: %s", key, util::ErrorString(check).original));
+            }
+
+            if (!errors.empty()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid settings: %s", util::Join(errors, "; ")));
+            }
+
+            // Every mempool-backed setting needs the mempool; check once up front so a
+            // mid-batch failure cannot leave earlier settings already applied.
+            EnsureAnyMemPool(request.context);
+
+            // Pass 2: apply all (validated) changes.
+            UniValue results(UniValue::VOBJ);
+            for (const std::string& key : keys) {
+                const PolicySettingDef* def = node::FindPolicySetting(key);
+                auto applied = node::UpdatePolicySetting(node, key, settings[key]);
+                UniValue entry(UniValue::VOBJ);
+                if (!applied) {
+                    entry.pushKV("applied", false);
+                    entry.pushKV("error", util::ErrorString(applied).original);
+                } else {
+                    entry.pushKV("applied", true);
+                    entry.pushKV("restart_required", def->restart_required);
+                }
+                results.pushKV(key, entry);
+            }
+
+            UniValue result(UniValue::VOBJ);
+            result.pushKV("results", results);
+            return result;
+        },
+    };
+}
+
+void RegisterSettingsRPCCommands(CRPCTable& t)
+{
+    static const CRPCCommand commands[]{
+        {"settings", &dumpsettings},
+        {"settings", &setsettings},
+    };
+    for (const auto& c : commands) {
+        t.appendCommand(c.name, &c);
+    }
+}

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -88,6 +88,7 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "savefeeestimates",      // disabled as a precautionary measure: may take a file path argument in the future
     "savemempool",           // disabled as a precautionary measure: may take a file path argument in the future
     "setban",                // avoid DNS lookups
+    "setsettings",           // avoid writing to disk and mutating global policy state
     "stop",                  // avoid shutdown state
 };
 
@@ -107,6 +108,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "deriveaddresses",
     "descriptorprocesspsbt",
     "disconnectnode",
+    "dumpsettings",
     "echo",
     "echojson",
     "estimaterawfee",

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -103,7 +103,7 @@ class HelpRpcTest(BitcoinTestFramework):
         # command titles
         titles = [line[3:-3] for line in node.help().splitlines() if line.startswith('==')]
 
-        components = ['Blockchain', 'Control', 'Mining', 'Network', 'Rawtransactions', 'Stats', 'Util']
+        components = ['Blockchain', 'Control', 'Mining', 'Network', 'Rawtransactions', 'Settings', 'Stats', 'Util']
 
         if self.is_wallet_compiled():
             components.append('Wallet')

--- a/test/functional/rpc_settings.py
+++ b/test/functional/rpc_settings.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Knots developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the dumpsettings / setsettings RPCs (corepolicy settings over RPC)."""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+
+
+class RpcSettingsTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def dump(self):
+        return self.nodes[0].dumpsettings()["settings"]
+
+    def set_one(self, name, value):
+        res = self.nodes[0].setsettings({name: value})["results"]
+        assert name in res, f"{name} missing from setsettings result"
+        assert_equal(res[name]["applied"], True)
+        return res[name]
+
+    def test_roundtrip(self):
+        node = self.nodes[0]
+        self.log.info("Round-trip each setting kind through setsettings -> dumpsettings")
+
+        # (name, value, expected-readback)
+        cases = [
+            # booleans
+            ("rejectparasites", True, True),
+            ("rejecttokens", True, True),
+            ("permitbaremultisig", True, True),
+            ("permitbarepubkey", True, True),
+            ("permitbaredatacarrier", True, True),
+            ("permitbareanchor", True, True),
+            ("acceptnonstddatacarrier", True, True),
+            ("acceptnonstdtxn", True, True),
+            ("subdustfeepenalty", False, False),
+            ("acceptunknownwitness", False, False),
+            # integers
+            ("maxmempool", 500, 500),
+            ("mempoolexpiry", 240, 240),
+            ("minrelaycoinblocks", 3, 3),
+            ("minrelaymaturity", 2, 2),
+            ("limitancestorcount", 30, 30),
+            ("limitancestorsize", 202, 202),
+            ("limitdescendantcount", 30, 30),
+            ("limitdescendantsize", 202, 202),
+            ("maxtxlegacysigops", 1000, 1000),
+            ("bytespersigop", 50, 50),
+            ("bytespersigopstrict", 50, 50),
+            ("maxscriptsize", 2000, 2000),
+            ("datacarriersize", 100, 100),
+            # amounts (BTC/kvB, numeric readback)
+            ("minrelaytxfee", "0.00002000", Decimal("0.00002000")),
+            ("incrementalrelayfee", "0.00001500", Decimal("0.00001500")),
+            ("dustrelayfee", "0.00003000", Decimal("0.00003000")),
+            # fixed-point number
+            ("datacarriercost", "2.50", Decimal("2.5")),
+            # strings
+            ("mempooltruc", "reject", "reject"),
+            ("mempoolreplacement", "never", "never"),
+            ("mempoolreplacement", "fee,optin", "fee,optin"),
+            ("mempoolreplacement", "fee", "fee,-optin"),
+            ("permitephemeral", "reject", "reject"),
+            ("permitephemeral", "-anchor,-send,dust", "-anchor,-send,dust"),
+            ("dustdynamic", "off", "off"),
+        ]
+        for name, value, expected in cases:
+            self.set_one(name, value)
+            got = self.dump()[name]
+            assert_equal(got, expected)
+
+        self.log.info("datacarriersize=0 disables datacarrier")
+        self.set_one("datacarriersize", 0)
+        assert_equal(self.dump()["datacarriersize"], 0)
+
+    def test_live_effect_via_getmempoolinfo(self):
+        node = self.nodes[0]
+        self.log.info("Changes take live effect (cross-checked via getmempoolinfo)")
+        self.set_one("minrelaytxfee", "0.00005000")
+        assert_equal(node.getmempoolinfo()["minrelaytxfee"], Decimal("0.00005000"))
+        self.set_one("maxmempool", 123)
+        assert_equal(node.getmempoolinfo()["maxmempool"], 123 * 1_000_000)
+        self.set_one("mempoolreplacement", "never")
+        assert_equal(node.getmempoolinfo()["fullrbf"], False)
+
+    def test_atomicity(self):
+        node = self.nodes[0]
+        self.log.info("A batch with any invalid value applies nothing")
+        before = self.dump()["rejectparasites"]
+        assert_raises_rpc_error(
+            -8, "Invalid settings",
+            node.setsettings, {"rejectparasites": (not before), "maxmempool": "not-a-number"})
+        assert_equal(self.dump()["rejectparasites"], before)
+
+        self.log.info("Unknown setting names are rejected")
+        assert_raises_rpc_error(-8, "unknown setting", node.setsettings, {"nosuchsetting": 1})
+
+        self.log.info("Type errors are rejected")
+        assert_raises_rpc_error(-8, "Invalid settings", node.setsettings, {"rejectparasites": "banana"})
+
+        self.log.info("Out-of-range integers are rejected")
+        assert_raises_rpc_error(-8, "Invalid settings", node.setsettings, {"maxmempool": 2**40})
+        assert_raises_rpc_error(-8, "Invalid settings", node.setsettings, {"maxmempool": -1})
+
+    def test_detailed(self):
+        node = self.nodes[0]
+        self.log.info("dumpsettings detailed returns real type/help metadata")
+        detailed = node.dumpsettings(True)["settings"]
+        entry = detailed["rejectparasites"]
+        assert_equal(entry["type"], "bool")
+        assert "value" in entry
+        assert "help" in entry and len(entry["help"]) > 0
+        assert_equal(detailed["spkreuse"]["restart_required"], True)
+
+    def test_persistence_and_restart(self):
+        node = self.nodes[0]
+        self.log.info("settings.json + rwconf persistence survives restart")
+        self.set_one("rejectparasites", True)      # settings.json
+        self.set_one("maxmempool", 456)            # rwconf
+        spk = self.set_one("spkreuse", "conflict")  # restart-required
+        assert_equal(spk["restart_required"], True)
+
+        settings_json = node.chain_path / "settings.json"
+        assert settings_json.exists()
+        assert "rejectparasites" in settings_json.read_text()
+
+        self.restart_node(0)
+        dumped = self.dump()
+        assert_equal(dumped["rejectparasites"], True)
+        assert_equal(dumped["maxmempool"], 456)
+        assert_equal(dumped["spkreuse"], "conflict")
+
+    def run_test(self):
+        self.test_roundtrip()
+        self.test_live_effect_via_getmempoolinfo()
+        self.test_atomicity()
+        self.test_detailed()
+        self.test_persistence_and_restart()
+
+
+if __name__ == "__main__":
+    RpcSettingsTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -214,6 +214,7 @@ BASE_SCRIPTS = [
     'mining_coin_age_priority.py',
     'rpc_getchaintips.py',
     'rpc_misc.py',
+    'rpc_settings.py',
     'p2p_1p1c_network.py',
     'interface_rest.py',
     'mempool_spend_coinbase.py',


### PR DESCRIPTION
Adds two RPCs so headless deployments (Start9, Umbrel, etc.) can read and change the node's corepolicy/mempool settings without the GUI. Resolves https://github.com/bitcoinknots/bitcoin/issues/130.

## Changes

- `dumpsettings ( detailed )`: export the current corepolicy/mempool settings as JSON. With `detailed`, each entry also reports its type and help text, so a headless UI can be built from the node instead of hard-coding the option list per release.
- `setsettings {"name": value, ...}`: validate the whole batch first (nothing is applied if any value is invalid), then apply and persist the valid changes. The result reports whether any change needs a restart (e.g. `spkreuse`).

RPC and the GUI now change these settings through a single internal interface (`node/policy_settings`), so `OptionsModel` and the RPCs stay consistent; the `OptionsModel` apply/persist duplication is removed. Setting names match the corresponding `bitcoin.conf` option names.

Includes a functional test (`rpc_settings.py`) covering round-trip, live effect via `getmempoolinfo`, batch atomicity, `detailed` metadata, and persistence across restart, plus release notes.
