### PR TITLE
Fix Transifex link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Translations
 ------------
 
 Changes to translations as well as new translations can be submitted to
-[Bitcoin Core's Transifex page](https://www.transifex.com/bitcoin/bitcoin/).
+[Bitcoin Core's Transifex page](https://explore.transifex.com/bitcoin/bitcoin/).
 
 Translations are periodically pulled from Transifex and merged into the git repository. See the
 [translation process](doc/translation_process.md) for details on how this works.


### PR DESCRIPTION
The link works on Bitcoin Core's GitHub, but here it's broken.
