### PR TITLE
GUI: Changes to adapt to dark mode palettes

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -135,7 +135,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
         Q_EMIT consoleShown(rpcConsole);
     }
 
-    modalOverlay = new ModalOverlay(enableWallet, this->centralWidget());
+    modalOverlay = new ModalOverlay(enableWallet, *platformStyle, this->centralWidget());
 
     // Accept D&D of URIs
     setAcceptDrops(true);

--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -31,9 +31,6 @@
    </property>
    <item>
     <widget class="QWidget" name="bgWidget" native="true">
-     <property name="styleSheet">
-      <string notr="true">#bgWidget { background: rgba(0,0,0,220); }</string>
-     </property>
      <layout class="QVBoxLayout" name="verticalLayoutMain" stretch="1">
       <property name="leftMargin">
        <number>60</number>
@@ -49,11 +46,6 @@
       </property>
       <item>
        <widget class="QWidget" name="contentWidget" native="true">
-        <property name="styleSheet">
-         <string notr="true">#contentWidget { background: rgba(255,255,255,240); border-radius: 6px; }
-
-QLabel { color: rgb(40,40,40);  }</string>
-        </property>
         <layout class="QVBoxLayout" name="verticalLayoutSub" stretch="1,0,0,0">
          <property name="spacing">
           <number>0</number>
@@ -78,32 +70,11 @@ QLabel { color: rgb(40,40,40);  }</string>
            <item>
             <layout class="QVBoxLayout" name="verticalLayoutIcon">
              <property name="leftMargin">
-              <number>0</number>
+              <number>25</number>
              </property>
-             <item>
-              <widget class="QPushButton" name="warningIcon">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>:/icons/warning</normaloff>
-                 <disabledoff>:/icons/warning</disabledoff>:/icons/warning</iconset>
-               </property>
-               <property name="iconSize">
-                <size>
-                 <width>48</width>
-                 <height>48</height>
-                </size>
-               </property>
-               <property name="flat">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
+             <property name="rightMargin">
+              <number>25</number>
+             </property>
              <item>
               <spacer name="verticalSpacerWarningIcon">
                <property name="orientation">

--- a/src/qt/modaloverlay.h
+++ b/src/qt/modaloverlay.h
@@ -16,13 +16,16 @@ namespace Ui {
     class ModalOverlay;
 }
 
+class PlatformStyle;
+class QEvent;
+
 /** Modal overlay to display information about the chain-sync state */
 class ModalOverlay : public QWidget
 {
     Q_OBJECT
 
 public:
-    explicit ModalOverlay(bool enable_wallet, QWidget *parent);
+    explicit ModalOverlay(bool enable_wallet, const PlatformStyle& platform_style, QWidget *parent);
     ~ModalOverlay();
 
     void tipUpdate(int count, const QDateTime& blockDate, double nVerificationProgress);
@@ -42,6 +45,7 @@ Q_SIGNALS:
 protected:
     bool eventFilter(QObject * obj, QEvent * ev) override;
     bool event(QEvent* ev) override;
+    void changeEvent(QEvent* e) override;
 
 private:
     Ui::ModalOverlay *ui;
@@ -51,8 +55,10 @@ private:
     bool layerIsVisible{false};
     bool userClosed{false};
     QPropertyAnimation m_animation;
+    const PlatformStyle& m_platform_style;
     void UpdateHeaderSyncLabel();
     void UpdateHeaderPresyncLabel(int height, const QDateTime& blockDate);
+    void updateThemeStyles();
 };
 
 #endif // BITCOIN_QT_MODALOVERLAY_H


### PR DESCRIPTION
Fixes GUI issues in v29.1-rc1:

- Fix mempool stats checkbox backgrounds to respect dark mode (transparent background)
- Fix splash screen logo alignment (already handled in latest tmp branch update)
- refactored luminosity based darkmode detection into guiutils
- Added palette event change handling in mempool stats and blockview
- Fix mempool stats to use dark and light mode color palettes (blue, orange, green, grey) for checkbox selected text, time period and graph lines
- Fix blockview elements to use same blue dark/light palette as mempool stats
- Fix bitcoingui pairing action icon to switch with palette change events
- ModalOverlay now responds to system theme events

Fully tested on macOS and Linux. 