### PR TITLE
GUI: Better invalid external script signer error dialog messaging

### DIFF
--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -301,7 +301,12 @@ void CreateWalletActivity::create()
     try {
         signers = node().listExternalSigners();
     } catch (const std::runtime_error& e) {
-        QMessageBox::critical(nullptr, tr("Can't list signers"), e.what());
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setWindowTitle(tr("Can't list signers"));
+        msgBox.setText(tr("Unable to execute external signer script. Please check that the script signer path is correct and that the script is functional."));
+        msgBox.setDetailedText(QString::fromStdString(e.what()));
+        msgBox.exec();
     }
     if (signers.size() > 1) {
         QMessageBox::critical(nullptr, tr("Too many external signers found"), QString::fromStdString("More than one external signer found. Please connect only one at a time."));


### PR DESCRIPTION
The current code gives very generic error messages when creating a new wallet and the External script signer path is either invalid or not a proper script signer.  This is a simple fix to catch these errors and give more succinct error messages to the user - without it the user really doesn't know what the problem is. With it, they know to go and fix their signer script path.

Before:  "waitpid failed: Interrupted system call (4) on CreateWallet" or "execve failed: No such file or directory (2)"

After: Messaging has changed slightly, now with details button.  screen:
<img width="420" height="276" alt="Screenshot 2025-08-22 at 9 20 09 PM" src="https://github.com/user-attachments/assets/ec7006bb-62ef-4b0d-91b5-2bf237326118" />

