### PR TITLE
[Compact Block Filter] Do not hint nonstandard TXNs

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3326,7 +3326,9 @@ void PeerManagerImpl::ProcessInvalidTx(NodeId nodeid, const CTransactionRef& ptx
             RecentRejectsFilter().insert(ptx->GetHash().ToUint256());
             m_txrequest.ForgetTxHash(ptx->GetHash());
         }
-        if (maybe_add_extra_compact_tx && RecursiveDynamicUsage(*ptx) < 100000) {
+        // Don't add transactions rejected for standardness policy violations to compact extra transactions
+        if (maybe_add_extra_compact_tx && RecursiveDynamicUsage(*ptx) < 100000 &&
+            state.GetResult() != TxValidationResult::TX_NOT_STANDARD) {
             AddToCompactExtraTransactions(ptx);
         }
     }


### PR DESCRIPTION
This change should stop the adding of nonstandard transactions to the CBF extra txns. 

This would mean that for anyone who uses more aggressive filters, they would not relay "spam" to all of their block peers on acceptance of a block; but instead only to those that do the round trip for that TXID of the hint that was excluded. This has the effect of slowing down the propagation of blocks with lots of filtered transactions while reducing bandwidth usage if connected to many spammy peers.