### PR TITLE
Docker support for Bitcoin Knots

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:22.04
+
+LABEL maintainer="you@example.com"
+LABEL description="Bitcoin Knots built from source with --disable-wallet"
+
+# Build args
+ARG BITCOIN_KNOTS_TAG=v28.1.knots20250305
+ARG CPU_CORES=4
+
+# Set env for usage
+ENV USERNAME=bitcoin
+ENV HOME_DIR=/home/$USERNAME
+ENV BITCOIN_SRC_DIR=$HOME_DIR/bitcoin
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libtool \
+    autotools-dev \
+    automake \
+    pkg-config \
+    bsdmainutils \
+    curl \
+    git \
+    gnupg \
+    libevent-dev \
+    libboost-system-dev \
+    libboost-filesystem-dev \
+    libboost-test-dev \
+    libboost-thread-dev \
+    libminiupnpc-dev \
+    libnatpmp-dev \
+    libssl-dev \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create user
+RUN useradd -m -s /bin/bash $USERNAME
+
+# Switch to user
+USER $USERNAME
+WORKDIR $HOME_DIR
+
+# Clone and build Bitcoin Knots
+RUN git clone https://github.com/bitcoinknots/bitcoin.git && \
+    cd bitcoin && \
+    git fetch --tags && \
+    git checkout $BITCOIN_KNOTS_TAG && \
+    ./autogen.sh && \
+    ./configure --disable-wallet --disable-zmq --prefix=$BITCOIN_SRC_DIR && \
+    make -j$CPU_CORES && \
+    make install
+
+# Back to root for running the daemon
+USER root
+
+# Expose standard Bitcoin ports
+EXPOSE 8333 8332
+
+# Data directory as a volume
+VOLUME ["/bitcoin/.bitcoin"]
+
+# Run bitcoind on container start
+ENTRYPOINT ["/home/bitcoin/bitcoin/bin/bitcoind", "-datadir=/bitcoin/.bitcoin", "-printtoconsole"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,11 +54,15 @@ RUN git clone https://github.com/bitcoinknots/bitcoin.git && \
 # Back to root for running the daemon
 USER root
 
+# ✅ Add to root user's PATH as well (affects docker exec)
+ENV PATH="/home/bitcoin/bitcoin/bin:${PATH}"
+
 # Expose standard Bitcoin ports
 EXPOSE 8333 8332
 
 # Data directory as a volume
 VOLUME ["/bitcoin/.bitcoin"]
+
 
 # Run bitcoind on container start
 ENTRYPOINT ["/home/bitcoin/bitcoin/bin/bitcoind", "-datadir=/bitcoin/.bitcoin", "-printtoconsole"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,14 @@
-FROM ubuntu:22.04
+# Builder stage: build Bitcoin Knots from source
+FROM debian:bookworm-slim AS builder
 
-
-LABEL description="Bitcoin Knots built from source with --disable-wallet"
-
-# Build args
 ARG BITCOIN_KNOTS_TAG=v28.1.knots20250305
 ARG CPU_CORES=4
 
-# Set env for usage
 ENV USERNAME=bitcoin
 ENV HOME_DIR=/home/$USERNAME
 ENV BITCOIN_SRC_DIR=$HOME_DIR/bitcoin
 
-# Install dependencies
+# Install build dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
     libtool \
@@ -34,35 +30,58 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Create user
+# Create a user
 RUN useradd -m -s /bin/bash $USERNAME
 
-# Switch to user
 USER $USERNAME
 WORKDIR $HOME_DIR
 
 # Clone and build Bitcoin Knots
 RUN git clone https://github.com/bitcoinknots/bitcoin.git && \
+    git -C bitcoin fetch --tags && \
+    git -C bitcoin checkout $BITCOIN_KNOTS_TAG && \
     cd bitcoin && \
-    git fetch --tags && \
-    git checkout $BITCOIN_KNOTS_TAG && \
     ./autogen.sh && \
     ./configure --disable-wallet --disable-zmq --prefix=$BITCOIN_SRC_DIR && \
     make -j$CPU_CORES && \
     make install
 
-# Back to root for running the daemon
-USER root
+# Runtime stage: smaller image with only runtime deps + binaries
+FROM debian:bookworm-slim
 
-# ✅ Add to root user's PATH as well (affects docker exec)
+ENV USERNAME=bitcoin
+ENV HOME_DIR=/home/$USERNAME
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    libevent-dev \
+    libboost-system-dev \
+    libboost-filesystem-dev \
+    libboost-test-dev \
+    libboost-thread-dev \
+    libminiupnpc-dev \
+    libnatpmp-dev \
+    libssl-dev \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create user
+RUN useradd -m -s /bin/bash $USERNAME
+
+# Copy binaries from builder
+COPY --from=builder /home/bitcoin/bitcoin/bin /home/bitcoin/bitcoin/bin
+
+# Add binary path to PATH
 ENV PATH="/home/bitcoin/bitcoin/bin:${PATH}"
 
 # Expose standard Bitcoin ports
 EXPOSE 8333 8332
 
-# Data directory as a volume
+
+# Volume for blockchain data
 VOLUME ["/bitcoin/.bitcoin"]
 
+USER root
 
-# Run bitcoind on container start
-ENTRYPOINT ["/home/bitcoin/bitcoin/bin/bitcoind", "-datadir=/bitcoin/.bitcoin", "-printtoconsole"]
+ENTRYPOINT ["bitcoind", "-datadir=/bitcoin/.bitcoin", "-printtoconsole"]
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-LABEL maintainer="you@example.com"
+
 LABEL description="Bitcoin Knots built from source with --disable-wallet"
 
 # Build args

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,10 @@ EXPOSE 8333 8332
 # Volume for blockchain data
 VOLUME ["/bitcoin/.bitcoin"]
 
-USER root
+RUN mkdir -p /bitcoin/.bitcoin && \
+    chown -R bitcoin:bitcoin /bitcoin
+
+USER bitcoin
 
 ENTRYPOINT ["bitcoind", "-datadir=/bitcoin/.bitcoin", "-printtoconsole"]
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,104 @@
+
+# 🚀 Bitcoin Knots Docker Image (Headless Node)
+
+This Dockerfile builds and runs a **Bitcoin Knots** full node (no wallet, no ZMQ) from source.
+
+## 🧱 Features
+
+* Built from a specific Bitcoin Knots tag
+* `--disable-wallet` and `--disable-zmq`
+* Data directory persisted via volume
+* Easy to update by just changing the tag
+* RPC support enabled by default
+
+---
+
+## 📦 Build the Docker Image
+
+```bash
+docker build -t bitcoin-knots:v28.1.knots20250305 .
+```
+
+> Replace `v28.1.knots20250305` with your desired tag.
+
+---
+
+## ▶️ Run the Node
+
+```bash
+docker run -d \
+  --name bitcoinknots \
+  -v $HOME/bitcoin-knots-data:/bitcoin/.bitcoin \
+  -p 8333:8333 \
+  -p 8332:8332 \
+  bitcoin-knots:v28.1.knots20250305
+```
+
+This will:
+
+* Start the node in the background
+* Save the blockchain and config in `~/bitcoin-knots-data`
+* Expose peer and RPC ports
+
+---
+
+## 📊 Check Node Status
+
+You can monitor the sync status using:
+
+```bash
+docker exec -it bitcoinknots bitcoin-cli -datadir=/bitcoin/.bitcoin getblockchaininfo
+```
+
+---
+
+## 📁 Bitcoin Config File
+
+The config is stored at:
+
+```
+$HOME/bitcoin-knots-data/bitcoin.conf
+```
+
+Create it manually if needed:
+
+```ini
+server=1
+rpcuser=yourusername
+rpcpassword=yoursecurepassword
+```
+
+---
+
+## 🛑 Stop the Node
+
+```bash
+docker stop bitcoinknots
+```
+
+---
+
+## ❗ Notes
+
+* You must manually create `bitcoin.conf` to use RPC securely.
+* Port 8333 is for P2P, 8332 is for RPC.
+* You can change the tag to build newer releases.
+
+---
+
+## 📌 Update to New Release
+
+Just change the `ARG BITCOIN_KNOTS_TAG` in the `Dockerfile` and rebuild:
+
+```dockerfile
+ARG BITCOIN_KNOTS_TAG=v29.0.knots20251001
+```
+
+Then:
+
+```bash
+docker build -t bitcoin-knots:v29.0.knots20251001 .
+```
+
+---
+

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+TAG="$1"  # e.g., v29.0.knots20251001
+CORES="${2:-4}"
+
+if [ -z "$TAG" ]; then
+    echo "Usage: $0 <bitcoin_knots_tag> [cpu_cores]"
+    exit 1
+fi
+
+docker build \
+  --build-arg BITCOIN_KNOTS_TAG="$TAG" \
+  --build-arg CPU_CORES="$CORES" \
+  -t "bitcoin-knots:$TAG" .

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+TAG="$1"       # e.g., v29.0.knots20251001
+CORES="${2:-4}"  # Optional: for future use if needed
+
+if [ -z "$TAG" ]; then
+    echo "Usage: $0 <bitcoin_knots_tag> [cpu_cores]"
+    exit 1
+fi
+
+# Ensure the data directory exists
+mkdir -p "$HOME/bitcoin-knots-data"
+
+# Run the Docker container
+docker run -d \
+  --name=bitcoinknots \
+  -v "$HOME/bitcoin-knots-data:/bitcoin/.bitcoin" \
+  -p 8333:8333 \
+  -p 8332:8332 \
+  "bitcoin-knots:$TAG"
+


### PR DESCRIPTION

### Add Docker Support for Bitcoin Knots (Headless, Wallet Disabled)

This pull request introduces a Dockerfile to build and run Bitcoin Knots from source in a minimal containerized environment.

Key details:

* Built from the official `bitcoinknots/bitcoin` repository at the specified tag.
* Compiled with `--disable-wallet` and runs in headless mode.
* Based on `debian:bookworm-slim` for reduced image size and minimal dependencies.
* Verified to work on macOS, x86\_64, and aarch64 architectures.
* Includes helper scripts and a `README.md` with usage instructions.

This setup is useful for deploying lightweight Bitcoin nodes, especially in automated or production environments.

### Integration

This Docker container is compatible with Datum Gateway which already supports Docker. When combined, a `docker-compose` setup can be used to deploy a fully containerized Bitcoin + Datum Gateway stack.

An example of such a setup can be found at: [https://github.com/electricalgrade/btc\_datum](https://github.com/electricalgrade/btc_datum)

This contribution can help simplify deployments for miners and developers who want to run Bitcoin Knots in a reproducible and isolated environment.



