### PR TITLE
Add Dockerfile

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.22 AS builder
+
+RUN apk add --no-cache \
+    build-base \
+    cmake \
+    boost-dev \
+    libevent-dev \
+    sqlite-dev \
+    zeromq-dev \
+    coreutils \
+    binutils
+
+WORKDIR /opt/bitcoin
+
+COPY . .
+
+WORKDIR /opt/bitcoin/build
+
+RUN cmake .. \
+    -DCMAKE_INSTALL_PREFIX="/usr/local/" \
+    -DBUILD_DAEMON="ON" \
+    -DBUILD_CLI="ON" \
+    -DENABLE_WALLET="ON" \
+    -DWITH_ZMQ="ON" \
+    -DBUILD_TESTS="ON" \
+    -DBUILD_GUI="OFF" \
+    -DBUILD_TX="OFF" \
+    -DBUILD_UTIL="OFF" \
+    -DBUILD_WALLET_TOOL="OFF" \
+    -DBUILD_BENCH="OFF" \
+    -DBUILD_FUZZ_BINARY="OFF" \
+    -DBUILD_UTIL_CHAINSTATE="OFF" \
+    -DWITH_BDB="OFF" \
+    -DWITH_USDT="OFF" \
+    -DINSTALL_MAN="OFF" \
+    -DWITH_CCACHE="OFF"
+
+RUN cmake --build . --parallel $(nproc)
+RUN ctest --output-on-failure
+RUN cmake --install .
+
+RUN strip --strip-unneeded /usr/local/bin/*
+
+FROM alpine:3.22 AS final
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+RUN apk add --no-cache \
+    libevent \
+    sqlite-libs \
+    zeromq \
+    boost-system \
+    boost-filesystem \
+    boost-program_options
+
+COPY --from=builder /usr/local/bin/bitcoind     /usr/local/bin/bitcoind
+COPY --from=builder /usr/local/bin/bitcoin-cli  /usr/local/bin/bitcoin-cli
+
+RUN addgroup -S -g ${GROUP_ID} bitcoin && \
+    adduser -S -u ${USER_ID} -G bitcoin -H -s /bin/false bitcoin
+
+WORKDIR /var/lib/bitcoind
+EXPOSE 8333 8332
+USER bitcoin
+VOLUME ["/var/lib/bitcoind", "/etc/bitcoin/bitcoin.conf"]
+
+ENTRYPOINT ["bitcoind", "-conf=/etc/bitcoin/bitcoin.conf", "-datadir=/var/lib/bitcoind"]
+
+HEALTHCHECK --interval=5m --timeout=15s --start-period=2m --start-interval=10s \
+    CMD ["bitcoin-cli", "-conf=/etc/bitcoin/bitcoin.conf", "-datadir=/var/lib/bitcoind", "getblockchaininfo"]

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -1,0 +1,67 @@
+
+# 🚀 Bitcoin Knots Docker Image (Headless Node)
+
+This Dockerfile builds and runs a **Bitcoin Knots** full node from source.
+
+## 🧱 Features
+
+* Stripped of all non-essential components (tests, debug data, documentation, etc.)
+* Data directory persisted via volume
+* Accessible via RPC
+
+---
+
+## 📦 Build the Docker Image
+
+**make sure you're at the root of the repo first!**
+
+```bash
+docker build \
+  -f contrib/docker/Dockerfile \
+  -t bitcoinknots \
+  --build-arg USER_ID=$(id -u) \
+  --build-arg GROUP_ID=$(id -g) \
+  --load .
+```
+
+---
+
+## ▶️ Run the Node
+
+```bash
+docker run -d \
+  --init \
+  --user $(id -u):$(id -g) \
+  --name bitcoinknots \
+  -p 8333:8333 -p 127.0.0.1:8332:8332 \
+  -v path/to/conf:/etc/bitcoin/bitcoin.conf:ro \
+  -v path/to/data:/var/lib/bitcoind:rw \
+  bitcoinknots
+```
+
+In case you want to use ZeroMQ sockets, make sure to expose those ports as well by adding `-p host_port:container_port` directives to the command above.
+In case `path/to/data` is not writable by your user, consider overriding the `--user` flag.
+
+This will:
+
+* Start the node in the background
+* Save the blockchain and config in `/path/to/data`
+* Expose peer and RPC ports
+
+---
+
+## 📊 Check Node Status
+
+```bash
+docker logs bitcoinknots
+```
+
+---
+
+## 🛑 Stop the Node
+
+```bash
+docker stop bitcoinknots
+```
+
+---


### PR DESCRIPTION
This PR adds a general purpose lightweight Dockerfile to easily build and run a Knots node.
The Dockerfile is meant to be run on the same host as were it is built from; this is because of  CPU architecture specific compatibility issues that not even Docker addresses.

Inspired by https://github.com/bitcoinknots/bitcoin/pull/170

 