### PR TITLE
depends: fetch miniupnpc sources from github releases

### DIFF
--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -1,6 +1,6 @@
 package=miniupnpc
 $(package)_version=2.3.3
-$(package)_download_path=https://miniupnp.tuxfamily.org/files/
+$(package)_download_path=https://github.com/miniupnp/miniupnp/releases/download/$(package)_$(subst .,_,$($(package)_version))/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=d52a0afa614ad6c088cc9ddff1ae7d29c8c595ac5fdd321170a05f41e634bd1a
 $(package)_patches=dont_leak_info.patch


### PR DESCRIPTION
miniupnp.tuxfamily.org seems unreliable or still unavailable.

relates to 21b8a14d37

<!--
*** Please remove the following help text before submitting: ***

Before opening a pull request to Bitcoin Knots, please first consider if it
is appropriate for Bitcoin Core and, if so, rebase it and [open a pull request](https://github.com/bitcoin/bitcoin/compare)
there first! Bitcoin Core has a strict and slow review process, but since
Knots is more relaxed, feel free to request a merge of your Core PR into
Knots even while it's waiting on Core.

-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Knots user experience or Bitcoin Knots developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are typically welcome.
* Refactoring changes are never accepted in Knots, and must be performed in
  Bitcoin Core.
-->
