### PR TITLE
GUI: Visually move and rephrase port mapping checkboxes

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -903,9 +903,12 @@ void InitParameterInteraction(ArgsManager& args)
 
     if (!args.GetBoolArg("-listen", DEFAULT_LISTEN)) {
         // do not map ports or try to retrieve public IP when not listening (pointless)
-        if (args.SoftSetBoolArg("-upnp", false))
+        if (args.GetBoolArg("-upnp", DEFAULT_UPNP)) {
+            args.ForceSetArg("-upnp", "0");
             LogInfo("parameter interaction: -listen=0 -> setting -upnp=0\n");
-        if (args.SoftSetBoolArg("-natpmp", false)) {
+        }
+        if (args.GetBoolArg("-natpmp", DEFAULT_NATPMP)) {
+            args.ForceSetArg("-natpmp", "0");
             LogInfo("parameter interaction: -listen=0 -> setting -natpmp=0\n");
         }
         if (args.SoftSetBoolArg("-discover", false))

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -391,7 +391,7 @@
           <string>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</string>
          </property>
          <property name="text">
-          <string>Map port using &amp;UPnP</string>
+          <string>Automatically configure router(s) that support &amp;UPnP</string>
          </property>
         </widget>
        </item>
@@ -401,7 +401,7 @@
           <string>Automatically open the Bitcoin client port on the router. This only works when your router supports PCP or NAT-PMP and it is enabled. The external port could be random.</string>
          </property>
          <property name="text">
-          <string>Map port using PCP or NA&amp;T-PMP</string>
+          <string>Automatically configure router(s) that support PCP or NA&amp;T-PMP</string>
          </property>
         </widget>
        </item>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -386,16 +386,6 @@
         </layout>
        </item>
        <item>
-        <widget class="QCheckBox" name="mapPortUpnp">
-         <property name="toolTip">
-          <string>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</string>
-         </property>
-         <property name="text">
-          <string>Automatically configure router(s) that support &amp;UPnP</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="mapPortNatpmp">
          <property name="toolTip">
           <string>Automatically open the Bitcoin client port on the router. This only works when your router supports PCP or NAT-PMP and it is enabled. The external port could be random.</string>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -312,6 +312,10 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
     // NOTE: Re-inserted in bottom-to-top order
     CreateOptionUI(ui->verticalLayout_Network, QStringLiteral("%1"), {ui->mapPortNatpmp}, { .insert_at=insert_at, .indent=checkbox_indent, });
     CreateOptionUI(ui->verticalLayout_Network, QStringLiteral("%1"), {ui->mapPortUpnp}, { .insert_at=insert_at, .indent=checkbox_indent, });
+    connect(ui->allowIncoming, &QPushButton::toggled, ui->mapPortUpnp, &QWidget::setEnabled);
+    connect(ui->allowIncoming, &QPushButton::toggled, ui->mapPortNatpmp, &QWidget::setEnabled);
+    ui->mapPortUpnp->setEnabled(ui->allowIncoming->isChecked());
+    ui->mapPortNatpmp->setEnabled(ui->allowIncoming->isChecked());
 
     prevwidget = dynamic_cast<QWidgetItem*>(ui->verticalLayout_Network->itemAt(ui->verticalLayout_Network->count() - 1))->widget();
 

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -100,6 +100,7 @@ void OptionsDialog::FixTabOrder(QWidget * const o)
 struct CreateOptionUIOpts {
     QBoxLayout *horizontal_layout{nullptr};
     int stretch{1};
+    int insert_at{-1};
     int indent{0};
 };
 
@@ -153,7 +154,7 @@ void OptionsDialog::CreateOptionUI(QBoxLayout * const layout, const QString& tex
 
     if (opts.stretch) horizontalLayout->addStretch(opts.stretch);
 
-    layout->addLayout(horizontalLayout);
+    layout->insertLayout(opts.insert_at, horizontalLayout);
 
     for (auto& o : objs) {
         o->setProperty("L", QVariant::fromValue((QLayout*)horizontalLayout));

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -299,8 +299,20 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
     ui->verticalLayout_Wallet->insertWidget(0, walletrbf);
     FixTabOrder(walletrbf);
 
+    QStyleOptionButton styleoptbtn;
+    const auto checkbox_indent = ui->allowIncoming->style()->subElementRect(QStyle::SE_CheckBoxIndicator, &styleoptbtn, ui->allowIncoming).width();
+
     /* Network tab */
     QLayoutItem *spacer = ui->verticalLayout_Network->takeAt(ui->verticalLayout_Network->count() - 1);
+
+    prevwidget = ui->allowIncoming;
+    ui->verticalLayout_Network->removeWidget(ui->mapPortUpnp);
+    ui->verticalLayout_Network->removeWidget(ui->mapPortNatpmp);
+    int insert_at = ui->verticalLayout_Network->indexOf(ui->connectSocks);
+    // NOTE: Re-inserted in bottom-to-top order
+    CreateOptionUI(ui->verticalLayout_Network, QStringLiteral("%1"), {ui->mapPortNatpmp}, { .insert_at=insert_at, .indent=checkbox_indent, });
+    CreateOptionUI(ui->verticalLayout_Network, QStringLiteral("%1"), {ui->mapPortUpnp}, { .insert_at=insert_at, .indent=checkbox_indent, });
+
     prevwidget = dynamic_cast<QWidgetItem*>(ui->verticalLayout_Network->itemAt(ui->verticalLayout_Network->count() - 1))->widget();
 
     blockreconstructionextratxn = new QSpinBox(ui->tabNetwork);
@@ -552,9 +564,6 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
     dustdynamic_multiplier->setMaximum(65);
     dustdynamic_multiplier->setValue(DEFAULT_DUST_RELAY_MULTIPLIER / 1000.0);
     CreateOptionUI(verticalLayout_Spamfiltering, tr("%1 Automatically adjust the dust limit upward to %2 times:"), {dustdynamic_enable, dustdynamic_multiplier});
-
-    QStyleOptionButton styleoptbtn;
-    const auto checkbox_indent = dustdynamic_enable->style()->subElementRect(QStyle::SE_CheckBoxIndicator, &styleoptbtn, dustdynamic_enable).width();
 
     dustdynamic_target = new QRadioButton(groupBox_Spamfiltering);
     dustdynamic_target_blocks = new QSpinBox(groupBox_Spamfiltering);

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -123,6 +123,7 @@ private:
 
     QCheckBox *walletrbf;
 
+    QCheckBox *upnp;
     QSpinBox *blockreconstructionextratxn;
     QDoubleSpinBox *blockreconstructionextratxnsize;
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -851,13 +851,17 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
     case MapPortUPnP: // core option - can be changed on-the-fly
         if (changed()) {
             update(value.toBool());
-            node().mapPort(value.toBool(), getOption(MapPortNatpmp).toBool());
+            if (gArgs.GetBoolArg("-listen", DEFAULT_LISTEN)) {
+                node().mapPort(value.toBool(), getOption(MapPortNatpmp).toBool());
+            }
         }
         break;
     case MapPortNatpmp: // core option - can be changed on-the-fly
         if (changed()) {
             update(value.toBool());
-            node().mapPort(getOption(MapPortUPnP).toBool(), value.toBool());
+            if (gArgs.GetBoolArg("-listen", DEFAULT_LISTEN)) {
+                node().mapPort(getOption(MapPortUPnP).toBool(), value.toBool());
+            }
         }
         break;
     case MinimizeOnClose:


### PR DESCRIPTION
Also includes a behaviour change: if listening is disabled, port mapping is forced off too.

<img width="931" height="672" alt="portmap_move" src="https://github.com/user-attachments/assets/e2b83456-bd95-4bb3-991b-782bf0f6e328" />
