### PR TITLE
Only enable the extra tx cache after the first gbt call

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1773,6 +1773,8 @@ void PeerManagerImpl::LimitOrphanTxSize(uint32_t nMaxOrphans)
 
 void PeerManagerImpl::AddToCompactExtraTransactions(const CTransactionRef& tx, const size_t tx_dynamic_usage)
 {
+    if (!m_chainman.node_is_mining)
+        return;
     if (m_opts.max_extra_txs <= 0)
         return;
     if (!vExtraTxnForCompact.size())

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -926,6 +926,8 @@ static RPCHelpMan getblocktemplate()
     }
     CHECK_NONFATAL(pindexPrev);
 
+    chainman.node_is_mining = true;
+
     return TemplateToJSON(consensusParams, chainman, &*block_template, pindexPrev, setClientRules, nTransactionsUpdatedLast);
 },
     };

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -24,6 +24,7 @@
 #include <rpc/server.h>
 #include <rpc/server_util.h>
 #include <rpc/util.h>
+#include <validation.h>
 #include <scheduler.h>
 #include <univalue.h>
 #include <util/any.h>
@@ -192,6 +193,33 @@ static RPCHelpMan getmemoryinfo()
     } else {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown mode " + mode);
     }
+},
+    };
+}
+
+static RPCHelpMan getextratxinfo()
+{
+    return RPCHelpMan{"getextratxinfo",
+                "Returns data about the extra tx cache.\n",
+                {},
+                RPCResult{
+                    RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::BOOL, "cache_enabled", "Is the extra tx cache enabled"},
+                    }
+                },
+                RPCExamples{
+                    HelpExampleCli("getextratxinfo", "")
+            + HelpExampleRpc("getextratxinfo", "")
+                },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+        NodeContext& node = EnsureAnyNodeContext(request.context);
+        ChainstateManager& chainman = EnsureChainman(node);
+
+        UniValue obj(UniValue::VOBJ);
+        obj.pushKV("cache_enabled", chainman.node_is_mining.load());
+        return obj;
 },
     };
 }
@@ -470,6 +498,7 @@ void RegisterNodeRPCCommands(CRPCTable& t)
         {"control", &getmemoryinfo},
         {"control", &getgeneralinfo},
         {"control", &logging},
+        {"util", &getextratxinfo},
         {"util", &getindexinfo},
         {"hidden", &setmocktime},
         {"hidden", &mockscheduler},

--- a/src/validation.h
+++ b/src/validation.h
@@ -1048,6 +1048,8 @@ public:
     int32_t nBlockReverseSequenceId = -1;
     /** chainwork for the last block that preciousblock has been applied to. */
     arith_uint256 nLastPreciousChainwork = 0;
+    
+    std::atomic<bool> node_is_mining{false};
 
     // Reset the memory-only sequence counters we use to track block arrival
     // (used by tests to reset state)

--- a/test/functional/p2p_compactblocks_extratxs.py
+++ b/test/functional/p2p_compactblocks_extratxs.py
@@ -128,6 +128,9 @@ class CompactBlocksBlockReconstructionLimitTest(BitcoinTestFramework):
         self.segwit_node = self.nodes[0].add_p2p_connection(TestP2PConn())
         self.segwit_node.send_and_ping(msg_sendcmpct(announce=True, version=2))
 
+        # Ensure extra txn pool is enable by calling gbt
+        create_block(tmpl=self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS))
+
     def create_policy_rejected_tx(self, rejection_type="dust", target_size=None):
         """Create a transaction that will be rejected for policy reasons but added to extra pool."""
 


### PR DESCRIPTION
To do:

- [ ] Be able to enable/disable the extra tx cache via RPC
- [x] Fix tests