### PR TITLE
Bugfix: Wallet: Migration: Adapt sanity checks for walletimplicitsegwit=0

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1840,6 +1840,26 @@ std::optional<MigrationData> LegacyDataSPKM::MigrateToDescriptor()
         return std::nullopt;
     }
 
+    constexpr auto sanitycheck = [](const bool erased, const bool maybe_compressed_key, const CScript &spk, const LegacyDataSPKM& self, const DescriptorScriptPubKeyMan& desc_spk_man) {
+        assert(desc_spk_man.IsMine(spk) == ISMINE_SPENDABLE);
+        if (erased) {
+            assert(self.IsMine(spk) == ISMINE_SPENDABLE);
+            return;
+        }
+        if (maybe_compressed_key && !g_implicit_segwit) {
+            // combo() includes segwit
+            if (spk.IsPayToScriptHash()) return;
+            int witness_version;
+            std::vector<unsigned char> witness_program;
+            if (spk.IsWitnessProgram(witness_version, witness_program)) {
+                if (witness_version == 0 && witness_program.size() == 20) {
+                    return;
+                }
+            }
+        }
+        assert(erased);
+    };
+
     // keyids is now all non-HD keys. Each key will have its own combo descriptor
     for (const CKeyID& keyid : keyids) {
         CKey key;
@@ -1877,8 +1897,7 @@ std::optional<MigrationData> LegacyDataSPKM::MigrateToDescriptor()
         // Remove the scriptPubKeys from our current set
         for (const CScript& spk : desc_spks) {
             size_t erased = spks.erase(spk);
-            assert(erased == 1);
-            assert(IsMine(spk) == ISMINE_SPENDABLE);
+            sanitycheck(erased, key.IsCompressed(), spk, *this, *desc_spk_man);
         }
 
         out.desc_spkms.push_back(std::move(desc_spk_man));
@@ -1923,8 +1942,7 @@ std::optional<MigrationData> LegacyDataSPKM::MigrateToDescriptor()
             // Remove the scriptPubKeys from our current set
             for (const CScript& spk : desc_spks) {
                 size_t erased = spks.erase(spk);
-                assert(erased == 1);
-                assert(IsMine(spk) == ISMINE_SPENDABLE);
+                sanitycheck(erased, /*maybe_compressed_key=*/true, spk, *this, *desc_spk_man);
             }
 
             out.desc_spkms.push_back(std::move(desc_spk_man));


### PR DESCRIPTION
Legacy wallets required segwit addresses to be explicitly defined (with walletimplicitsegwit=0, Knots default). This was originally so a third party couldn't take your non-segwit address and transform it into a segwit one to send you bitcoins. That was never a real-world issue.

To properly support that with descriptor wallets would require that we don't use `combo()` in migration, which is probably more trouble than it's worth.

Instead, just let legacy wallets gain implicit segwit support if migrated.