### PR TITLE
test: Verify debug log message in feature_block.py bad-version test

### DIFF
--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -25,6 +25,7 @@ from test_framework.messages import (
     SEQUENCE_FINAL,
     uint256_from_compact,
     uint256_from_str,
+    msg_block,
 )
 from test_framework.p2p import P2PDataStore
 from test_framework.script import (
@@ -1308,8 +1309,18 @@ class FullBlockTest(BitcoinTestFramework):
         self.send_blocks([block], True, timeout=2440)
 
         self.log.info("Reject a block with an invalid block header version")
+        tip = self.tip.sha256
         b_v1 = self.next_block('b_v1', version=1)
-        self.send_blocks([b_v1], success=False, force_send=True, reject_reason='bad-version(0x00000001)', reconnect=True)
+
+        with self.nodes[0].assert_debug_log(expected_msgs=[f'{b_v1.hash}, bad-version(0x00000001)']):
+            self.helper_peer.send_message(msg_block(b_v1))
+            # Wait for the peer to be disconnected after sending the invalid block
+            self.helper_peer.wait_for_disconnect()
+
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), tip)
+
+        # Reconnect after peer disconnection due to invalid block
+        self.reconnect_p2p()
 
         self.move_tip(chain1_tip + 2)
         b_cb34 = self.next_block('b_cb34')


### PR DESCRIPTION
Improve the invalid block version rejection test to verify the debug log contains the expected 'bad-version' rejection message, matching the pattern used in feature_dersig.py and feature_cltv.py.

Changes:
- Add msg_block import for direct P2P message sending
- Replace send_blocks() helper with assert_debug_log() context manager
- Send invalid block via send_message() and wait for peer disconnection
- Explicitly verify chain tip hasn't advanced after rejection
- Add reconnect_p2p() call after peer disconnection

This ensures the test verifies both P2P-level rejection and the internal logging behavior from ContextualCheckBlockHeader() in validation.cpp.

