### PR TITLE
p2p: Disable `feefilter` by default to improve compact block relay

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -66,7 +66,7 @@ class SignalInterrupt;
 } // namespace util
 
 /** Default for using fee filter */
-static const bool DEFAULT_FEEFILTER = true;
+static const bool DEFAULT_FEEFILTER = false;
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of ActiveChain().Tip() will not be pruned. */
 static const unsigned int MIN_BLOCKS_TO_KEEP = 288;
 static const signed int DEFAULT_CHECKBLOCKS = 6;


### PR DESCRIPTION
Rationale: https://uncensoredtech.substack.com/p/compact-block-relay-with-extra-pool

```
2025-10-14T21:18:40Z Saw new cmpctblock header hash=00000000000000000000ac62d97784e191f45414b7614c18128924e869fc2b7a peer=67
2025-10-14T21:18:40Z [cmpctblock] Initialized PartiallyDownloadedBlock for block 00000000000000000000ac62d97784e191f45414b7614c18128924e869fc2b7a using a cmpctblock of size 26595
2025-10-14T21:18:41Z [cmpctblock] Successfully reconstructed block 00000000000000000000ac62d97784e191f45414b7614c18128924e869fc2b7a with 1 txn prefilled, 4334 txn from mempool (incl at least 2167 from extra pool) and 20 txn requested
2025-10-14T21:18:41Z UpdateTip: new best=00000000000000000000ac62d97784e191f45414b7614c18128924e869fc2b7a height=919095 version=0x252e2000 log2_work=95.879675 tx=1256453270 date='2025-10-14T21:18:35Z' progress=1.000000 cache=12.3MiB(71076txo) warning='Miner violated version bit protocol'
```