### PR TITLE
mempressure: Fix Linux memory detection and reduce memory check overhead

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -81,7 +81,7 @@
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
-#include <util/mempressure.h>
+#include <util/systemmemory.h>
 #include <util/moneystr.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
@@ -403,6 +403,7 @@ void Shutdown(NodeContext& node)
     node.chainman.reset();
     node.validation_signals.reset();
     node.scheduler.reset();
+    g_memory_profiler.reset();
     node.ecc_context.reset();
     node.kernel.reset();
 
@@ -1453,7 +1454,11 @@ static ChainstateLoadResult InitAndLoadChainstate(
     }
     LogPrintf("* Using %.1f MiB for in-memory UTXO set (plus up to %.1f MiB of unused mempool space)\n", cache_sizes.coins * (1.0 / 1024 / 1024), mempool_opts.max_size_bytes * (1.0 / 1024 / 1024));
 
-    if (gArgs.IsArgSet("-lowmem")) {
+    // Initialize memory pressure threshold
+    if (!gArgs.IsArgSet("-lowmem")) {
+        size_t batch_size_bytes = gArgs.GetIntArg("-dbbatchsize", nDefaultDbBatchSize);
+        InitializeMemoryThreshold(batch_size_bytes);
+    } else {
         g_low_memory_threshold = gArgs.GetIntArg("-lowmem", 0 /* not used */) * 1024 * 1024;
     }
     if (g_low_memory_threshold > 0) {
@@ -1605,11 +1610,21 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
     }, std::chrono::minutes{5});
 
-    // Check system memory pressure every 10 seconds.
-    // Updates g_system_needs_memory_released flag used by FlushStateToDisk.
-    scheduler.scheduleEvery([]{
+    // Initialize memory profiler for tracking flush overhead
+    assert(!g_memory_profiler);
+    g_memory_profiler = std::make_unique<MemoryProfiler>();
+
+    // Check system memory pressure every 5 seconds.
+    // If pressure detected, directly force flush to avoid OOM.
+    scheduler.scheduleEvery([&node]{
         CheckMemoryPressure();
-    }, std::chrono::seconds{10});
+        if (!node.chainman) return;  // Safety check during startup/shutdown
+        if (SystemNeedsMemoryReleased()) {
+            LogDebug(BCLog::MEMPRESSURE, "Memory pressure detected by scheduler - forcing immediate flush\n");
+            ResetMemoryPressure();
+            node.chainman->ActiveChainstate().ForceFlushStateToDisk();
+        }
+    }, std::chrono::seconds{5});
 
     if (args.GetBoolArg("-logratelimit", BCLog::DEFAULT_LOGRATELIMIT)) {
         LogInstance().SetRateLimiting(BCLog::LogRateLimiter::Create(

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1605,6 +1605,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
     }, std::chrono::minutes{5});
 
+    // Check system memory pressure every 10 seconds.
+    // Updates g_system_needs_memory_released flag used by FlushStateToDisk.
+    scheduler.scheduleEvery([]{
+        CheckMemoryPressure();
+    }, std::chrono::seconds{10});
+
     if (args.GetBoolArg("-logratelimit", BCLog::DEFAULT_LOGRATELIMIT)) {
         LogInstance().SetRateLimiting(BCLog::LogRateLimiter::Create(
             [&scheduler](auto func, auto window) { scheduler.scheduleEvery(std::move(func), window); },

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -201,6 +201,7 @@ static const std::map<std::string, BCLog::LogFlags, std::less<>> LOG_CATEGORIES_
     {"txreconciliation", BCLog::TXRECONCILIATION},
     {"scan", BCLog::SCAN},
     {"txpackages", BCLog::TXPACKAGES},
+    {"mempressure", BCLog::MEMPRESSURE},
 };
 
 static const std::unordered_map<BCLog::LogFlags, std::string> LOG_CATEGORIES_BY_FLAG{

--- a/src/logging.h
+++ b/src/logging.h
@@ -94,6 +94,7 @@ namespace BCLog {
         TXRECONCILIATION = (CategoryMask{1} << 26),
         SCAN        = (CategoryMask{1} << 27),
         TXPACKAGES  = (CategoryMask{1} << 28),
+        MEMPRESSURE = (CategoryMask{1} << 29),
         ALL         = ~NONE,
     };
     enum class Level {

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -14,7 +14,7 @@
 #include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/check.h>
-#include <util/mempressure.h>
+#include <util/systemmemory.h>
 #include <validation.h>
 
 #include <vector>

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -46,4 +46,5 @@ target_link_libraries(bitcoin_util
     bitcoin_crypto
     $<$<PLATFORM_ID:Windows>:ws2_32>
     $<$<PLATFORM_ID:Windows>:iphlpapi>
+    $<$<PLATFORM_ID:Windows>:psapi>
 )

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -15,7 +15,8 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   fs_helpers.cpp
   hasher.cpp
   ioprio.cpp
-  mempressure.cpp
+  systemmemory.cpp
+  memory_profiler.cpp
   moneystr.cpp
   rbf.cpp
   readwritefile.cpp

--- a/src/util/memory_profiler.cpp
+++ b/src/util/memory_profiler.cpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2025 The Bitcoin Knots developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bitcoin-build-config.h> // IWYU pragma: keep
+
+#include <util/memory_profiler.h>
+
+#include <algorithm>
+
+#ifdef WIN32
+#include <windows.h>
+#include <psapi.h>
+#elif defined(__linux__)
+#include <fstream>
+#include <sstream>
+#include <string>
+#elif defined(__APPLE__)
+#include <sys/resource.h>
+#include <mach/mach.h>
+#endif
+
+std::unique_ptr<MemoryProfiler> g_memory_profiler;
+
+MemoryProfiler::MemoryProfiler()
+{
+    m_profiler_thread = std::make_unique<std::thread>(&MemoryProfiler::ProfilerThread, this);
+}
+
+MemoryProfiler::~MemoryProfiler()
+{
+    m_shutdown = true;
+    {
+        std::lock_guard<std::mutex> cv_lock(m_cv_mutex);
+        m_cv.notify_all();
+    }
+    if (m_profiler_thread && m_profiler_thread->joinable()) {
+        m_profiler_thread->join();
+    }
+}
+
+size_t MemoryProfiler::GetProcessRSS()
+{
+#ifdef WIN32
+    PROCESS_MEMORY_COUNTERS_EX pmc;
+    if (GetProcessMemoryInfo(GetCurrentProcess(), (PROCESS_MEMORY_COUNTERS*)&pmc, sizeof(pmc))) {
+        return static_cast<size_t>(pmc.PrivateUsage);  // Current commit charge
+    }
+#elif defined(__linux__)
+    std::ifstream status("/proc/self/status");
+    std::string line;
+    while (std::getline(status, line)) {
+        if (line.compare(0, 8, "RssAnon:") == 0) {
+            size_t pos = line.find_first_of("0123456789");
+            if (pos != std::string::npos) {
+                size_t kb = std::stoull(line.substr(pos));
+                return kb * 1024;
+            }
+        }
+    }
+#elif defined(__APPLE__)
+    struct mach_task_basic_info info;
+    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info, &count) == KERN_SUCCESS) {
+        return static_cast<size_t>(info.resident_size);
+    }
+#endif
+    return 0;
+}
+
+void MemoryProfiler::StartFlushProfiling()
+{
+    // Check if already profiling and stop previous profile if needed
+    if (m_profiling.load()) {
+        StopFlushProfiling();
+    }
+
+    LOCK(m_mutex);
+
+    m_current_profile = std::make_unique<FlushProfile>();
+    m_current_profile->start_time = std::chrono::steady_clock::now();
+
+    // Capture initial memory state (lock already held)
+    auto initial_sample = CaptureMemorySampleLocked("pre_flush", true);
+    m_current_profile->pre_flush_memory_mb = initial_sample.process_rss_mb;
+    m_current_profile->peak_memory_mb = initial_sample.process_rss_mb;
+    m_current_profile->samples.push_back(initial_sample);
+
+    m_profiling = true;
+
+    // Notify profiler thread
+    {
+        std::lock_guard<std::mutex> cv_lock(m_cv_mutex);
+        m_cv.notify_one();
+    }
+}
+
+std::unique_ptr<MemoryProfiler::FlushProfile> MemoryProfiler::StopFlushProfiling()
+{
+    LOCK(m_mutex);
+
+    if (!m_current_profile) {
+        return nullptr;
+    }
+
+    m_profiling = false;
+
+    // Capture final memory state
+    auto final_sample = CaptureMemorySampleLocked("post_flush", true);
+    m_current_profile->samples.push_back(final_sample);
+    m_current_profile->post_flush_memory_mb = final_sample.process_rss_mb;
+    m_current_profile->end_time = std::chrono::steady_clock::now();
+
+    // Calculate peak from all samples
+    for (const auto& sample : m_current_profile->samples) {
+        m_current_profile->peak_memory_mb = std::max(m_current_profile->peak_memory_mb, sample.process_rss_mb);
+    }
+
+    // Store in history
+    m_flush_history.push_back(*m_current_profile);
+    if (m_flush_history.size() > MAX_HISTORY_SIZE) {
+        m_flush_history.pop_front();
+    }
+
+    return std::move(m_current_profile);
+}
+
+std::vector<MemoryProfiler::FlushProfile> MemoryProfiler::GetRecentProfiles(size_t count) const
+{
+    LOCK(m_mutex);
+
+    std::vector<FlushProfile> result;
+    size_t start_idx = m_flush_history.size() > count ? m_flush_history.size() - count : 0;
+
+    for (size_t i = start_idx; i < m_flush_history.size(); ++i) {
+        result.push_back(m_flush_history[i]);
+    }
+
+    return result;
+}
+
+void MemoryProfiler::ProfilerThread()
+{
+    while (!m_shutdown) {
+        std::unique_lock<std::mutex> cv_lock(m_cv_mutex);
+
+        m_cv.wait_for(cv_lock, std::chrono::milliseconds(100), [this] {
+            return m_profiling.load() || m_shutdown.load();
+        });
+
+        cv_lock.unlock();
+
+        if (m_shutdown) break;
+
+        if (m_profiling) {
+            LOCK(m_mutex);
+            if (m_current_profile) {
+                auto profile_copy = *m_current_profile;
+                LEAVE_CRITICAL_SECTION(m_mutex);
+
+                auto sample = CaptureMemorySample("profiling");
+
+                ENTER_CRITICAL_SECTION(m_mutex);
+                if (m_current_profile && m_profiling) {
+                    m_current_profile->samples.push_back(sample);
+                    m_current_profile->peak_memory_mb = std::max(m_current_profile->peak_memory_mb, sample.process_rss_mb);
+                }
+            }
+        }
+    }
+}
+
+MemoryProfiler::MemorySample MemoryProfiler::CaptureMemorySample(const std::string& phase) const
+{
+    return CaptureMemorySampleLocked(phase, false);
+}
+
+MemoryProfiler::MemorySample MemoryProfiler::CaptureMemorySampleLocked(const std::string& phase, bool lock_already_held) const
+{
+    MemorySample sample;
+    sample.timestamp = std::chrono::steady_clock::now();
+    sample.phase = phase;
+
+    size_t rss_bytes = GetProcessRSS();
+    sample.process_rss_mb = rss_bytes > 0 ? rss_bytes / (1 << 20) : 0;
+
+    return sample;
+}

--- a/src/util/memory_profiler.h
+++ b/src/util/memory_profiler.h
@@ -1,0 +1,90 @@
+// Copyright (c) 2025 The Bitcoin Knots developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_MEMORY_PROFILER_H
+#define BITCOIN_UTIL_MEMORY_PROFILER_H
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <sync.h>
+#include <util/time.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+/**
+ * Memory profiler for tracking memory usage during database operations
+ * Particularly focused on understanding memory overhead during LevelDB flushes
+ */
+class MemoryProfiler
+{
+public:
+    struct MemorySample {
+        std::chrono::steady_clock::time_point timestamp;
+        size_t process_rss_mb;          // Process resident set size
+        std::string phase;              // Current operation phase
+    };
+
+    struct FlushProfile {
+        std::chrono::steady_clock::time_point start_time;
+        std::chrono::steady_clock::time_point end_time;
+        size_t pre_flush_memory_mb;
+        size_t peak_memory_mb;
+        size_t post_flush_memory_mb;
+        std::vector<MemorySample> samples;
+
+        int64_t GetDurationMs() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
+        }
+    };
+
+    MemoryProfiler();
+    ~MemoryProfiler();
+
+    // Start profiling a flush operation
+    void StartFlushProfiling() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    // Stop profiling and return the profile
+    std::unique_ptr<FlushProfile> StopFlushProfiling() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    // Get historical flush profiles
+    std::vector<FlushProfile> GetRecentProfiles(size_t count = 10) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+private:
+    void ProfilerThread() NO_THREAD_SAFETY_ANALYSIS;
+    MemorySample CaptureMemorySample(const std::string& phase) const NO_THREAD_SAFETY_ANALYSIS;
+    MemorySample CaptureMemorySampleLocked(const std::string& phase, bool lock_already_held) const NO_THREAD_SAFETY_ANALYSIS;
+
+    // Platform-specific memory tracking functions
+    static size_t GetProcessRSS();
+
+    mutable Mutex m_mutex;
+
+    // Current profiling state
+    std::atomic<bool> m_profiling{false};
+    std::unique_ptr<FlushProfile> m_current_profile GUARDED_BY(m_mutex);
+
+    // Historical data
+    std::deque<FlushProfile> m_flush_history GUARDED_BY(m_mutex);
+    static constexpr size_t MAX_HISTORY_SIZE = 100;
+
+    // Profiler thread
+    std::unique_ptr<std::thread> m_profiler_thread;
+    std::atomic<bool> m_shutdown{false};
+    mutable std::mutex m_cv_mutex;
+    mutable std::condition_variable m_cv;
+};
+
+// Global instance (initialized in init.cpp if profiling is enabled)
+extern std::unique_ptr<MemoryProfiler> g_memory_profiler;
+
+#endif // BITCOIN_UTIL_MEMORY_PROFILER_H

--- a/src/util/mempressure.cpp
+++ b/src/util/mempressure.cpp
@@ -9,48 +9,454 @@
 #include <logging.h>
 #include <util/byte_units.h>
 
-#ifdef HAVE_LINUX_SYSINFO
-#include <sys/sysinfo.h>
-#endif
 #ifdef WIN32
 #include <windows.h>
+#include <psapi.h>
 #endif
 
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#include <mach/mach.h>
+#include <mach/mach_host.h>
+#endif
+
+#include <algorithm>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
+#include <fstream>
+#include <string>
 
 size_t g_low_memory_threshold{64_MiB};
+std::atomic<bool> g_system_needs_memory_released{false};
+
+// File-local state variables
+static std::atomic<bool> checks_paused{false};
+
+// Container detection state
+enum class ContainerState {
+    UNKNOWN,
+    SYSTEM,
+    CONTAINERIZED
+};
+static std::atomic<ContainerState> container_state{ContainerState::UNKNOWN};
+
+namespace {
+#ifdef WIN32
+    MemoryPressureInfo GetWindowsMemoryInfo();
+#elif defined(__linux__)
+    MemoryPressureInfo GetLinuxMemoryInfo();
+#elif defined(__APPLE__)
+    MemoryPressureInfo GetMacOSMemoryInfo();
+#endif
+}
+
+void CheckMemoryPressure()
+{
+    if (checks_paused.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    if (g_low_memory_threshold <= 0) {
+        g_system_needs_memory_released.store(false, std::memory_order_relaxed);
+        return;
+    }
+
+#ifdef WIN32
+    MemoryPressureInfo info = GetWindowsMemoryInfo();
+#elif defined(__linux__)
+    MemoryPressureInfo info = GetLinuxMemoryInfo();
+#elif defined(__APPLE__)
+    MemoryPressureInfo info = GetMacOSMemoryInfo();
+#else
+    // Unsupported platform - disable pressure detection
+    g_system_needs_memory_released.store(false, std::memory_order_relaxed);
+    return;
+#endif
+
+    LogDebug(BCLog::MEMPRESSURE, "%sMemAvailable=%.2f MB, MemUsed=%.2f MB, threshold=%.2f MB, trigger=%s\n",
+             info.is_containerized ? "Container " : "",
+             info.mem_available / (1024.0 * 1024.0),
+             info.mem_used / (1024.0 * 1024.0),
+             g_low_memory_threshold / (1024.0 * 1024.0),
+             info.under_pressure ? "YES" : "NO");
+
+    if (info.under_pressure) {
+        LogPrintf("Mempressure detected - available: %.2f MB, threshold: %.2f MB\n",
+                  info.mem_available / (1024.0 * 1024.0),
+                  g_low_memory_threshold / (1024.0 * 1024.0));
+    }
+
+    g_system_needs_memory_released.store(info.under_pressure, std::memory_order_relaxed);
+}
 
 bool SystemNeedsMemoryReleased()
 {
     if (g_low_memory_threshold <= 0) {
-        // Intentionally bypass other metrics when disabled entirely
         return false;
     }
-#ifdef WIN32
-    MEMORYSTATUSEX mem_status;
-    mem_status.dwLength = sizeof(mem_status);
-    if (GlobalMemoryStatusEx(&mem_status)) {
-        if (mem_status.dwMemoryLoad >= 99 ||
-            mem_status.ullAvailPhys < g_low_memory_threshold ||
-            mem_status.ullAvailVirtual < g_low_memory_threshold) {
-            LogPrintf("%s: YES: %s%% memory load; %s available physical memory; %s available virtual memory\n", __func__, int(mem_status.dwMemoryLoad), size_t(mem_status.ullAvailPhys), size_t(mem_status.ullAvailVirtual));
-            return true;
-        }
-    }
-#endif
-#ifdef HAVE_LINUX_SYSINFO
-    struct sysinfo sys_info;
-    if (!sysinfo(&sys_info)) {
-        // Explicitly 64-bit in case of 32-bit userspace on 64-bit kernel
-        const uint64_t free_ram = uint64_t(sys_info.freeram) * sys_info.mem_unit;
-        const uint64_t buffer_ram = uint64_t(sys_info.bufferram) * sys_info.mem_unit;
-        if (free_ram + buffer_ram < g_low_memory_threshold) {
-            LogPrintf("%s: YES: %s free RAM + %s buffer RAM\n", __func__, free_ram, buffer_ram);
-            return true;
-        }
-    }
-#endif
-    // NOTE: sysconf(_SC_AVPHYS_PAGES) doesn't account for caches on at least Linux, so not safe to use here
-    return false;
+
+    return g_system_needs_memory_released.load(std::memory_order_relaxed);
 }
+
+void PauseMemoryPressureChecks()
+{
+    checks_paused.store(true, std::memory_order_relaxed);
+}
+
+void ResumeMemoryPressureChecks()
+{
+    checks_paused.store(false, std::memory_order_relaxed);
+    g_system_needs_memory_released.store(false, std::memory_order_relaxed);
+}
+
+#ifdef WIN32
+namespace {
+    // Check Windows container memory status (Job Object)
+    // Docker, etc on Windows use Job Objects to enforce memory limits.
+    MemoryPressureInfo GetWindowsContainerMemoryInfo()
+    {
+        MemoryPressureInfo info;
+
+        // Query information about the job object the current process belongs to
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_info = {};
+        if (!QueryInformationJobObject(nullptr, JobObjectExtendedLimitInformation,
+                                       &job_info, sizeof(job_info), nullptr)) {
+            return info;
+        }
+
+        if (!(job_info.BasicLimitInformation.LimitFlags & JOB_OBJECT_LIMIT_JOB_MEMORY)) {
+            return info;
+        }
+
+        info.is_containerized = true;
+        size_t container_limit = static_cast<size_t>(job_info.JobMemoryLimit);
+
+        PROCESS_MEMORY_COUNTERS_EX pmc;
+        if (!GetProcessMemoryInfo(GetCurrentProcess(), (PROCESS_MEMORY_COUNTERS*)&pmc, sizeof(pmc))) {
+            return info;
+        }
+
+        info.mem_used = pmc.PrivateUsage;
+        info.mem_available = (info.mem_used < container_limit)
+                           ? (container_limit - info.mem_used)
+                           : 0;
+
+        // Windows container pressure: check threshold
+        if (info.mem_available < g_low_memory_threshold) {
+            info.under_pressure = true;
+        }
+
+        return info;
+    }
+
+    // Check system (non-container) Windows memory status
+    MemoryPressureInfo GetWindowsSystemMemoryInfo()
+    {
+        MemoryPressureInfo info;
+
+        MEMORYSTATUSEX mem_status;
+        mem_status.dwLength = sizeof(mem_status);
+        if (!GlobalMemoryStatusEx(&mem_status)) {
+            return info;
+        }
+
+        // Use the lesser of available physical or virtual memory
+        info.mem_available = std::min(static_cast<size_t>(mem_status.ullAvailPhys),
+                                      static_cast<size_t>(mem_status.ullAvailVirtual));
+        info.mem_used = static_cast<size_t>(mem_status.ullTotalPhys) - static_cast<size_t>(mem_status.ullAvailPhys);
+
+        // Windows low memory detection: high memory usage (99%+) AND below threshold
+        // This will be supplemented with Pages/sec pressure detection in the future
+        if (mem_status.dwMemoryLoad >= 99 && info.mem_available < g_low_memory_threshold) {
+            info.under_pressure = true;
+        }
+
+        return info;
+    }
+
+    MemoryPressureInfo GetWindowsMemoryInfo()
+    {
+        ContainerState state = container_state.load(std::memory_order_relaxed);
+        if (state == ContainerState::UNKNOWN || state == ContainerState::CONTAINERIZED) {
+            MemoryPressureInfo info = GetWindowsContainerMemoryInfo();
+            if (info.is_containerized) {
+                container_state.store(ContainerState::CONTAINERIZED, std::memory_order_relaxed);
+                return info;
+            }
+        }
+        if (state == ContainerState::UNKNOWN) {
+            container_state.store(ContainerState::SYSTEM, std::memory_order_relaxed);
+        }
+
+        return GetWindowsSystemMemoryInfo();
+    }
+}
+#endif
+
+#ifdef __linux__
+namespace {
+    // Helper function to parse memory statistics with error handling
+    std::optional<uint64_t> ParseMemoryStat(const std::string& value_str, const char* stat_name)
+    {
+        try {
+            return std::stoull(value_str);
+        } catch (const std::exception& e) {
+            return std::nullopt;
+        }
+    }
+
+    MemoryPressureInfo GetCgroupV2MemoryInfo()
+    {
+        MemoryPressureInfo info;
+
+        std::ifstream v2_check("/sys/fs/cgroup/memory.max");
+        std::string limit_str;
+        if (!v2_check.is_open() || !std::getline(v2_check, limit_str)) {
+            return info;
+        }
+
+        size_t container_limit = 0;
+        if (limit_str != "max") {
+            auto limit = ParseMemoryStat(limit_str, "memory.max");
+            if (!limit) return info;
+            if (*limit < UINT64_MAX / 2) { // sanity check
+                container_limit = static_cast<size_t>(*limit);
+            }
+        }
+
+        if (container_limit == 0) {
+            return info;
+        }
+
+        size_t inactive_file = 0;
+        std::ifstream stat_file("/sys/fs/cgroup/memory.stat");
+        if (!stat_file.is_open()) {
+            return info;
+        }
+
+        std::string stat_line;
+        while (std::getline(stat_file, stat_line)) {
+            if (stat_line.compare(0, 14, "inactive_file ") == 0) {
+                auto value = ParseMemoryStat(stat_line.substr(14), "inactive_file");
+                if (!value) return info;
+                inactive_file = *value;
+                break;
+            }
+        }
+
+        size_t total = 0;
+        std::ifstream current_file("/sys/fs/cgroup/memory.current");
+        std::string current_str;
+        if (!current_file.is_open() || !std::getline(current_file, current_str)) {
+            return info;
+        }
+
+        auto value = ParseMemoryStat(current_str, "memory.current");
+        if (!value) return info;
+        total = *value;
+
+        info.is_containerized = true;
+        info.mem_used = (total > inactive_file) ? (total - inactive_file) : 0;
+        info.mem_available = (info.mem_used < container_limit) ? (container_limit - info.mem_used) : 0;
+
+        // Linux pressure detection: low available memory threshold
+        if (info.mem_available < g_low_memory_threshold) {
+            info.under_pressure = true;
+        }
+
+        return info;
+    }
+
+    MemoryPressureInfo GetCgroupV1MemoryInfo()
+    {
+        MemoryPressureInfo info;
+
+        std::ifstream limit_file("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+        std::string limit_str;
+        if (!limit_file.is_open() || !std::getline(limit_file, limit_str)) {
+            return info;
+        }
+
+        size_t limit = 0, usage = 0, cache = 0;
+
+        auto limit_val = ParseMemoryStat(limit_str, "memory.limit_in_bytes");
+        if (!limit_val) return info;
+        limit = *limit_val;
+        if (limit >= UINT64_MAX / 2) {
+            return info;
+        }
+
+        std::ifstream usage_file("/sys/fs/cgroup/memory/memory.usage_in_bytes");
+        std::string usage_str;
+        if (!usage_file.is_open() || !std::getline(usage_file, usage_str)) {
+            return info;
+        }
+
+        auto usage_val = ParseMemoryStat(usage_str, "memory.usage_in_bytes");
+        if (!usage_val) return info;
+        usage = *usage_val;
+
+        std::ifstream stat_file("/sys/fs/cgroup/memory/memory.stat");
+        if (!stat_file.is_open()) {
+            return info;
+        }
+
+        std::string line;
+        while (std::getline(stat_file, line)) {
+            if (line.compare(0, 6, "cache ") == 0) {
+                auto cache_val = ParseMemoryStat(line.substr(6), "cache");
+                if (cache_val) cache = *cache_val;
+                break;
+            }
+        }
+
+        info.is_containerized = true;
+        info.mem_used = usage - cache;
+        info.mem_available = (info.mem_used < limit) ? (limit - info.mem_used) : 0;
+
+        // Linux pressure detection: low available memory threshold
+        if (info.mem_available < g_low_memory_threshold) {
+            info.under_pressure = true;
+        }
+
+        return info;
+    }
+
+    // Check system (non-container) Linux memory status
+    MemoryPressureInfo GetLinuxSystemMemoryInfo()
+    {
+        MemoryPressureInfo info;
+
+        std::ifstream meminfo("/proc/meminfo");
+        if (!meminfo.is_open()) {
+            return info;
+        }
+
+        std::string line;
+        uint64_t mem_total_kb = 0;
+        uint64_t mem_available_kb = 0;
+
+        while (std::getline(meminfo, line)) {
+            if (line.compare(0, 9, "MemTotal:") == 0) {
+                size_t pos = line.find_first_of("0123456789");
+                if (pos != std::string::npos) {
+                    auto value = ParseMemoryStat(line.substr(pos), "MemTotal");
+                    if (value) mem_total_kb = *value;
+                }
+            } else if (line.compare(0, 13, "MemAvailable:") == 0) {
+                size_t pos = line.find_first_of("0123456789");
+                if (pos != std::string::npos) {
+                    auto value = ParseMemoryStat(line.substr(pos), "MemAvailable");
+                    if (value) mem_available_kb = *value;
+                }
+            }
+
+            if (mem_total_kb > 0 && mem_available_kb > 0) {
+                break;
+            }
+        }
+
+        if (mem_total_kb > 0 && mem_available_kb > 0) {
+            // Check for overflow before multiplication
+            if (mem_available_kb > UINT64_MAX / 1024 || mem_total_kb > UINT64_MAX / 1024) {
+                // huge value is "plenty of memory"
+                return info;
+            }
+
+            info.mem_available = mem_available_kb * 1024;
+            size_t total_memory = mem_total_kb * 1024;
+            info.mem_used = total_memory - info.mem_available;
+        }
+
+        // Linux pressure detection: low available memory threshold
+        if (info.mem_available < g_low_memory_threshold) {
+            info.under_pressure = true;
+        }
+
+        return info;
+    }
+
+    // Unified Linux memory info - tries cgroup v2, then v1, then system
+    MemoryPressureInfo GetLinuxMemoryInfo()
+    {
+        ContainerState state = container_state.load(std::memory_order_relaxed);
+        if (state == ContainerState::UNKNOWN || state == ContainerState::CONTAINERIZED) {
+            // Try cgroup v2 first
+            MemoryPressureInfo info = GetCgroupV2MemoryInfo();
+            if (!info.is_containerized) {
+                info = GetCgroupV1MemoryInfo();
+            }
+
+            if (info.is_containerized) {
+                container_state.store(ContainerState::CONTAINERIZED, std::memory_order_relaxed);
+                return info;
+            }
+        }
+        if (state == ContainerState::UNKNOWN) {
+            container_state.store(ContainerState::SYSTEM, std::memory_order_relaxed);
+        }
+
+        return GetLinuxSystemMemoryInfo();
+    }
+}
+#endif
+
+#ifdef __APPLE__
+namespace {
+    // TODO: Determine if kern.memorystatus_vm_pressure_level is useful for pressure detection,
+    // or if we should just use mem_available < threshold like Linux.
+    // PSI on Linux created a feedback loop where flushing triggered more pressure.
+    // macOS pressure_level may have the same issue - needs testing.
+    MemoryPressureInfo GetMacOSMemoryInfo()
+    {
+        MemoryPressureInfo info;
+
+        vm_statistics64_data_t vm_stats;
+        mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+        kern_return_t kr = host_statistics64(mach_host_self(), HOST_VM_INFO64,
+                                            (host_info64_t)&vm_stats, &count);
+
+        if (kr == KERN_SUCCESS) {
+            vm_size_t page_size = 0;
+            host_page_size(mach_host_self(), &page_size);
+
+            // Calculate memory in bytes
+            // Available = free + inactive pages (can be reclaimed)
+            uint64_t free_pages = vm_stats.free_count;
+            uint64_t inactive_pages = vm_stats.inactive_count;
+            uint64_t active_pages = vm_stats.active_count;
+            uint64_t wired_pages = vm_stats.wire_count;
+
+            info.mem_available = (free_pages + inactive_pages) * page_size;
+            info.mem_used = (active_pages + wired_pages) * page_size;
+        }
+
+        // macOS memory pressure levels:
+        // - NORMAL (1): System is fine
+        // - WARN (2): System experiencing pressure - should free memory if possible
+        // - CRITICAL (4): System actively paging to disk - aggressive reclamation needed
+        int pressure_level = 0;
+        size_t size = sizeof(pressure_level);
+
+        if (sysctlbyname("kern.memorystatus_vm_pressure_level", &pressure_level, &size, nullptr, 0) == 0) {
+            // Trigger memory release at WARN level or higher
+            if (pressure_level >= 2) {
+                LogPrintf("CheckMemoryPressure: macOS memory pressure level %d (WARN or CRITICAL)\n", pressure_level);
+                info.under_pressure = true;
+            }
+        }
+
+        // macOS pressure detection: OS pressure level OR low available memory
+        if (!info.under_pressure && info.mem_available < g_low_memory_threshold) {
+            info.under_pressure = true;
+        }
+
+        return info;
+    }
+}
+#endif
+
+
+

--- a/src/util/mempressure.h
+++ b/src/util/mempressure.h
@@ -5,10 +5,28 @@
 #ifndef BITCOIN_UTIL_MEMPRESSURE_H
 #define BITCOIN_UTIL_MEMPRESSURE_H
 
+#include <atomic>
 #include <cstddef>
+#include <cstdint>
 
 extern size_t g_low_memory_threshold;
+extern std::atomic<bool> g_system_needs_memory_released;
+
+/** Memory pressure information returned by platform-specific checks */
+struct MemoryPressureInfo {
+    bool under_pressure = false;
+    size_t mem_available = 0;
+    size_t mem_used = 0;
+    bool is_containerized = false;
+};
+
+/** Checks system memory pressure and updates g_system_needs_memory_released flag.
+ * This function is called periodically by the scheduler
+ */
+void CheckMemoryPressure();
 
 bool SystemNeedsMemoryReleased();
+void PauseMemoryPressureChecks();
+void ResumeMemoryPressureChecks();
 
 #endif // BITCOIN_UTIL_MEMPRESSURE_H

--- a/src/util/systemmemory.cpp
+++ b/src/util/systemmemory.cpp
@@ -4,10 +4,11 @@
 
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
-#include <util/mempressure.h>
+#include <util/systemmemory.h>
 
 #include <logging.h>
 #include <util/byte_units.h>
+#include <util/memory_profiler.h>
 
 #ifdef WIN32
 #include <windows.h>
@@ -24,14 +25,17 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <exception>
 #include <fstream>
 #include <string>
 
-size_t g_low_memory_threshold{64_MiB};
+// Memory pressure threshold - initialized based on leveldb batch size
+// Default will be set by InitializeMemoryThreshold()
+size_t g_low_memory_threshold{0};
 std::atomic<bool> g_system_needs_memory_released{false};
 
-// File-local state variables
+// If our periodic memory pressure checks are paused
 static std::atomic<bool> checks_paused{false};
 
 // Container detection state
@@ -44,12 +48,23 @@ static std::atomic<ContainerState> container_state{ContainerState::UNKNOWN};
 
 namespace {
 #ifdef WIN32
-    MemoryPressureInfo GetWindowsMemoryInfo();
+    MemoryInfo GetWindowsMemoryInfo();
 #elif defined(__linux__)
-    MemoryPressureInfo GetLinuxMemoryInfo();
+    MemoryInfo GetLinuxMemoryInfo();
 #elif defined(__APPLE__)
-    MemoryPressureInfo GetMacOSMemoryInfo();
+    MemoryInfo GetMacOSMemoryInfo();
 #endif
+}
+
+void InitializeMemoryThreshold(size_t batch_size_bytes)
+{
+    // Calculate memory pressure threshold based on leveldb batch size
+    // Formula uses moderate multiplier (2.9x) plus buffer (330 MB)
+    // Based on empirical testing across platforms (Windows/Linux/VM) and batch sizes (64/128/256 MB)
+    size_t batch_size_mb = batch_size_bytes / (1024 * 1024);
+    size_t overhead_mb = static_cast<size_t>(batch_size_mb * 2.9);
+    size_t threshold_mb = overhead_mb + 330;
+    g_low_memory_threshold = threshold_mb * 1024 * 1024;
 }
 
 void CheckMemoryPressure()
@@ -64,23 +79,23 @@ void CheckMemoryPressure()
     }
 
 #ifdef WIN32
-    MemoryPressureInfo info = GetWindowsMemoryInfo();
+    MemoryInfo info = GetWindowsMemoryInfo();
 #elif defined(__linux__)
-    MemoryPressureInfo info = GetLinuxMemoryInfo();
+    MemoryInfo info = GetLinuxMemoryInfo();
 #elif defined(__APPLE__)
-    MemoryPressureInfo info = GetMacOSMemoryInfo();
+    MemoryInfo info = GetMacOSMemoryInfo();
 #else
     // Unsupported platform - disable pressure detection
     g_system_needs_memory_released.store(false, std::memory_order_relaxed);
     return;
 #endif
 
-    LogDebug(BCLog::MEMPRESSURE, "%sMemAvailable=%.2f MB, MemUsed=%.2f MB, threshold=%.2f MB, trigger=%s\n",
-             info.is_containerized ? "Container " : "",
-             info.mem_available / (1024.0 * 1024.0),
-             info.mem_used / (1024.0 * 1024.0),
-             g_low_memory_threshold / (1024.0 * 1024.0),
-             info.under_pressure ? "YES" : "NO");
+    // LogDebug(BCLog::MEMPRESSURE, "%sMemAvailable=%.2f MB, MemUsed=%.2f MB, threshold=%.2f MB, trigger=%s\n",
+    //          info.is_containerized ? "Container " : "",
+    //          info.mem_available / (1024.0 * 1024.0),
+    //          info.mem_used / (1024.0 * 1024.0),
+    //          g_low_memory_threshold / (1024.0 * 1024.0),
+    //          info.under_pressure ? "YES" : "NO");
 
     if (info.under_pressure) {
         LogPrintf("Mempressure detected - available: %.2f MB, threshold: %.2f MB\n",
@@ -100,6 +115,11 @@ bool SystemNeedsMemoryReleased()
     return g_system_needs_memory_released.load(std::memory_order_relaxed);
 }
 
+void ResetMemoryPressure()
+{
+    g_system_needs_memory_released.store(false, std::memory_order_relaxed);
+}
+
 void PauseMemoryPressureChecks()
 {
     checks_paused.store(true, std::memory_order_relaxed);
@@ -111,13 +131,27 @@ void ResumeMemoryPressureChecks()
     g_system_needs_memory_released.store(false, std::memory_order_relaxed);
 }
 
+MemoryInfo GetMemoryInfo()
+{
+#ifdef WIN32
+    return GetWindowsMemoryInfo();
+#elif defined(__linux__)
+    return GetLinuxMemoryInfo();
+#elif defined(__APPLE__)
+    return GetMacOSMemoryInfo();
+#else
+    // Unsupported platform - return empty info
+    return MemoryInfo{};
+#endif
+}
+
 #ifdef WIN32
 namespace {
     // Check Windows container memory status (Job Object)
     // Docker, etc on Windows use Job Objects to enforce memory limits.
-    MemoryPressureInfo GetWindowsContainerMemoryInfo()
+    MemoryInfo GetWindowsContainerMemoryInfo()
     {
-        MemoryPressureInfo info;
+        MemoryInfo info;
 
         // Query information about the job object the current process belongs to
         JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_info = {};
@@ -152,35 +186,38 @@ namespace {
     }
 
     // Check system (non-container) Windows memory status
-    MemoryPressureInfo GetWindowsSystemMemoryInfo()
+    MemoryInfo GetWindowsSystemMemoryInfo()
     {
-        MemoryPressureInfo info;
+        MemoryInfo info;
 
-        MEMORYSTATUSEX mem_status;
-        mem_status.dwLength = sizeof(mem_status);
-        if (!GlobalMemoryStatusEx(&mem_status)) {
+        PERFORMANCE_INFORMATION perf_info;
+        if (!GetPerformanceInfo(&perf_info, sizeof(perf_info))) {
             return info;
         }
 
-        // Use the lesser of available physical or virtual memory
-        info.mem_available = std::min(static_cast<size_t>(mem_status.ullAvailPhys),
-                                      static_cast<size_t>(mem_status.ullAvailVirtual));
-        info.mem_used = static_cast<size_t>(mem_status.ullTotalPhys) - static_cast<size_t>(mem_status.ullAvailPhys);
+        size_t page_size = perf_info.PageSize;
+        size_t commit_limit = static_cast<size_t>(perf_info.CommitLimit) * page_size;
+        size_t commit_total = static_cast<size_t>(perf_info.CommitTotal) * page_size;
+        size_t physical_available = static_cast<size_t>(perf_info.PhysicalAvailable) * page_size;
 
-        // Windows low memory detection: high memory usage (99%+) AND below threshold
-        // This will be supplemented with Pages/sec pressure detection in the future
-        if (mem_status.dwMemoryLoad >= 99 && info.mem_available < g_low_memory_threshold) {
+        size_t commit_available = (commit_total < commit_limit) ? (commit_limit - commit_total) : 0;
+
+        // Use the minimum of commit available and physical available
+        info.mem_available = std::min(commit_available, physical_available);
+        info.mem_used = commit_total;
+
+        if (info.mem_available < g_low_memory_threshold) {
             info.under_pressure = true;
         }
 
         return info;
     }
 
-    MemoryPressureInfo GetWindowsMemoryInfo()
+    MemoryInfo GetWindowsMemoryInfo()
     {
         ContainerState state = container_state.load(std::memory_order_relaxed);
         if (state == ContainerState::UNKNOWN || state == ContainerState::CONTAINERIZED) {
-            MemoryPressureInfo info = GetWindowsContainerMemoryInfo();
+            MemoryInfo info = GetWindowsContainerMemoryInfo();
             if (info.is_containerized) {
                 container_state.store(ContainerState::CONTAINERIZED, std::memory_order_relaxed);
                 return info;
@@ -207,9 +244,9 @@ namespace {
         }
     }
 
-    MemoryPressureInfo GetCgroupV2MemoryInfo()
+    MemoryInfo GetCgroupV2MemoryInfo()
     {
-        MemoryPressureInfo info;
+        MemoryInfo info;
 
         std::ifstream v2_check("/sys/fs/cgroup/memory.max");
         std::string limit_str;
@@ -269,9 +306,9 @@ namespace {
         return info;
     }
 
-    MemoryPressureInfo GetCgroupV1MemoryInfo()
+    MemoryInfo GetCgroupV1MemoryInfo()
     {
-        MemoryPressureInfo info;
+        MemoryInfo info;
 
         std::ifstream limit_file("/sys/fs/cgroup/memory/memory.limit_in_bytes");
         std::string limit_str;
@@ -325,9 +362,9 @@ namespace {
     }
 
     // Check system (non-container) Linux memory status
-    MemoryPressureInfo GetLinuxSystemMemoryInfo()
+    MemoryInfo GetLinuxSystemMemoryInfo()
     {
-        MemoryPressureInfo info;
+        MemoryInfo info;
 
         std::ifstream meminfo("/proc/meminfo");
         if (!meminfo.is_open()) {
@@ -379,12 +416,12 @@ namespace {
     }
 
     // Unified Linux memory info - tries cgroup v2, then v1, then system
-    MemoryPressureInfo GetLinuxMemoryInfo()
+    MemoryInfo GetLinuxMemoryInfo()
     {
         ContainerState state = container_state.load(std::memory_order_relaxed);
         if (state == ContainerState::UNKNOWN || state == ContainerState::CONTAINERIZED) {
             // Try cgroup v2 first
-            MemoryPressureInfo info = GetCgroupV2MemoryInfo();
+            MemoryInfo info = GetCgroupV2MemoryInfo();
             if (!info.is_containerized) {
                 info = GetCgroupV1MemoryInfo();
             }
@@ -409,9 +446,9 @@ namespace {
     // or if we should just use mem_available < threshold like Linux.
     // PSI on Linux created a feedback loop where flushing triggered more pressure.
     // macOS pressure_level may have the same issue - needs testing.
-    MemoryPressureInfo GetMacOSMemoryInfo()
+    MemoryInfo GetMacOSMemoryInfo()
     {
-        MemoryPressureInfo info;
+        MemoryInfo info;
 
         vm_statistics64_data_t vm_stats;
         mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
@@ -458,5 +495,26 @@ namespace {
 }
 #endif
 
+void ReportFlushProfile(std::unique_ptr<MemoryProfiler::FlushProfile> profile, size_t cache_size_bytes)
+{
+    if (!profile) return;
 
+    size_t cache_size_mb = cache_size_bytes / (1024 * 1024);
 
+    // Calculate overhead from peak - pre_flush
+    size_t overhead_mb = (profile->peak_memory_mb >= profile->pre_flush_memory_mb)
+        ? (profile->peak_memory_mb - profile->pre_flush_memory_mb)
+        : 0;
+
+    int64_t duration_ms = profile->GetDurationMs();
+
+    // Get current system memory state
+    MemoryInfo mem_info = GetMemoryInfo();
+    size_t sys_memavail_mb = mem_info.mem_available / (1024 * 1024);
+
+    // Log the flush profile
+    LogDebug(BCLog::MEMPRESSURE, "Flush profile: cache_size=%zu MB, overhead=%zu MB, duration=%lld ms, "
+             "pre_flush=%zu MB, peak=%zu MB, post_flush=%zu MB, sys_memavail=%zu MB\n",
+             cache_size_mb, overhead_mb, (long long)duration_ms,
+             profile->pre_flush_memory_mb, profile->peak_memory_mb, profile->post_flush_memory_mb, sys_memavail_mb);
+}

--- a/src/util/systemmemory.h
+++ b/src/util/systemmemory.h
@@ -2,23 +2,36 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_MEMPRESSURE_H
-#define BITCOIN_UTIL_MEMPRESSURE_H
+#ifndef BITCOIN_UTIL_SYSTEMMEMORY_H
+#define BITCOIN_UTIL_SYSTEMMEMORY_H
 
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+
+#include <util/memory_profiler.h>
 
 extern size_t g_low_memory_threshold;
 extern std::atomic<bool> g_system_needs_memory_released;
 
-/** Memory pressure information returned by platform-specific checks */
-struct MemoryPressureInfo {
+/** System memory information */
+struct MemoryInfo {
     bool under_pressure = false;
     size_t mem_available = 0;
     size_t mem_used = 0;
     bool is_containerized = false;
 };
+
+/** Get current system memory information
+ * @return MemoryInfo struct with available/used memory, pressure status, and containerization
+ */
+MemoryInfo GetMemoryInfo();
+
+/** Initialize memory pressure threshold based on database batch size
+ * @param batch_size_bytes Database write batch size in bytes
+ */
+void InitializeMemoryThreshold(size_t batch_size_bytes);
 
 /** Checks system memory pressure and updates g_system_needs_memory_released flag.
  * This function is called periodically by the scheduler
@@ -26,7 +39,11 @@ struct MemoryPressureInfo {
 void CheckMemoryPressure();
 
 bool SystemNeedsMemoryReleased();
+void ResetMemoryPressure();
 void PauseMemoryPressureChecks();
 void ResumeMemoryPressureChecks();
 
-#endif // BITCOIN_UTIL_MEMPRESSURE_H
+/** Report flush profile data */
+void ReportFlushProfile(std::unique_ptr<MemoryProfiler::FlushProfile> profile, size_t cache_size_bytes);
+
+#endif // BITCOIN_UTIL_SYSTEMMEMORY_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -56,7 +56,7 @@
 #include <util/fs_helpers.h>
 #include <util/hasher.h>
 #include <util/ioprio.h>
-#include <util/mempressure.h>
+#include <util/systemmemory.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
 #include <util/result.h>
@@ -3148,20 +3148,28 @@ bool Chainstate::FlushStateToDisk(
             if (cache_state >= CoinsCacheSizeState::CRITICAL) {
                 // The cache is over the limit, we have to write now.
                 fCacheCritical = true;
-            } else if (SystemNeedsMemoryReleased()) {
-                fCacheCritical = true;
             }
         }
         // It's been a while since we wrote the block index and chain state to disk. Do this frequently, so we don't need to redownload or reindex after a crash.
         bool fPeriodicWrite = mode == FlushStateMode::PERIODIC && nNow >= m_next_write;
         // Combine all conditions that result in a write to disk.
         bool should_write = (mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical || fPeriodicWrite || fFlushForPrune;
+
         // Write blocks, block index and best chain related state to disk.
         if (should_write) {
             // Ensure we can write block index
             if (!CheckDiskSpace(m_blockman.m_opts.blocks_dir)) {
                 return FatalError(m_chainman.GetNotifications(), state, _("Disk space is too low!"));
             }
+
+            // Pause memory pressure checks during the flush operation
+            PauseMemoryPressureChecks();
+
+            // Start profiling memory usage during entire flush operation
+            if (g_memory_profiler) {
+                g_memory_profiler->StartFlushProfiling();
+            }
+
             {
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
 
@@ -3199,9 +3207,6 @@ bool Chainstate::FlushStateToDisk(
                            coins_mem_usage / (1024.0 * 1024.0));
             }
 
-            // Pause memory pressure checks during the flush/sync operation
-            PauseMemoryPressureChecks();
-
             LOG_TIME_MILLIS_WITH_CATEGORY(strprintf("write coins cache to disk (%d coins, %.2fKiB)",
                 coins_count, coins_mem_usage >> 10), BCLog::BENCH);
 
@@ -3223,6 +3228,14 @@ bool Chainstate::FlushStateToDisk(
                    (uint64_t)coins_count,
                    (uint64_t)coins_mem_usage,
                    (bool)fFlushForPrune);
+
+            // Stop profiling and report flush overhead to mempressure
+            if (g_memory_profiler) {
+                auto profile = g_memory_profiler->StopFlushProfiling();
+                if (profile) {
+                    ReportFlushProfile(std::move(profile), coins_mem_usage);
+                }
+            }
 
             // Resume memory pressure checks after the flush/sync completes
             ResumeMemoryPressureChecks();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3190,7 +3190,18 @@ bool Chainstate::FlushStateToDisk(
 
             if (!CoinsTip().GetBestBlock().IsNull()) {
 
-            if (coins_mem_usage >= WARN_FLUSH_COINS_SIZE) LogWarning("Flushing large (%d GiB) UTXO set to disk, it may take several minutes", coins_mem_usage >> 30);
+            // Flush the chainstate (which may refer to block index entries).
+            const auto empty_cache{(mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical};
+
+            if (coins_mem_usage >= WARN_FLUSH_COINS_SIZE) {
+                LogWarning("%s: Flushing large (%.2f MiB) UTXO set to disk, it may take several minutes",
+                           empty_cache ? "FLUSH" : "SYNC",
+                           coins_mem_usage / (1024.0 * 1024.0));
+            }
+
+            // Pause memory pressure checks during the flush/sync operation
+            PauseMemoryPressureChecks();
+
             LOG_TIME_MILLIS_WITH_CATEGORY(strprintf("write coins cache to disk (%d coins, %.2fKiB)",
                 coins_count, coins_mem_usage >> 10), BCLog::BENCH);
 
@@ -3202,8 +3213,6 @@ bool Chainstate::FlushStateToDisk(
             if (!CheckDiskSpace(m_chainman.m_options.datadir, 48 * 2 * 2 * CoinsTip().GetCacheSize())) {
                 return FatalError(m_chainman.GetNotifications(), state, _("Disk space is too low!"));
             }
-            // Flush the chainstate (which may refer to block index entries).
-            const auto empty_cache{(mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical};
             if (empty_cache ? !CoinsTip().Flush() : !CoinsTip().Sync()) {
                 return FatalError(m_chainman.GetNotifications(), state, _("Failed to write to coin database."));
             }
@@ -3215,6 +3224,8 @@ bool Chainstate::FlushStateToDisk(
                    (uint64_t)coins_mem_usage,
                    (bool)fFlushForPrune);
 
+            // Resume memory pressure checks after the flush/sync completes
+            ResumeMemoryPressureChecks();
             }
         }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -19,7 +19,7 @@
 #include <test/util/logging.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
-#include <util/mempressure.h>
+#include <util/systemmemory.h>
 #include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>


### PR DESCRIPTION
Use /proc/meminfo MemAvailable instead of sysinfo() freeram+bufferram on Linux. MemAvailable accounts for reclaimable memory (page cache, etc), providing accurate memory availability.

Added support for macOS using kern.memorystatus_vm_pressure_level sysctl

Added support for containers on both linux and windows. (new macOS native containers to TBD)
1. linux - (edit: proc/self/meminfo doesn't exist.. was misinformed) using cgroup code instead
2. Windows - uses Job Objects (QueryInformationJobObject)

Memory pressure is periodically via Scheduler (10s interval). SystemNeedsMemoryReleased() (used in FlushStateToDisk) now reads a cached flag instead of rechecking available memory each time. After a Flush/Sync, Update flag immediately after to prevent repeated flushes.

Fixes #188
Addresses #216

Regarding #216 point:
* First, try to free already-dumped coins (maybe only as needed). If that's insufficient, dump and free dirty ones.

After much experimentation found that the custom memory allocator (PoolAllocator -> Pool.h - which uses a singly-linked list for its free list), is fairly hard to use in context of trying to free _partial_ amounts of allocated memory. The current way of freeing this memory is to completely destroy and recreate it (in ReallocateCache which happens in Flush). All or nothing.  So, doing anything other than a full Flush, will not help with memory.

Using Flush when we have a low available memory seems to work just fine though. (tested multiple times on linux, with <64MB of available memory). 

Adding some instructions for creating a Docker image to test containers, in post below.

Needs further testing altogether. Specifically:
Windows testing
Linux testing (Tested)
MacOS testing
Container testing: Linux container, Windows container, Mac container

Edit 10/20/25:  Still working on best metrics for determining container mempressure.  
