### PR TITLE
taproot/script limits; default unknown-witness off; BIP8 stub

### DIFF
--- a/doc/release-notes-bip444.md
+++ b/doc/release-notes-bip444.md
@@ -1,0 +1,52 @@
+# BIP-0444 Policy Changes (Taproot and Script Limits)
+
+## Summary
+
+This release introduces policy-level enforcement of BIP-0444 to prevent large arbitrary-data inscriptions and reduce UTXO/script bloat. These changes are active immediately as relay/mempool policy defaults; consensus enforcement will follow after BIP8 activation (parameters TBD).
+
+## Policy Changes (Active Now)
+
+### scriptPubKey Limits
+- **Non-NULL_DATA scriptPubKey size cap**: Transactions with non-NULL_DATA outputs exceeding 34 bytes are rejected (`scriptpubkey-size-34`).
+- **scriptPubKey push length cap**: Any single push operation in a scriptPubKey exceeding 256 bytes is rejected (`scriptpubkey-pushlen`).
+
+### Taproot/Tapscript Limits
+- **Control block size cap**: Taproot control blocks exceeding 257 bytes (33-byte base + 7 merkle path nodes) are rejected (`taproot-controlblock-size`).
+- **Per-input witness size cap**: Segwit v1 inputs with total witness data exceeding 1024 bytes are rejected (`taproot-perinput-witness`). Configurable via `-v1perinputwitnesslimit` (min 128, max 8192).
+- **Tapscript IF ban**: OP_IF and OP_NOTIF opcodes are disallowed in Tapscript leaves (`taproot-if-disallowed`).
+- **Tapscript push-only run cap**: Contiguous push-only regions in Tapscript leaves exceeding 256 bytes total payload are rejected (`taproot-pushrun`).
+- **Tapscript IF-body cap**: Push-only IF/NOTIF branch bodies exceeding 80 bytes total payload are rejected (`taproot-if-pushonly`).
+
+### Unknown Witness Versions
+- **Default reject unknown witness**: The default for `-acceptunknownwitness` is now `false`. Transactions sending to undefined witness program versions are rejected by default unless explicitly allowed via `-acceptunknownwitness=1`.
+
+## Configuration Options
+
+- `-v1perinputwitnesslimit=<n>`: Set maximum total witness bytes per segwit v1 input (default: 1024; min 128, max 8192).
+- `-acceptunknownwitness=<bool>`: Allow relay of transactions to unknown/future witness versions (default: 0).
+
+## Rationale
+
+These policy defaults target the common inscription vectors (Taproot witness/script abuse) while preserving legitimate usage:
+- Standard P2TR/P2WSH outputs remain valid (≤34 bytes).
+- Normal signatures, keys, and small scripts are unaffected.
+- Taproot key-path spends are unaffected.
+- The limits are conservative and tunable for advanced use cases.
+
+## Deployment
+
+BIP-0444 includes a soft-fork component with BIP8 activation (parameters TBD). Policy enforcement is active immediately; consensus rules will activate after the signaling period and delayed activation height.
+
+For testing on regtest/testnet/signet, use `-vbparams=taproot_script_limits:start:end[:min_activation_height]` to override deployment parameters.
+
+## Compatibility
+
+- **Wallets**: Avoid creating transactions with oversized scriptPubKeys, large push payloads, or Tapscript leaves using OP_IF/NOTIF.
+- **Contracts**: Multi-party protocols with large witness data (e.g., complex lightning channels, vaults) may need to tune `-v1perinputwitnesslimit` or split across multiple inputs.
+- **Unknown witness versions**: If your application relies on future witness versions, set `-acceptunknownwitness=1`.
+
+## References
+
+- BIP-0444: https://github.com/bitcoin/bips/blob/master/bip-0444.mediawiki (pending merge)
+- Discussion: https://gnusha.org/pi/bitcoindev/CALeFGL0PDjtRt2rfbY4gTkoc+5oNQ0mn_obraE7PrtHuNYFpQw@mail.gmail.com/T/#mb71350c5dfb119efeb92c5ee738b6c8225bf15b6
+

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -32,7 +32,7 @@ constexpr bool ValidDeployment(BuriedDeployment dep) { return dep <= DEPLOYMENT_
 enum DeploymentPos : uint16_t {
     DEPLOYMENT_TESTDUMMY,
     DEPLOYMENT_TAPROOT, // Deployment of Schnorr/Taproot (BIPs 340-342)
-    DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS, // BIP-0444: Taproot Push-Only Limits
+    DEPLOYMENT_TAPROOT_SCRIPT_LIMITS, // BIP-0444: Taproot and Script Limits
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in deploymentinfo.cpp
     MAX_VERSION_BITS_DEPLOYMENTS
 };

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -32,6 +32,7 @@ constexpr bool ValidDeployment(BuriedDeployment dep) { return dep <= DEPLOYMENT_
 enum DeploymentPos : uint16_t {
     DEPLOYMENT_TESTDUMMY,
     DEPLOYMENT_TAPROOT, // Deployment of Schnorr/Taproot (BIPs 340-342)
+    DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS, // BIP-0444: Taproot Push-Only Limits
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in deploymentinfo.cpp
     MAX_VERSION_BITS_DEPLOYMENTS
 };

--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -18,7 +18,7 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
         /*.gbt_force =*/ true,
     },
     {
-        /*.name =*/ "taproot_pushonly_limits",
+        /*.name =*/ "taproot_script_limits",
         /*.gbt_force =*/ true,
     },
 };

--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -17,6 +17,10 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
         /*.name =*/ "taproot",
         /*.gbt_force =*/ true,
     },
+    {
+        /*.name =*/ "taproot_pushonly_limits",
+        /*.gbt_force =*/ true,
+    },
 };
 
 std::string DeploymentName(Consensus::BuriedDeployment dep)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -856,6 +856,11 @@ void InitParameterInteraction(ArgsManager& args)
         args.SoftSetArg("-datacarriercost", "0.25");
         args.SoftSetArg("-datacarrierfullcount", "0");
         args.SoftSetArg("-datacarriersize", "83");
+    }
+
+    {
+        argsman.AddArg("-datacarrierwitnesslimit", "Set maximum bytes allowed in any single push-only witness element for policy (default: 80)", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+        argsman.AddArg("-v1perinputwitnesslimit", "Set maximum total witness bytes per segwit v1 input for policy (default: 1024)", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
         args.SoftSetArg("-maxtxlegacysigops", strprintf("%s", std::numeric_limits<unsigned int>::max()));
         args.SoftSetArg("-maxscriptsize", strprintf("%s", std::numeric_limits<unsigned int>::max()));
         args.SoftSetArg("-mempooltruc", "enforce");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -717,6 +717,8 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                    strprintf("Maximum size of data in data carrier transactions we relay and mine, in bytes (default: %u)",
                              MAX_OP_RETURN_RELAY),
                    ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-datacarrierwitnesslimit", "Set maximum bytes allowed in any single push-only witness element for policy (default: 80)", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-v1perinputwitnesslimit", "Set maximum total witness bytes per segwit v1 input for policy (default: 1024)", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-maxscriptsize", strprintf("Maximum size of scripts (including the entire witness stack) we relay and mine, in bytes (default: %s)", DEFAULT_SCRIPT_SIZE_POLICY_LIMIT), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-maxtxlegacysigops",
                    strprintf("Maximum number of legacy sigops allowed in transactions we relay and mine, as measured by BIP54 (default: %s)",
@@ -858,18 +860,7 @@ void InitParameterInteraction(ArgsManager& args)
         args.SoftSetArg("-datacarriersize", "83");
     }
 
-    {
-        argsman.AddArg("-datacarrierwitnesslimit", "Set maximum bytes allowed in any single push-only witness element for policy (default: 80)", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
-        argsman.AddArg("-v1perinputwitnesslimit", "Set maximum total witness bytes per segwit v1 input for policy (default: 1024)", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
-        args.SoftSetArg("-maxtxlegacysigops", strprintf("%s", std::numeric_limits<unsigned int>::max()));
-        args.SoftSetArg("-maxscriptsize", strprintf("%s", std::numeric_limits<unsigned int>::max()));
-        args.SoftSetArg("-mempooltruc", "enforce");
-        args.SoftSetArg("-permitephemeral", "anchor,send,dust");
-        args.SoftSetArg("-spkreuse", "allow");
-        args.SoftSetArg("-blockprioritysize", "0");
-        args.SoftSetArg("-blockmaxsize", "4000000");
-        args.SoftSetArg("-blockmaxweight", "4000000");
-    }
+    
 
     // when specifying an explicit binding address, you want to listen on it
     // even when -connect or -proxy is specified

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -717,7 +717,6 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                    strprintf("Maximum size of data in data carrier transactions we relay and mine, in bytes (default: %u)",
                              MAX_OP_RETURN_RELAY),
                    ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
-    argsman.AddArg("-datacarrierwitnesslimit", "Set maximum bytes allowed in any single push-only witness element for policy (default: 80)", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-v1perinputwitnesslimit", "Set maximum total witness bytes per segwit v1 input for policy (default: 1024)", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-maxscriptsize", strprintf("Maximum size of scripts (including the entire witness stack) we relay and mine, in bytes (default: %s)", DEFAULT_SCRIPT_SIZE_POLICY_LIMIT), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-maxtxlegacysigops",
@@ -858,6 +857,14 @@ void InitParameterInteraction(ArgsManager& args)
         args.SoftSetArg("-datacarriercost", "0.25");
         args.SoftSetArg("-datacarrierfullcount", "0");
         args.SoftSetArg("-datacarriersize", "83");
+        args.SoftSetArg("-maxtxlegacysigops", strprintf("%s", std::numeric_limits<unsigned int>::max()));
+        args.SoftSetArg("-maxscriptsize", strprintf("%s", std::numeric_limits<unsigned int>::max()));
+        args.SoftSetArg("-mempooltruc", "enforce");
+        args.SoftSetArg("-permitephemeral", "anchor,send,dust");
+        args.SoftSetArg("-spkreuse", "allow");
+        args.SoftSetArg("-blockprioritysize", "0");
+        args.SoftSetArg("-blockmaxsize", "4000000");
+        args.SoftSetArg("-blockmaxweight", "4000000");
     }
 
     

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -717,7 +717,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                    strprintf("Maximum size of data in data carrier transactions we relay and mine, in bytes (default: %u)",
                              MAX_OP_RETURN_RELAY),
                    ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
-    argsman.AddArg("-v1perinputwitnesslimit", "Set maximum total witness bytes per segwit v1 input for policy (default: 1024)", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-v1perinputwitnesslimit", "Set maximum total witness bytes per segwit v1 input for policy (default: 1024; min 128, max 8192)", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-maxscriptsize", strprintf("Maximum size of scripts (including the entire witness stack) we relay and mine, in bytes (default: %s)", DEFAULT_SCRIPT_SIZE_POLICY_LIMIT), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-maxtxlegacysigops",
                    strprintf("Maximum number of legacy sigops allowed in transactions we relay and mine, as measured by BIP54 (default: %s)",

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -117,11 +117,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628640000; // August 11th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 709632; // Approximately November 12th, 2021
 
-        // Deployment of BIP-0444 Taproot Push-Only Limits (parameters TBD)
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].bit = 3; // TBD: select final bit
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE; // set via -vbparams or when finalized
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;     // set via -vbparams or when finalized
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].min_activation_height = 0; // set to Timeout+period when finalized
+        // Deployment of BIP-0444 Taproot and Script Limits (parameters TBD)
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].bit = 3; // TBD: select final bit
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE; // set via -vbparams or when finalized
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;     // set via -vbparams or when finalized
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].min_activation_height = 0; // set to Timeout+period when finalized
 
         consensus.nMinimumChainWork = uint256{"0000000000000000000000000000000000000000dee8e2a309ad8a9820433c68"};
         consensus.defaultAssumeValid = uint256{"00000000000000000000611fd22f2df7c8fbd0688745c3a6c3bb5109cc2a12cb"}; // 912683
@@ -286,11 +286,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628640000; // August 11th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
-        // BIP-0444 Taproot Push-Only Limits (parameters TBD)
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].bit = 3; // TBD
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].min_activation_height = 0;
+        // BIP-0444 Taproot and Script Limits (parameters TBD)
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].bit = 3; // TBD
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].min_activation_height = 0;
 
         consensus.nMinimumChainWork = uint256{"0000000000000000000000000000000000000000000015f5e0c9f13455b0eb17"};
         consensus.defaultAssumeValid = uint256{"00000000000003fc7967410ba2d0a8a8d50daedc318d43e8baf1a9782c236a57"}; // 3974606
@@ -391,11 +391,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
-        // BIP-0444 Taproot Push-Only Limits (parameters TBD)
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].bit = 3; // TBD
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE; // allow testing
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].min_activation_height = 0;
+        // BIP-0444 Taproot and Script Limits (parameters TBD)
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].bit = 3; // TBD
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE; // allow testing
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].min_activation_height = 0;
 
         consensus.nMinimumChainWork = uint256{"0000000000000000000000000000000000000000000001d6dce8651b6094e4c1"};
         consensus.defaultAssumeValid = uint256{"0000000000003ed4f08dbdf6f7d6b271a6bcffce25675cb40aa9fa43179a89f3"}; // 72600
@@ -535,11 +535,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
-        // BIP-0444 Taproot Push-Only Limits (parameters overridable via -vbparams)
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].bit = 3; // TBD
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].min_activation_height = 0;
+        // BIP-0444 Taproot and Script Limits (parameters overridable via -vbparams)
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].bit = 3; // TBD
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].min_activation_height = 0;
 
         // message start is defined as the first 4 bytes of the sha256d of the block script
         HashWriter h{};

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -117,6 +117,12 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628640000; // August 11th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 709632; // Approximately November 12th, 2021
 
+        // Deployment of BIP-0444 Taproot Push-Only Limits (parameters TBD)
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].bit = 3; // TBD: select final bit
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE; // set via -vbparams or when finalized
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;     // set via -vbparams or when finalized
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].min_activation_height = 0; // set to Timeout+period when finalized
+
         consensus.nMinimumChainWork = uint256{"0000000000000000000000000000000000000000dee8e2a309ad8a9820433c68"};
         consensus.defaultAssumeValid = uint256{"00000000000000000000611fd22f2df7c8fbd0688745c3a6c3bb5109cc2a12cb"}; // 912683
 
@@ -280,6 +286,12 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628640000; // August 11th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
+        // BIP-0444 Taproot Push-Only Limits (parameters TBD)
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].bit = 3; // TBD
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].min_activation_height = 0;
+
         consensus.nMinimumChainWork = uint256{"0000000000000000000000000000000000000000000015f5e0c9f13455b0eb17"};
         consensus.defaultAssumeValid = uint256{"00000000000003fc7967410ba2d0a8a8d50daedc318d43e8baf1a9782c236a57"}; // 3974606
 
@@ -378,6 +390,12 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
+
+        // BIP-0444 Taproot Push-Only Limits (parameters TBD)
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].bit = 3; // TBD
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE; // allow testing
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].min_activation_height = 0;
 
         consensus.nMinimumChainWork = uint256{"0000000000000000000000000000000000000000000001d6dce8651b6094e4c1"};
         consensus.defaultAssumeValid = uint256{"0000000000003ed4f08dbdf6f7d6b271a6bcffce25675cb40aa9fa43179a89f3"}; // 72600
@@ -516,6 +534,12 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
+
+        // BIP-0444 Taproot Push-Only Limits (parameters overridable via -vbparams)
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].bit = 3; // TBD
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_PUSHONLY_LIMITS].min_activation_height = 0;
 
         // message start is defined as the first 4 bytes of the sha256d of the block script
         HashWriter h{};

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -393,7 +393,7 @@ public:
 
         // BIP-0444 Taproot and Script Limits (parameters TBD)
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].bit = 3; // TBD
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE; // allow testing
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE; // ALWAYS_ACTIVE for easy signet testing
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT_SCRIPT_LIMITS].min_activation_height = 0;
 

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -41,7 +41,7 @@ static constexpr bool DEFAULT_ACCEPT_NON_STD_DATACARRIER{false};
 /** Default for -acceptnonstdtxn */
 static constexpr bool DEFAULT_ACCEPT_NON_STD_TXN{false};
 /** Default for -acceptunknownwitness */
-static constexpr bool DEFAULT_ACCEPTUNKNOWNWITNESS{true};
+static constexpr bool DEFAULT_ACCEPTUNKNOWNWITNESS{false};
 
 namespace kernel {
 /**

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -95,6 +95,9 @@ struct MemPoolOptions {
     bool permitephemeral_send{DEFAULT_PERMITEPHEMERAL_SEND};
     bool permitephemeral_dust{DEFAULT_PERMITEPHEMERAL_DUST};
     bool persist_v1_dat{DEFAULT_PERSIST_V1_DAT};
+    // Policy to limit inscription-like data in witnesses/tapscripts
+    unsigned int policy_max_pushonly_witness_elem{80};
+    unsigned int policy_max_v1_perinput_witness{1024};
     MemPoolLimits limits{};
 
     ValidationSignals* signals{nullptr};

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -96,7 +96,6 @@ struct MemPoolOptions {
     bool permitephemeral_dust{DEFAULT_PERMITEPHEMERAL_DUST};
     bool persist_v1_dat{DEFAULT_PERSIST_V1_DAT};
     // Policy to limit inscription-like data in witnesses/tapscripts
-    unsigned int policy_max_pushonly_witness_elem{80};
     unsigned int policy_max_v1_perinput_witness{1024};
     MemPoolLimits limits{};
 

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -308,7 +308,6 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
     mempool_opts.persist_v1_dat = argsman.GetBoolArg("-persistmempoolv1", mempool_opts.persist_v1_dat);
 
     // Policy flags to constrain push-only witness elements and per-input size for segwit v1
-    mempool_opts.policy_max_pushonly_witness_elem = argsman.GetIntArg("-datacarrierwitnesslimit", mempool_opts.policy_max_pushonly_witness_elem);
     mempool_opts.policy_max_v1_perinput_witness = argsman.GetIntArg("-v1perinputwitnesslimit", mempool_opts.policy_max_v1_perinput_witness);
 
     ApplyArgsManOptions(argsman, mempool_opts.limits);

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -307,7 +307,7 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
 
     mempool_opts.persist_v1_dat = argsman.GetBoolArg("-persistmempoolv1", mempool_opts.persist_v1_dat);
 
-    // Policy flags to constrain push-only witness elements and per-input size for segwit v1
+    // Policy flags to constrain per-input witness size for segwit v1
     mempool_opts.policy_max_v1_perinput_witness = argsman.GetIntArg("-v1perinputwitnesslimit", mempool_opts.policy_max_v1_perinput_witness);
 
     ApplyArgsManOptions(argsman, mempool_opts.limits);

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -307,6 +307,10 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
 
     mempool_opts.persist_v1_dat = argsman.GetBoolArg("-persistmempoolv1", mempool_opts.persist_v1_dat);
 
+    // Policy flags to constrain push-only witness elements and per-input size for segwit v1
+    mempool_opts.policy_max_pushonly_witness_elem = argsman.GetIntArg("-datacarrierwitnesslimit", mempool_opts.policy_max_pushonly_witness_elem);
+    mempool_opts.policy_max_v1_perinput_witness = argsman.GetIntArg("-v1perinputwitnesslimit", mempool_opts.policy_max_v1_perinput_witness);
+
     ApplyArgsManOptions(argsman, mempool_opts.limits);
 
     return {};

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -308,7 +308,13 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
     mempool_opts.persist_v1_dat = argsman.GetBoolArg("-persistmempoolv1", mempool_opts.persist_v1_dat);
 
     // Policy flags to constrain per-input witness size for segwit v1
-    mempool_opts.policy_max_v1_perinput_witness = argsman.GetIntArg("-v1perinputwitnesslimit", mempool_opts.policy_max_v1_perinput_witness);
+    if (auto lim = argsman.GetIntArg("-v1perinputwitnesslimit")) {
+        // Enforce reasonable bounds to avoid footguns
+        unsigned val = *lim;
+        if (val < 128) val = 128;
+        if (val > 8192) val = 8192;
+        mempool_opts.policy_max_v1_perinput_witness = val;
+    }
 
     ApplyArgsManOptions(argsman, mempool_opts.limits);
 

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -28,6 +28,137 @@
 
 unsigned int g_script_size_policy_limit{DEFAULT_SCRIPT_SIZE_POLICY_LIMIT};
 
+// BIP-0444 policy limits (documented in BIP-0444):
+// - 34 bytes max for non-NULL_DATA scriptPubKey (keeps UTXOs small)
+// - 256 bytes max for any single push payload in scriptPubKey
+// - 257 bytes max Taproot control block size (33-byte base + up to 7 * 32-byte merkle path)
+// - 256 bytes max contiguous push-only run in Tapscript leaves
+// - 80 bytes max push-only IF/NOTIF branch body in Tapscript leaves
+static constexpr unsigned int POLICY_MAX_SPK_SIZE_NON_NULLDATA{34};
+static constexpr unsigned int POLICY_MAX_SCRIPT_PUSH_LEN{256};
+static constexpr unsigned int POLICY_MAX_TAPROOT_CONTROL_BLOCK{257};
+static constexpr unsigned int POLICY_MAX_TAPSCRIPT_PUSH_RUN{256};
+static constexpr unsigned int POLICY_MAX_TAPSCRIPT_IF_BODY{80};
+
+// Helpers for script parsing to avoid duplication and bugs
+namespace {
+
+// Return true if op is a small integer push (OP_0, OP_1NEGATE, OP_1..OP_16)
+inline bool IsSmallIntPush(uint8_t op) {
+    return op == OP_0 || op == OP_1NEGATE || (op >= OP_1 && op <= OP_16);
+}
+
+// Parse a data push starting at s[pos]. Supports OP_0/OP_1NEGATE/OP_1..OP_16 as pushes of length 0.
+// On success, advances pos to the byte after the payload and sets pushed_len to the payload size (0 for small-int pushes).
+// Returns false on malformed/incomplete encoding or if a non-push opcode is encountered.
+inline bool ParsePush(const std::vector<unsigned char>& s, size_t& pos, uint64_t& pushed_len) {
+    if (pos >= s.size()) return false;
+    uint8_t op = s[pos++];
+    pushed_len = 0;
+    if (IsSmallIntPush(op)) {
+        // Small integer push has no explicit payload
+        return true;
+    }
+    size_t need = 0;
+    if (op >= 0x01 && op <= 0x4b) {
+        pushed_len = op;
+    } else if (op == OP_PUSHDATA1) {
+        if (pos >= s.size()) return false;
+        pushed_len = s[pos++];
+    } else if (op == OP_PUSHDATA2) {
+        if (pos + 1 >= s.size()) return false;
+        pushed_len = s[pos] | (uint32_t(s[pos+1]) << 8);
+        pos += 2;
+    } else if (op == OP_PUSHDATA4) {
+        if (pos + 3 >= s.size()) return false;
+        pushed_len = s[pos] | (uint32_t(s[pos+1]) << 8) | (uint32_t(s[pos+2]) << 16) | (uint32_t(s[pos+3]) << 24);
+        pos += 4;
+    } else {
+        return false; // non-push opcode
+    }
+    if (pushed_len > 0) {
+        if (pos + pushed_len > s.size()) return false;
+        pos += pushed_len;
+    }
+    return true;
+}
+
+// Advance across exactly one opcode (including its payload if a push), without interpreting it.
+inline bool AdvanceOneOp(const std::vector<unsigned char>& s, size_t& pos) {
+    if (pos >= s.size()) return false;
+    uint8_t op = s[pos++];
+    if (IsSmallIntPush(op)) return true;
+    size_t payload = 0;
+    if (op >= 0x01 && op <= 0x4b) payload = op;
+    else if (op == OP_PUSHDATA1) { if (pos >= s.size()) return false; payload = s[pos++]; }
+    else if (op == OP_PUSHDATA2) { if (pos + 1 >= s.size()) return false; payload = s[pos] | (uint32_t(s[pos+1]) << 8); pos += 2; }
+    else if (op == OP_PUSHDATA4) { if (pos + 3 >= s.size()) return false; payload = s[pos] | (uint32_t(s[pos+1]) << 8) | (uint32_t(s[pos+2]) << 16) | (uint32_t(s[pos+3]) << 24); pos += 4; }
+    // Non-push opcode: nothing to skip
+    if (payload) {
+        if (pos + payload > s.size()) return false;
+        pos += payload;
+    }
+    return true;
+}
+
+struct Branch { size_t start; size_t end; };
+
+// Single-pass scan over a Tapscript leaf to compute:
+// - max contiguous push-only run total payload (max_run)
+// - IF/NOTIF branch bodies (branches) with [start,end) byte ranges
+// - presence of any OP_IF/OP_NOTIF opcodes (if_found)
+inline bool ScanTapscriptLeaf(const std::vector<unsigned char>& leaf, uint64_t& max_run, std::vector<Branch>& branches, bool& if_found) {
+    max_run = 0;
+    if_found = false;
+    branches.clear();
+    std::vector<size_t> if_stack;
+    for (size_t k = 0; k < leaf.size();) {
+        // Count a push-only run starting at k
+        size_t j = k;
+        uint64_t sum = 0;
+        while (j < leaf.size()) {
+            size_t before = j;
+            uint8_t op = leaf[j];
+            if (op == OP_IF || op == OP_NOTIF) { if_found = true; break; }
+            uint64_t pushed = 0;
+            if (!ParsePush(leaf, j, pushed)) { j = before; break; }
+            sum += pushed;
+        }
+        if (sum > max_run) max_run = sum;
+        // If no progress, consume one opcode and update IF/ELSE/ENDIF bookkeeping
+        if (j == k) {
+            if (j >= leaf.size()) break;
+            uint8_t op = leaf[j++];
+            if (op == OP_IF || op == OP_NOTIF) {
+                if_found = true;
+                if_stack.push_back(j);
+            } else if (op == OP_ELSE) {
+                if (!if_stack.empty()) {
+                    size_t body_start = if_stack.back();
+                    size_t body_end = j - 1;
+                    if (body_end > body_start) branches.push_back({body_start, body_end});
+                    if_stack.back() = j; // else-branch starts now
+                }
+            } else if (op == OP_ENDIF) {
+                if (!if_stack.empty()) {
+                    size_t body_start = if_stack.back();
+                    size_t body_end = j - 1;
+                    if (body_end > body_start) branches.push_back({body_start, body_end});
+                    if_stack.pop_back();
+                }
+            } else {
+                // Non-push non-IF opcode: if it has data payload, skip it
+                j--; // step back to opcode position for AdvanceOneOp
+                if (!AdvanceOneOp(leaf, j)) return false;
+            }
+        }
+        k = j;
+    }
+    return true;
+}
+
+} // namespace
+
 CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFeeIn)
 {
     // "Dust" is defined in terms of dustRelayFee,
@@ -166,7 +297,6 @@ bool IsStandardTx(const CTransaction& tx, const kernel::MemPoolOptions& opts, st
     unsigned int nDataOut = 0;
     unsigned int n_dust{0};
     unsigned int n_monetary{0};
-    TxoutType whichType;
     for (size_t i{tx.vout.size()}; i; ) {
         const CTxOut& txout = tx.vout[--i];
 
@@ -174,29 +304,24 @@ bool IsStandardTx(const CTransaction& tx, const kernel::MemPoolOptions& opts, st
             MaybeReject("scriptpubkey-size");
         }
 
-        // New policy: limit new scriptPubKeys to 34 bytes (except NULL_DATA)
-        if (whichType != TxoutType::NULL_DATA && txout.scriptPubKey.size() > 34) {
-            MaybeReject("scriptpubkey-size-34");
-        }
-
+        TxoutType whichType;
         if (!::IsStandard(txout.scriptPubKey, opts.max_datacarrier_bytes, whichType)) {
             MaybeReject("scriptpubkey");
         }
 
-        // Enforce max push length 256 bytes in scriptPubKey (policy), excluding NULL_DATA which already has its own size limit.
+        // New policy: limit new scriptPubKeys to POLICY_MAX_SPK_SIZE_NON_NULLDATA bytes (except NULL_DATA)
+        if (whichType != TxoutType::NULL_DATA && txout.scriptPubKey.size() > POLICY_MAX_SPK_SIZE_NON_NULLDATA) {
+            MaybeReject("scriptpubkey-size-34");
+        }
+
+        // Enforce max push length in scriptPubKey (policy), excluding NULL_DATA which already has its own size limit.
         if (whichType != TxoutType::NULL_DATA) {
             const std::vector<unsigned char>& s = txout.scriptPubKey;
             for (size_t p = 0; p < s.size();) {
-                uint8_t op = s[p++];
-                size_t push_len = 0;
-                if (op >= 0x01 && op <= 0x4b) { push_len = op; }
-                else if (op == OP_PUSHDATA1) { if (p >= s.size()) break; push_len = s[p++]; }
-                else if (op == OP_PUSHDATA2) { if (p + 1 >= s.size()) break; push_len = s[p] | (s[p+1] << 8); p += 2; }
-                else if (op == OP_PUSHDATA4) { if (p + 3 >= s.size()) break; push_len = s[p] | (s[p+1] << 8) | (s[p+2] << 16) | (s[p+3] << 24); p += 4; }
-                if (push_len) {
-                    if (push_len > 256) { MaybeReject("scriptpubkey-pushlen"); }
-                    if (p + push_len > s.size()) break; p += push_len;
-                }
+                size_t before = p;
+                uint64_t pushed = 0;
+                if (!ParsePush(s, p, pushed)) { p = before; if (!AdvanceOneOp(s, p)) break; continue; }
+                if (pushed > POLICY_MAX_SCRIPT_PUSH_LEN) { MaybeReject("scriptpubkey-pushlen"); }
             }
         }
 
@@ -460,8 +585,8 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
             if (stack.size() >= 2) {
                 // Script path spend (2 or more stack elements after removing optional annex)
                 const auto& control_block = SpanPopBack(stack);
-                // Policy: limit Taproot control block size to 257 bytes
-                if (control_block.size() > 257) {
+                // Policy: limit Taproot control block size
+                if (control_block.size() > POLICY_MAX_TAPROOT_CONTROL_BLOCK) {
                     MaybeReject("taproot-controlblock-size");
                 }
                 const auto& script_bytes = SpanPopBack(stack); // revealed leaf script
@@ -480,99 +605,34 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
                             }
                         }
                     }
-                    // Policy: tapscript-level analysis
-                    // 1) Reject push-only IF/NOTIF branch bodies exceeding 80 bytes total pushed
-                    // 2) Reject large contiguous push-only runs exceeding 256 bytes total pushed
-                    // 3) Disallow OP_IF/OP_NOTIF entirely inside Tapscript (temporarily, per policy)
+                    // Policy: tapscript-level analysis (single pass)
+                    // - Disallow OP_IF/OP_NOTIF entirely (temporary policy)
+                    // - Cap contiguous push-only run total payload
+                    // - Cap push-only IF/NOTIF branch body total payload
                     const std::vector<unsigned char> leaf(script_bytes.begin(), script_bytes.end());
-                    // Helper lambdas to scan
-                    auto parse_push = [&](const std::vector<unsigned char>& s, size_t& j, uint64_t& sum)->bool{
-                        uint8_t op = s[j++];
-                        size_t push_len = 0;
-                        if (op >= 0x01 && op <= 0x4b) { push_len = op; }
-                        else if (op == OP_PUSHDATA1) { if (j >= s.size()) return false; push_len = s[j++]; }
-                        else if (op == OP_PUSHDATA2) { if (j + 1 >= s.size()) return false; push_len = s[j] | (s[j+1] << 8); j += 2; }
-                        else if (op == OP_PUSHDATA4) { if (j + 3 >= s.size()) return false; push_len = s[j] | (s[j+1] << 8) | (s[j+2] << 16) | (s[j+3] << 24); j += 4; }
-                        else { return false; }
-                        if (j + push_len > s.size()) return false;
-                        sum += push_len;
-                        j += push_len;
-                        return true;
-                    };
-                    // Max push-only run
                     uint64_t max_run_sum{0};
-                    for (size_t k = 0; k < leaf.size();) {
-                        size_t j = k;
-                        uint64_t sum = 0;
-                        while (j < leaf.size()) {
-                            size_t before = j;
-                            uint8_t op = leaf[j];
-                            if (op == OP_IF || op == OP_NOTIF) {
-                                MaybeReject("taproot-if-disallowed");
-                                break;
-                            }
-                            if (!parse_push(leaf, j, sum)) { j = before; break; }
-                        }
-                        if (sum > max_run_sum) max_run_sum = sum;
-                        // advance by one opcode (skip any push data if present)
-                        if (j == k) {
-                            if (j >= leaf.size()) break;
-                            uint8_t op = leaf[j++];
-                            if (op >= 0x01 && op <= 0x4b) { if (j + op > leaf.size()) break; j += op; }
-                            else if (op == OP_PUSHDATA1) { if (j >= leaf.size()) break; size_t l = leaf[j++]; if (j + l > leaf.size()) break; j += l; }
-                            else if (op == OP_PUSHDATA2) { if (j + 1 >= leaf.size()) break; size_t l = leaf[j] | (leaf[j+1] << 8); j += 2; if (j + l > leaf.size()) break; j += l; }
-                            else if (op == OP_PUSHDATA4) { if (j + 3 >= leaf.size()) break; size_t l = leaf[j] | (leaf[j+1] << 8) | (leaf[j+2] << 16) | (leaf[j+3] << 24); j += 4; if (j + l > leaf.size()) break; j += l; }
-                        }
-                        k = j;
-                    }
-                    if (max_run_sum > 256) {
-                        MaybeReject("taproot-pushrun");
-                    }
-                    // IF/NOTIF branch bodies scan (simple linear scan with stack for OP_IF/OP_NOTIF ... OP_ENDIF)
-                    struct Branch { size_t start; size_t end; };
                     std::vector<Branch> branches;
-                    std::vector<size_t> if_stack;
-                    for (size_t j = 0; j < leaf.size();) {
-                        uint8_t op = leaf[j++];
-                        if (op == OP_IF || op == OP_NOTIF) {
-                            if_stack.push_back(j);
-                            continue;
-                        }
-                        if (op == OP_ELSE) {
-                            if (!if_stack.empty()) {
-                                size_t body_start = if_stack.back();
-                                size_t body_end = j - 1; // before OP_ELSE
-                                branches.push_back({body_start, body_end});
-                                if_stack.back() = j; // else-body starts now
-                            }
-                            continue;
-                        }
-                        if (op == OP_ENDIF) {
-                            if (!if_stack.empty()) {
-                                size_t body_start = if_stack.back();
-                                size_t body_end = j - 1; // before ENDIF
-                                branches.push_back({body_start, body_end});
-                                if_stack.pop_back();
-                            }
-                            continue;
-                        }
-                        // skip pushdata payloads
-                        size_t push_len = 0;
-                        if (op >= 0x01 && op <= 0x4b) { push_len = op; }
-                        else if (op == OP_PUSHDATA1) { if (j >= leaf.size()) break; push_len = leaf[j++]; }
-                        else if (op == OP_PUSHDATA2) { if (j + 1 >= leaf.size()) break; push_len = leaf[j] | (leaf[j+1] << 8); j += 2; }
-                        else if (op == OP_PUSHDATA4) { if (j + 3 >= leaf.size()) break; push_len = leaf[j] | (leaf[j+1] << 8) | (leaf[j+2] << 16) | (leaf[j+3] << 24); j += 4; }
-                        if (push_len) { if (j + push_len > leaf.size()) break; j += push_len; }
+                    bool if_found{false};
+                    if (!ScanTapscriptLeaf(leaf, max_run_sum, branches, if_found)) {
+                        MaybeReject("taproot-malformed");
+                    }
+                    if (if_found) {
+                        MaybeReject("taproot-if-disallowed");
+                    }
+                    if (max_run_sum > POLICY_MAX_TAPSCRIPT_PUSH_RUN) {
+                        MaybeReject("taproot-pushrun");
                     }
                     for (const auto& b : branches) {
                         uint64_t sum = 0;
                         bool push_only = true;
                         for (size_t j = b.start; j < b.end;) {
                             size_t before = j;
-                            if (!parse_push(leaf, j, sum)) { push_only = false; break; }
+                            uint64_t pushed = 0;
+                            if (!ParsePush(leaf, j, pushed)) { push_only = false; break; }
+                            sum += pushed;
                             if (j == before) break;
                         }
-                        if (push_only && sum > 80) {
+                        if (push_only && sum > POLICY_MAX_TAPSCRIPT_IF_BODY) {
                             MaybeReject("taproot-if-pushonly");
                             break;
                         }

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -460,6 +460,10 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
             if (stack.size() >= 2) {
                 // Script path spend (2 or more stack elements after removing optional annex)
                 const auto& control_block = SpanPopBack(stack);
+                // Policy: limit Taproot control block size to 257 bytes
+                if (control_block.size() > 257) {
+                    MaybeReject("taproot-controlblock-size");
+                }
                 const auto& script_bytes = SpanPopBack(stack); // revealed leaf script
                 if (control_block.empty()) {
                     // Empty control block is invalid

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -348,7 +348,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
     return true;
 }
 
-bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, const std::string& reason_prefix, std::string& out_reason, const ignore_rejects_type& ignore_rejects)
+bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, const kernel::MemPoolOptions& opts, const std::string& reason_prefix, std::string& out_reason, const ignore_rejects_type& ignore_rejects)
 {
     if (tx.IsCoinBase())
         return true; // Coinbases are skipped
@@ -425,7 +425,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
             // Policy: per-input total witness size budget to prevent data-splitting across elements
             size_t per_input_bytes_total{0};
             for (const auto& elem : tx.vin[i].scriptWitness.stack) per_input_bytes_total += elem.size();
-            if (per_input_bytes_total > 1024) {
+            if (per_input_bytes_total > opts.policy_max_v1_perinput_witness) {
                 MaybeReject("taproot-perinput-witness");
             }
             Span stack{tx.vin[i].scriptWitness.stack};
@@ -454,30 +454,95 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
                             }
                         }
                     }
-                    // Policy: reject large push-only witness elements (any version), checked here for v1 path for efficiency
-                    for (const auto& item : stack) {
-                        if (item.size() > 0) {
-                            // Attempt to parse as push-only element
-                            size_t j = 0, n = item.size();
-                            uint64_t pushed_sum = 0;
-                            bool push_only = true;
-                            while (j < n) {
-                                uint8_t op = item[j++];
-                                size_t push_len = 0;
-                                if (op >= 0x01 && op <= 0x4b) { push_len = op; }
-                                else if (op == OP_PUSHDATA1) { if (j >= n) { push_only = false; break; } push_len = item[j++]; }
-                                else if (op == OP_PUSHDATA2) { if (j + 1 >= n) { push_only = false; break; } push_len = item[j] | (item[j+1] << 8); j += 2; }
-                                else if (op == OP_PUSHDATA4) { if (j + 3 >= n) { push_only = false; break; } push_len = item[j] | (item[j+1] << 8) | (item[j+2] << 16) | (item[j+3] << 24); j += 4; }
-                                else { push_only = false; break; }
-                                if (j + push_len > n) { push_only = false; break; }
-                                pushed_sum += push_len;
-                                j += push_len;
+                    // Policy: tapscript-level analysis
+                    // 1) Reject push-only IF/NOTIF branch bodies exceeding 80 bytes total pushed
+                    // 2) Reject large contiguous push-only runs exceeding 256 bytes total pushed
+                    const std::vector<unsigned char> leaf(script_bytes.begin(), script_bytes.end());
+                    // Helper lambdas to scan
+                    auto parse_push = [&](const std::vector<unsigned char>& s, size_t& j, uint64_t& sum)->bool{
+                        uint8_t op = s[j++];
+                        size_t push_len = 0;
+                        if (op >= 0x01 && op <= 0x4b) { push_len = op; }
+                        else if (op == OP_PUSHDATA1) { if (j >= s.size()) return false; push_len = s[j++]; }
+                        else if (op == OP_PUSHDATA2) { if (j + 1 >= s.size()) return false; push_len = s[j] | (s[j+1] << 8); j += 2; }
+                        else if (op == OP_PUSHDATA4) { if (j + 3 >= s.size()) return false; push_len = s[j] | (s[j+1] << 8) | (s[j+2] << 16) | (s[j+3] << 24); j += 4; }
+                        else { return false; }
+                        if (j + push_len > s.size()) return false;
+                        sum += push_len;
+                        j += push_len;
+                        return true;
+                    };
+                    // Max push-only run
+                    uint64_t max_run_sum{0};
+                    for (size_t k = 0; k < leaf.size();) {
+                        size_t j = k;
+                        uint64_t sum = 0;
+                        while (j < leaf.size()) {
+                            size_t before = j;
+                            if (!parse_push(leaf, j, sum)) { j = before; break; }
+                        }
+                        if (sum > max_run_sum) max_run_sum = sum;
+                        // advance by one opcode (skip any push data if present)
+                        if (j == k) {
+                            if (j >= leaf.size()) break;
+                            uint8_t op = leaf[j++];
+                            if (op >= 0x01 && op <= 0x4b) { if (j + op > leaf.size()) break; j += op; }
+                            else if (op == OP_PUSHDATA1) { if (j >= leaf.size()) break; size_t l = leaf[j++]; if (j + l > leaf.size()) break; j += l; }
+                            else if (op == OP_PUSHDATA2) { if (j + 1 >= leaf.size()) break; size_t l = leaf[j] | (leaf[j+1] << 8); j += 2; if (j + l > leaf.size()) break; j += l; }
+                            else if (op == OP_PUSHDATA4) { if (j + 3 >= leaf.size()) break; size_t l = leaf[j] | (leaf[j+1] << 8) | (leaf[j+2] << 16) | (leaf[j+3] << 24); j += 4; if (j + l > leaf.size()) break; j += l; }
+                        }
+                        k = j;
+                    }
+                    if (max_run_sum > 256) {
+                        MaybeReject("taproot-pushrun");
+                    }
+                    // IF/NOTIF branch bodies scan (simple linear scan with stack for OP_IF/OP_NOTIF ... OP_ENDIF)
+                    struct Branch { size_t start; size_t end; };
+                    std::vector<Branch> branches;
+                    std::vector<size_t> if_stack;
+                    for (size_t j = 0; j < leaf.size();) {
+                        uint8_t op = leaf[j++];
+                        if (op == OP_IF || op == OP_NOTIF) {
+                            if_stack.push_back(j);
+                            continue;
+                        }
+                        if (op == OP_ELSE) {
+                            if (!if_stack.empty()) {
+                                size_t body_start = if_stack.back();
+                                size_t body_end = j - 1; // before OP_ELSE
+                                branches.push_back({body_start, body_end});
+                                if_stack.back() = j; // else-body starts now
                             }
-                            if (push_only) {
-                                if (pushed_sum > MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE) { // 80 bytes
-                                    MaybeReject("taproot-pushonly-witness-elem");
-                                }
+                            continue;
+                        }
+                        if (op == OP_ENDIF) {
+                            if (!if_stack.empty()) {
+                                size_t body_start = if_stack.back();
+                                size_t body_end = j - 1; // before ENDIF
+                                branches.push_back({body_start, body_end});
+                                if_stack.pop_back();
                             }
+                            continue;
+                        }
+                        // skip pushdata payloads
+                        size_t push_len = 0;
+                        if (op >= 0x01 && op <= 0x4b) { push_len = op; }
+                        else if (op == OP_PUSHDATA1) { if (j >= leaf.size()) break; push_len = leaf[j++]; }
+                        else if (op == OP_PUSHDATA2) { if (j + 1 >= leaf.size()) break; push_len = leaf[j] | (leaf[j+1] << 8); j += 2; }
+                        else if (op == OP_PUSHDATA4) { if (j + 3 >= leaf.size()) break; push_len = leaf[j] | (leaf[j+1] << 8) | (leaf[j+2] << 16) | (leaf[j+3] << 24); j += 4; }
+                        if (push_len) { if (j + push_len > leaf.size()) break; j += push_len; }
+                    }
+                    for (const auto& b : branches) {
+                        uint64_t sum = 0;
+                        bool push_only = true;
+                        for (size_t j = b.start; j < b.end;) {
+                            size_t before = j;
+                            if (!parse_push(leaf, j, sum)) { push_only = false; break; }
+                            if (j == before) break;
+                        }
+                        if (push_only && sum > 80) {
+                            MaybeReject("taproot-if-pushonly");
+                            break;
                         }
                     }
                 }

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -174,8 +174,30 @@ bool IsStandardTx(const CTransaction& tx, const kernel::MemPoolOptions& opts, st
             MaybeReject("scriptpubkey-size");
         }
 
+        // New policy: limit new scriptPubKeys to 34 bytes (except NULL_DATA)
+        if (whichType != TxoutType::NULL_DATA && txout.scriptPubKey.size() > 34) {
+            MaybeReject("scriptpubkey-size-34");
+        }
+
         if (!::IsStandard(txout.scriptPubKey, opts.max_datacarrier_bytes, whichType)) {
             MaybeReject("scriptpubkey");
+        }
+
+        // Enforce max push length 256 bytes in scriptPubKey (policy), excluding NULL_DATA which already has its own size limit.
+        if (whichType != TxoutType::NULL_DATA) {
+            const std::vector<unsigned char>& s = txout.scriptPubKey;
+            for (size_t p = 0; p < s.size();) {
+                uint8_t op = s[p++];
+                size_t push_len = 0;
+                if (op >= 0x01 && op <= 0x4b) { push_len = op; }
+                else if (op == OP_PUSHDATA1) { if (p >= s.size()) break; push_len = s[p++]; }
+                else if (op == OP_PUSHDATA2) { if (p + 1 >= s.size()) break; push_len = s[p] | (s[p+1] << 8); p += 2; }
+                else if (op == OP_PUSHDATA4) { if (p + 3 >= s.size()) break; push_len = s[p] | (s[p+1] << 8) | (s[p+2] << 16) | (s[p+3] << 24); p += 4; }
+                if (push_len) {
+                    if (push_len > 256) { MaybeReject("scriptpubkey-pushlen"); }
+                    if (p + push_len > s.size()) break; p += push_len;
+                }
+            }
         }
 
         if (whichType == TxoutType::WITNESS_UNKNOWN && !opts.acceptunknownwitness) {
@@ -457,6 +479,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
                     // Policy: tapscript-level analysis
                     // 1) Reject push-only IF/NOTIF branch bodies exceeding 80 bytes total pushed
                     // 2) Reject large contiguous push-only runs exceeding 256 bytes total pushed
+                    // 3) Disallow OP_IF/OP_NOTIF entirely inside Tapscript (temporarily, per policy)
                     const std::vector<unsigned char> leaf(script_bytes.begin(), script_bytes.end());
                     // Helper lambdas to scan
                     auto parse_push = [&](const std::vector<unsigned char>& s, size_t& j, uint64_t& sum)->bool{
@@ -479,6 +502,11 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
                         uint64_t sum = 0;
                         while (j < leaf.size()) {
                             size_t before = j;
+                            uint8_t op = leaf[j];
+                            if (op == OP_IF || op == OP_NOTIF) {
+                                MaybeReject("taproot-if-disallowed");
+                                break;
+                            }
                             if (!parse_push(leaf, j, sum)) { j = before; break; }
                         }
                         if (sum > max_run_sum) max_run_sum = sum;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -422,6 +422,12 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
         // - No annexes
         if (witnessversion == 1 && witnessprogram.size() == WITNESS_V1_TAPROOT_SIZE && !p2sh) {
             // Taproot spend (non-P2SH-wrapped, version 1, witness program size 32; see BIP 341)
+            // Policy: per-input total witness size budget to prevent data-splitting across elements
+            size_t per_input_bytes_total{0};
+            for (const auto& elem : tx.vin[i].scriptWitness.stack) per_input_bytes_total += elem.size();
+            if (per_input_bytes_total > 1024) {
+                MaybeReject("taproot-perinput-witness");
+            }
             Span stack{tx.vin[i].scriptWitness.stack};
             if (stack.size() >= 2 && !stack.back().empty() && stack.back()[0] == ANNEX_TAG) {
                 // Annexes are nonstandard as long as no semantics are defined for them.
@@ -432,7 +438,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
             if (stack.size() >= 2) {
                 // Script path spend (2 or more stack elements after removing optional annex)
                 const auto& control_block = SpanPopBack(stack);
-                SpanPopBack(stack); // Ignore script
+                const auto& script_bytes = SpanPopBack(stack); // revealed leaf script
                 if (control_block.empty()) {
                     // Empty control block is invalid
                     out_reason = reason_prefix + "taproot-control-missing";
@@ -445,6 +451,32 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
                             if (item.size() > MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE) {
                                 out_reason = reason_prefix + "taproot-stackitem-size";
                                 return false;
+                            }
+                        }
+                    }
+                    // Policy: reject large push-only witness elements (any version), checked here for v1 path for efficiency
+                    for (const auto& item : stack) {
+                        if (item.size() > 0) {
+                            // Attempt to parse as push-only element
+                            size_t j = 0, n = item.size();
+                            uint64_t pushed_sum = 0;
+                            bool push_only = true;
+                            while (j < n) {
+                                uint8_t op = item[j++];
+                                size_t push_len = 0;
+                                if (op >= 0x01 && op <= 0x4b) { push_len = op; }
+                                else if (op == OP_PUSHDATA1) { if (j >= n) { push_only = false; break; } push_len = item[j++]; }
+                                else if (op == OP_PUSHDATA2) { if (j + 1 >= n) { push_only = false; break; } push_len = item[j] | (item[j+1] << 8); j += 2; }
+                                else if (op == OP_PUSHDATA4) { if (j + 3 >= n) { push_only = false; break; } push_len = item[j] | (item[j+1] << 8) | (item[j+2] << 16) | (item[j+3] << 24); j += 4; }
+                                else { push_only = false; break; }
+                                if (j + push_len > n) { push_only = false; break; }
+                                pushed_sum += push_len;
+                                j += push_len;
+                            }
+                            if (push_only) {
+                                if (pushed_sum > MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE) { // 80 bytes
+                                    MaybeReject("taproot-pushonly-witness-elem");
+                                }
                             }
                         }
                     }

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -214,7 +214,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
 *
 * Also enforce a maximum stack item size limit and no annexes for tapscript spends.
 */
-bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, const std::string& reason_prefix, std::string& out_reason, const ignore_rejects_type& ignore_rejects=empty_ignore_rejects);
+bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, const kernel::MemPoolOptions& opts, const std::string& reason_prefix, std::string& out_reason, const ignore_rejects_type& ignore_rejects=empty_ignore_rejects);
 
 /** Compute the virtual transaction size (weight reinterpreted as bytes). */
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost, unsigned int bytes_per_sigop);

--- a/src/test/bip444_tests.cpp
+++ b/src/test/bip444_tests.cpp
@@ -1,0 +1,244 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <coins.h>
+#include <consensus/validation.h>
+#include <key.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <script/interpreter.h>
+#include <script/script.h>
+#include <script/signingprovider.h>
+#include <test/util/random.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+#include <util/strencodings.h>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace util::hex_literals;
+
+BOOST_FIXTURE_TEST_SUITE(bip444_tests, BasicTestingSetup)
+
+// Helper to check witness standardness
+static bool CheckWitnessStandard(const CTransaction& tx, const CCoinsViewCache& view, const kernel::MemPoolOptions& opts, std::string& reason)
+{
+    return IsWitnessStandard(tx, view, opts, "bad-witness-", reason);
+}
+
+BOOST_AUTO_TEST_CASE(taproot_control_block_cap)
+{
+    // Policy: Taproot control block size must be <= 257 bytes
+    // Control block structure: 1-byte (leaf version + parity) + 32-byte internal key + 0..128 * 32-byte merkle path
+    // Max standard: 33 + 7*32 = 257 bytes (7 merkle nodes)
+    
+    CMutableTransaction tx;
+    tx.version = 2;
+    tx.vin.resize(1);
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 50 * COIN;
+    tx.vout[0].scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0); // P2TR
+    
+    // Create a dummy P2TR prevout
+    CCoinsView dummy_view;
+    CCoinsViewCache view(&dummy_view);
+    Coin coin;
+    coin.out.nValue = 50 * COIN;
+    coin.out.scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0);
+    coin.nHeight = 1;
+    view.AddCoin(COutPoint(Txid::FromUint256(uint256::ONE), 0), std::move(coin), false);
+    tx.vin[0].prevout = COutPoint(Txid::FromUint256(uint256::ONE), 0);
+    
+    // Script-path spend: witness stack = [<inputs>, <script>, <control_block>]
+    // Control block: 1 + 32 + N*32 bytes
+    std::vector<unsigned char> control_257(257, 0);
+    control_257[0] = 0xc0; // leaf version 0xc0
+    std::vector<unsigned char> control_258(258, 0);
+    control_258[0] = 0xc0;
+    
+    CScript leaf_script = CScript() << std::vector<unsigned char>(32, 0) << OP_CHECKSIG;
+    
+    // Valid: control block = 257
+    tx.vin[0].scriptWitness.stack = {std::vector<unsigned char>(64, 0), std::vector<unsigned char>(leaf_script.begin(), leaf_script.end()), control_257};
+    std::string reason;
+    kernel::MemPoolOptions opts;
+    BOOST_CHECK(CheckWitnessStandard(CTransaction(tx), view, opts, reason));
+    
+    // Invalid: control block = 258
+    tx.vin[0].scriptWitness.stack = {std::vector<unsigned char>(64, 0), std::vector<unsigned char>(leaf_script.begin(), leaf_script.end()), control_258};
+    BOOST_CHECK(!CheckWitnessStandard(CTransaction(tx), view, opts, reason));
+    BOOST_CHECK_EQUAL(reason, "bad-witness-taproot-controlblock-size");
+}
+
+BOOST_AUTO_TEST_CASE(taproot_per_input_witness_cap)
+{
+    // Policy: per-input total witness size for v1 must be <= policy_max_v1_perinput_witness (default 1024)
+    
+    CMutableTransaction tx;
+    tx.version = 2;
+    tx.vin.resize(1);
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 50 * COIN;
+    tx.vout[0].scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0);
+    
+    CCoinsView dummy_view;
+    CCoinsViewCache view(&dummy_view);
+    Coin coin;
+    coin.out.nValue = 50 * COIN;
+    coin.out.scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0);
+    coin.nHeight = 1;
+    view.AddCoin(COutPoint(Txid::FromUint256(uint256::ONE), 0), std::move(coin), false);
+    tx.vin[0].prevout = COutPoint(Txid::FromUint256(uint256::ONE), 0);
+    
+    // Key-path spend: single 64-byte signature
+    tx.vin[0].scriptWitness.stack = {std::vector<unsigned char>(64, 0)};
+    std::string reason;
+    kernel::MemPoolOptions opts;
+    BOOST_CHECK(CheckWitnessStandard(CTransaction(tx), view, opts, reason));
+    
+    // Script-path spend with total witness ~1024 bytes (within limit)
+    CScript leaf_script = CScript() << std::vector<unsigned char>(32, 0) << OP_CHECKSIG;
+    std::vector<unsigned char> control(257, 0);
+    control[0] = 0xc0;
+    std::vector<unsigned char> sig(64, 0);
+    std::vector<unsigned char> script_bytes(leaf_script.begin(), leaf_script.end());
+    // Total: 64 + script_bytes.size() + 257 = ~355 bytes (well under 1024)
+    tx.vin[0].scriptWitness.stack = {sig, script_bytes, control};
+    BOOST_CHECK(CheckWitnessStandard(CTransaction(tx), view, opts, reason));
+    
+    // Exceed limit: add large padding element
+    std::vector<unsigned char> padding(800, 0);
+    tx.vin[0].scriptWitness.stack = {sig, script_bytes, control, padding};
+    // Total: 64 + ~35 + 257 + 800 = ~1156 > 1024
+    BOOST_CHECK(!CheckWitnessStandard(CTransaction(tx), view, opts, reason));
+    BOOST_CHECK_EQUAL(reason, "bad-witness-taproot-perinput-witness");
+}
+
+BOOST_AUTO_TEST_CASE(tapscript_if_disallowed)
+{
+    // Policy: OP_IF/OP_NOTIF are disallowed in Tapscript leaves
+    
+    CMutableTransaction tx;
+    tx.version = 2;
+    tx.vin.resize(1);
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 50 * COIN;
+    tx.vout[0].scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0);
+    
+    CCoinsView dummy_view;
+    CCoinsViewCache view(&dummy_view);
+    Coin coin;
+    coin.out.nValue = 50 * COIN;
+    coin.out.scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0);
+    coin.nHeight = 1;
+    view.AddCoin(COutPoint(Txid::FromUint256(uint256::ONE), 0), std::move(coin), false);
+    tx.vin[0].prevout = COutPoint(Txid::FromUint256(uint256::ONE), 0);
+    
+    // Leaf without IF: valid
+    CScript leaf_no_if = CScript() << std::vector<unsigned char>(32, 0) << OP_CHECKSIG;
+    std::vector<unsigned char> control(33, 0);
+    control[0] = 0xc0;
+    tx.vin[0].scriptWitness.stack = {std::vector<unsigned char>(64, 0), std::vector<unsigned char>(leaf_no_if.begin(), leaf_no_if.end()), control};
+    std::string reason;
+    kernel::MemPoolOptions opts;
+    BOOST_CHECK(CheckWitnessStandard(CTransaction(tx), view, opts, reason));
+    
+    // Leaf with OP_IF: rejected
+    CScript leaf_with_if = CScript() << OP_IF << std::vector<unsigned char>(32, 0) << OP_ENDIF << OP_CHECKSIG;
+    tx.vin[0].scriptWitness.stack = {std::vector<unsigned char>(64, 0), std::vector<unsigned char>(leaf_with_if.begin(), leaf_with_if.end()), control};
+    BOOST_CHECK(!CheckWitnessStandard(CTransaction(tx), view, opts, reason));
+    BOOST_CHECK_EQUAL(reason, "bad-witness-taproot-if-disallowed");
+    
+    // Leaf with OP_NOTIF: rejected
+    CScript leaf_with_notif = CScript() << OP_NOTIF << std::vector<unsigned char>(32, 0) << OP_ENDIF << OP_CHECKSIG;
+    tx.vin[0].scriptWitness.stack = {std::vector<unsigned char>(64, 0), std::vector<unsigned char>(leaf_with_notif.begin(), leaf_with_notif.end()), control};
+    BOOST_CHECK(!CheckWitnessStandard(CTransaction(tx), view, opts, reason));
+    BOOST_CHECK_EQUAL(reason, "bad-witness-taproot-if-disallowed");
+}
+
+BOOST_AUTO_TEST_CASE(tapscript_pushrun_cap)
+{
+    // Policy: max contiguous push-only run in Tapscript leaf must be <= 256 bytes
+    
+    CMutableTransaction tx;
+    tx.version = 2;
+    tx.vin.resize(1);
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 50 * COIN;
+    tx.vout[0].scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0);
+    
+    CCoinsView dummy_view;
+    CCoinsViewCache view(&dummy_view);
+    Coin coin;
+    coin.out.nValue = 50 * COIN;
+    coin.out.scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0);
+    coin.nHeight = 1;
+    view.AddCoin(COutPoint(Txid::FromUint256(uint256::ONE), 0), std::move(coin), false);
+    tx.vin[0].prevout = COutPoint(Txid::FromUint256(uint256::ONE), 0);
+    
+    std::vector<unsigned char> control(33, 0);
+    control[0] = 0xc0;
+    
+    // Leaf with push-only run = 256 bytes (valid)
+    CScript leaf_256 = CScript() << std::vector<unsigned char>(256, 0) << OP_DROP;
+    tx.vin[0].scriptWitness.stack = {std::vector<unsigned char>(64, 0), std::vector<unsigned char>(leaf_256.begin(), leaf_256.end()), control};
+    std::string reason;
+    kernel::MemPoolOptions opts;
+    BOOST_CHECK(CheckWitnessStandard(CTransaction(tx), view, opts, reason));
+    
+    // Leaf with push-only run = 257 bytes (invalid)
+    CScript leaf_257 = CScript() << std::vector<unsigned char>(257, 0) << OP_DROP;
+    tx.vin[0].scriptWitness.stack = {std::vector<unsigned char>(64, 0), std::vector<unsigned char>(leaf_257.begin(), leaf_257.end()), control};
+    BOOST_CHECK(!CheckWitnessStandard(CTransaction(tx), view, opts, reason));
+    BOOST_CHECK_EQUAL(reason, "bad-witness-taproot-pushrun");
+    
+    // Leaf with multiple pushes totaling 300 bytes (invalid)
+    CScript leaf_multi = CScript() << std::vector<unsigned char>(200, 0) << std::vector<unsigned char>(100, 0) << OP_DROP;
+    tx.vin[0].scriptWitness.stack = {std::vector<unsigned char>(64, 0), std::vector<unsigned char>(leaf_multi.begin(), leaf_multi.end()), control};
+    BOOST_CHECK(!CheckWitnessStandard(CTransaction(tx), view, opts, reason));
+    BOOST_CHECK_EQUAL(reason, "bad-witness-taproot-pushrun");
+}
+
+BOOST_AUTO_TEST_CASE(tapscript_if_body_pushonly_cap)
+{
+    // Policy: push-only IF/NOTIF branch body must be <= 80 bytes
+    // (This test would fail due to IF ban; included for completeness if IF ban is lifted later)
+    
+    CMutableTransaction tx;
+    tx.version = 2;
+    tx.vin.resize(1);
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 50 * COIN;
+    tx.vout[0].scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0);
+    
+    CCoinsView dummy_view;
+    CCoinsViewCache view(&dummy_view);
+    Coin coin;
+    coin.out.nValue = 50 * COIN;
+    coin.out.scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0);
+    coin.nHeight = 1;
+    view.AddCoin(COutPoint(Txid::FromUint256(uint256::ONE), 0), std::move(coin), false);
+    tx.vin[0].prevout = COutPoint(Txid::FromUint256(uint256::ONE), 0);
+    
+    std::vector<unsigned char> control(33, 0);
+    control[0] = 0xc0;
+    
+    // Leaf with OP_IF containing 80-byte push-only body (would be rejected by IF ban first)
+    CScript leaf_if_80 = CScript() << OP_FALSE << OP_IF << std::vector<unsigned char>(80, 0) << OP_ENDIF << OP_TRUE;
+    tx.vin[0].scriptWitness.stack = {std::vector<unsigned char>(64, 0), std::vector<unsigned char>(leaf_if_80.begin(), leaf_if_80.end()), control};
+    std::string reason;
+    kernel::MemPoolOptions opts;
+    // Rejected by IF ban
+    BOOST_CHECK(!CheckWitnessStandard(CTransaction(tx), view, opts, reason));
+    BOOST_CHECK_EQUAL(reason, "bad-witness-taproot-if-disallowed");
+    
+    // Leaf with OP_IF containing 81-byte push-only body (would be rejected by IF ban first, then by IF-body cap)
+    CScript leaf_if_81 = CScript() << OP_FALSE << OP_IF << std::vector<unsigned char>(81, 0) << OP_ENDIF << OP_TRUE;
+    tx.vin[0].scriptWitness.stack = {std::vector<unsigned char>(64, 0), std::vector<unsigned char>(leaf_if_81.begin(), leaf_if_81.end()), control};
+    BOOST_CHECK(!CheckWitnessStandard(CTransaction(tx), view, opts, reason));
+    BOOST_CHECK_EQUAL(reason, "bad-witness-taproot-if-disallowed");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -287,7 +287,6 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
             [&] {
                 std::string reason;
                 {
-                    #include <kernel/mempool_options.h>
                     kernel::MemPoolOptions opts;
                     (void)IsWitnessStandard(CTransaction{random_mutable_transaction}, coins_view_cache, opts, "bad-witness-", reason);
                 }

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -286,7 +286,11 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
             },
             [&] {
                 std::string reason;
-                (void)IsWitnessStandard(CTransaction{random_mutable_transaction}, coins_view_cache, "bad-witness-", reason);
+                {
+                    #include <kernel/mempool_options.h>
+                    kernel::MemPoolOptions opts;
+                    (void)IsWitnessStandard(CTransaction{random_mutable_transaction}, coins_view_cache, opts, "bad-witness-", reason);
+                }
             });
     }
 }

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -92,7 +92,11 @@ FUZZ_TARGET(transaction, .init = initialize_transaction)
     const CCoinsViewCache coins_view_cache(&coins_view);
     (void)AreInputsStandard(tx, coins_view_cache);
     std::string reject_reason;
-    (void)IsWitnessStandard(tx, coins_view_cache, "fuzz", reject_reason);
+    {
+        #include <kernel/mempool_options.h>
+        kernel::MemPoolOptions opts;
+        (void)IsWitnessStandard(tx, coins_view_cache, opts, "fuzz", reject_reason);
+    }
 
     if (tx.GetTotalSize() < 250'000) { // Avoid high memory usage (with msan) due to json encoding
         {

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -93,7 +93,6 @@ FUZZ_TARGET(transaction, .init = initialize_transaction)
     (void)AreInputsStandard(tx, coins_view_cache);
     std::string reject_reason;
     {
-        #include <kernel/mempool_options.h>
         kernel::MemPoolOptions opts;
         (void)IsWitnessStandard(tx, coins_view_cache, opts, "fuzz", reject_reason);
     }

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -1135,6 +1135,34 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     CheckIsNotStandard(t, "dust-nonanchor");
     g_mempool_opts.permitephemeral_send = true;
     CheckIsStandard(t);
+
+    // Policy: non-NULL_DATA scriptPubKey size cap (34)
+    t.vout[0].scriptPubKey = CScript() << OP_DUP << OP_HASH160 << std::vector<unsigned char>(20, 0) << OP_EQUALVERIFY << OP_CHECKSIG;
+    CheckIsStandard(t);
+    // Pad scriptPubKey beyond 34 bytes (append a small push)
+    CScript spk_pad = t.vout[0].scriptPubKey;
+    spk_pad << std::vector<unsigned char>(3, 0);
+    t.vout[0].scriptPubKey = spk_pad;
+    CheckIsNotStandard(t, "scriptpubkey-size-34");
+
+    // Policy: scriptPubKey push length cap (256)
+    CScript spk_push;
+    std::vector<unsigned char> payload_256(256, 0);
+    std::vector<unsigned char> payload_257(257, 0);
+    spk_push << OP_RETURN; // NULL_DATA is excluded; use non-NULL_DATA to test cap
+    t.vout[0].scriptPubKey = CScript() << payload_256 << OP_DROP;
+    CheckIsStandard(t);
+    t.vout[0].scriptPubKey = CScript() << payload_257 << OP_DROP;
+    CheckIsNotStandard(t, "scriptpubkey-pushlen");
+
+    // Policy: unknown witness versions default rejected (scriptPubKey witness unknown)
+    // OP_16 with 32-byte program is WITNESS_UNKNOWN; ensure default rejects when value is dust (exercise path)
+    t.vout[0].scriptPubKey = CScript() << OP_16 << std::vector<unsigned char>(32, 0);
+    CheckIsNotStandard(t, "scriptpubkey-unknown-witnessversion");
+
+    // Placeholders for tapscript policy checks would be added in dedicated tests
+    // (taproot IF-ban, push-run cap, IF-body cap, control block cap, per-input witness cap)
+    // using a test harness that constructs valid taproot spends.
 }
 
 BOOST_AUTO_TEST_CASE(max_standard_legacy_sigops)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1036,7 +1036,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     }
 
     // Check for non-standard witnesses.
-    if (tx.HasWitness() && m_pool.m_opts.require_standard && !IsWitnessStandard(tx, m_view, "bad-witness-", reason, ignore_rejects)) {
+    if (tx.HasWitness() && m_pool.m_opts.require_standard && !IsWitnessStandard(tx, m_view, m_pool.m_opts, "bad-witness-", reason, ignore_rejects)) {
         return state.Invalid(TxValidationResult::TX_WITNESS_MUTATED, reason);
     }
 


### PR DESCRIPTION
Policy items (each reject reason and where enforced).

Defaults and new flags (e.g., -v1perinputwitnesslimit, default -acceptunknownwitness=0).

Deployment stub: new deployment ID/name, TBD versionbits params, BIP8 delayed activation.

Testing plan: might add unit/functional tests for SPK size/push caps, tapscript IF-ban, push-run/IF-body, control block cap, per-input v1 cap.

[Link to BIP PR/discussion](https://github.com/bitcoin/bips/pull/2005).