### PR TITLE
split lcov and genhtml cmake opts for the Coverage profile

### DIFF
--- a/cmake/script/CoverageInclude.cmake.in
+++ b/cmake/script/CoverageInclude.cmake.in
@@ -2,13 +2,6 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-if(NOT DEFINED LCOV_OPTS)
-  set(LCOV_OPTS "$ENV{LCOV_OPTS}")
-endif()
-if(NOT DEFINED GENHTML_OPTS)
-  set(GENHTML_OPTS "$ENV{GENHTML_OPTS}")
-endif()
-
 if("@CMAKE_CXX_COMPILER_ID@" STREQUAL "Clang")
   find_program(LLVM_COV_EXECUTABLE llvm-cov REQUIRED)
   set(COV_TOOL "${LLVM_COV_EXECUTABLE} gcov")
@@ -31,8 +24,8 @@ separate_arguments(LCOV_OPTS)
 set(LCOV_COMMAND ${LCOV_EXECUTABLE} --gcov-tool ${CMAKE_CURRENT_LIST_DIR}/cov_tool_wrapper.sh ${LCOV_OPTS})
 
 find_program(GENHTML_EXECUTABLE genhtml REQUIRED)
-separate_arguments(GENHTML_OPTS)
-set(GENHTML_COMMAND ${GENHTML_EXECUTABLE} --show-details ${GENHTML_OPTS})
+separate_arguments(HTML_OPTS)
+set(GENHTML_COMMAND ${GENHTML_EXECUTABLE} --show-details ${HTML_OPTS})
 
 find_program(GREP_EXECUTABLE grep REQUIRED)
 find_program(AWK_EXECUTABLE awk REQUIRED)

--- a/cmake/script/CoverageInclude.cmake.in
+++ b/cmake/script/CoverageInclude.cmake.in
@@ -26,10 +26,17 @@ set(LCOV_COMMAND ${LCOV_EXECUTABLE} --gcov-tool ${CMAKE_CURRENT_LIST_DIR}/cov_to
 find_program(GENHTML_EXECUTABLE genhtml REQUIRED)
 
 # HTML_OPTS is optionally passed via -D flag.
-# If HTML_OPTS is not provided, implicitly pass LCOV_OPTS to genhtml.
+# If HTML_OPTS is not provided at all, implicitly pass LCOV_OPTS to genhtml.
+# If HTML_OPTS is provided but empty (e.g. -DHTML_OPTS=""), use an empty list
+# and do NOT inherit LCOV_OPTS.
+set(_HTML_OPTS_WAS_DEFINED FALSE)
+if(DEFINED HTML_OPTS)
+  set(_HTML_OPTS_WAS_DEFINED TRUE)
+endif()
 separate_arguments(HTML_OPTS)
-set(GENHTML_OPTS ${HTML_OPTS})
-if(NOT GENHTML_OPTS)
+if(_HTML_OPTS_WAS_DEFINED)
+  set(GENHTML_OPTS ${HTML_OPTS})
+else()
   set(GENHTML_OPTS ${LCOV_OPTS})
 endif()
 set(GENHTML_COMMAND ${GENHTML_EXECUTABLE} --show-details ${GENHTML_OPTS})

--- a/cmake/script/CoverageInclude.cmake.in
+++ b/cmake/script/CoverageInclude.cmake.in
@@ -26,18 +26,11 @@ set(LCOV_COMMAND ${LCOV_EXECUTABLE} --gcov-tool ${CMAKE_CURRENT_LIST_DIR}/cov_to
 find_program(GENHTML_EXECUTABLE genhtml REQUIRED)
 
 # HTML_OPTS is optionally passed via -D flag.
-# If HTML_OPTS is not provided at all, implicitly pass LCOV_OPTS to genhtml.
-# If HTML_OPTS is provided but empty (e.g. -DHTML_OPTS=""), use an empty list
-# and do NOT inherit LCOV_OPTS.
-set(_HTML_OPTS_WAS_DEFINED FALSE)
+# Default: inherit LCOV_OPTS. If HTML_OPTS is provided (even if empty), use it instead.
+set(GENHTML_OPTS ${LCOV_OPTS})
 if(DEFINED HTML_OPTS)
-  set(_HTML_OPTS_WAS_DEFINED TRUE)
-endif()
-separate_arguments(HTML_OPTS)
-if(_HTML_OPTS_WAS_DEFINED)
+  separate_arguments(HTML_OPTS)
   set(GENHTML_OPTS ${HTML_OPTS})
-else()
-  set(GENHTML_OPTS ${LCOV_OPTS})
 endif()
 set(GENHTML_COMMAND ${GENHTML_EXECUTABLE} --show-details ${GENHTML_OPTS})
 

--- a/cmake/script/CoverageInclude.cmake.in
+++ b/cmake/script/CoverageInclude.cmake.in
@@ -24,8 +24,13 @@ separate_arguments(LCOV_OPTS)
 set(LCOV_COMMAND ${LCOV_EXECUTABLE} --gcov-tool ${CMAKE_CURRENT_LIST_DIR}/cov_tool_wrapper.sh ${LCOV_OPTS})
 
 find_program(GENHTML_EXECUTABLE genhtml REQUIRED)
+# If HTML_OPTS is not provided, implicitly pass LCOV_OPTS to genhtml.
 separate_arguments(HTML_OPTS)
-set(GENHTML_COMMAND ${GENHTML_EXECUTABLE} --show-details ${HTML_OPTS})
+set(GENHTML_OPTS ${HTML_OPTS})
+if(NOT GENHTML_OPTS)
+  set(GENHTML_OPTS ${LCOV_OPTS})
+endif()
+set(GENHTML_COMMAND ${GENHTML_EXECUTABLE} --show-details ${GENHTML_OPTS})
 
 find_program(GREP_EXECUTABLE grep REQUIRED)
 find_program(AWK_EXECUTABLE awk REQUIRED)

--- a/cmake/script/CoverageInclude.cmake.in
+++ b/cmake/script/CoverageInclude.cmake.in
@@ -24,6 +24,8 @@ separate_arguments(LCOV_OPTS)
 set(LCOV_COMMAND ${LCOV_EXECUTABLE} --gcov-tool ${CMAKE_CURRENT_LIST_DIR}/cov_tool_wrapper.sh ${LCOV_OPTS})
 
 find_program(GENHTML_EXECUTABLE genhtml REQUIRED)
+
+# HTML_OPTS is optionally passed via -D flag.
 # If HTML_OPTS is not provided, implicitly pass LCOV_OPTS to genhtml.
 separate_arguments(HTML_OPTS)
 set(GENHTML_OPTS ${HTML_OPTS})

--- a/cmake/script/CoverageInclude.cmake.in
+++ b/cmake/script/CoverageInclude.cmake.in
@@ -11,9 +11,6 @@ endif()
 separate_arguments(LCOV_OPTS)
 separate_arguments(GENHTML_OPTS)
 
-set(LCOV_COMMAND ${LCOV_EXECUTABLE} --gcov-tool ${CMAKE_CURRENT_LIST_DIR}/cov_tool_wrapper.sh ${LCOV_OPTS})
-set(GENHTML_COMMAND ${GENHTML_EXECUTABLE} --show-details ${GENHTML_OPTS})
-
 list(APPEND LCOV_FILTER_COMMAND -p "CMakeFiles/")
 
 if("@CMAKE_CXX_COMPILER_ID@" STREQUAL "Clang")

--- a/cmake/script/CoverageInclude.cmake.in
+++ b/cmake/script/CoverageInclude.cmake.in
@@ -2,6 +2,20 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
+if(NOT DEFINED LCOV_OPTS)
+  set(LCOV_OPTS "$ENV{LCOV_OPTS}")
+endif()
+if(NOT DEFINED GENHTML_OPTS)
+  set(GENHTML_OPTS "$ENV{GENHTML_OPTS}")
+endif()
+separate_arguments(LCOV_OPTS)
+separate_arguments(GENHTML_OPTS)
+
+set(LCOV_COMMAND ${LCOV_EXECUTABLE} --gcov-tool ${CMAKE_CURRENT_LIST_DIR}/cov_tool_wrapper.sh ${LCOV_OPTS})
+set(GENHTML_COMMAND ${GENHTML_EXECUTABLE} --show-details ${GENHTML_OPTS})
+
+list(APPEND LCOV_FILTER_COMMAND -p "CMakeFiles/")
+
 if("@CMAKE_CXX_COMPILER_ID@" STREQUAL "Clang")
   find_program(LLVM_COV_EXECUTABLE llvm-cov REQUIRED)
   set(COV_TOOL "${LLVM_COV_EXECUTABLE} gcov")
@@ -24,7 +38,7 @@ separate_arguments(LCOV_OPTS)
 set(LCOV_COMMAND ${LCOV_EXECUTABLE} --gcov-tool ${CMAKE_CURRENT_LIST_DIR}/cov_tool_wrapper.sh ${LCOV_OPTS})
 
 find_program(GENHTML_EXECUTABLE genhtml REQUIRED)
-set(GENHTML_COMMAND ${GENHTML_EXECUTABLE} --show-details ${LCOV_OPTS})
+set(GENHTML_COMMAND ${GENHTML_EXECUTABLE} --show-details ${GENHTML_OPTS})
 
 find_program(GREP_EXECUTABLE grep REQUIRED)
 find_program(AWK_EXECUTABLE awk REQUIRED)

--- a/cmake/script/CoverageInclude.cmake.in
+++ b/cmake/script/CoverageInclude.cmake.in
@@ -8,10 +8,6 @@ endif()
 if(NOT DEFINED GENHTML_OPTS)
   set(GENHTML_OPTS "$ENV{GENHTML_OPTS}")
 endif()
-separate_arguments(LCOV_OPTS)
-separate_arguments(GENHTML_OPTS)
-
-list(APPEND LCOV_FILTER_COMMAND -p "CMakeFiles/")
 
 if("@CMAKE_CXX_COMPILER_ID@" STREQUAL "Clang")
   find_program(LLVM_COV_EXECUTABLE llvm-cov REQUIRED)
@@ -35,6 +31,7 @@ separate_arguments(LCOV_OPTS)
 set(LCOV_COMMAND ${LCOV_EXECUTABLE} --gcov-tool ${CMAKE_CURRENT_LIST_DIR}/cov_tool_wrapper.sh ${LCOV_OPTS})
 
 find_program(GENHTML_EXECUTABLE genhtml REQUIRED)
+separate_arguments(GENHTML_OPTS)
 set(GENHTML_COMMAND ${GENHTML_EXECUTABLE} --show-details ${GENHTML_OPTS})
 
 find_program(GREP_EXECUTABLE grep REQUIRED)

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -508,7 +508,7 @@ enabled by setting `LCOV_OPTS="--rc branch_coverage=1"`:
 cmake -DLCOV_OPTS="--rc branch_coverage=1" -P build/Coverage.cmake
 ```
 
-HTML_OPTS can be specified to provide options to genhtml, the program that generates the
+HTML_OPTS can be specified to provide an options override to genhtml from the default LCOV_OPTS, the program that generates the
 html report from lcov: `HTML_OPTS="--exclude boost"`.
 
 ```

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -508,8 +508,7 @@ enabled by setting `LCOV_OPTS="--rc branch_coverage=1"`:
 cmake -DLCOV_OPTS="--rc branch_coverage=1" -P build/Coverage.cmake
 ```
 
-HTML_OPTS can be specified to provide an options override to genhtml from the default LCOV_OPTS, the program that generates the
-html report from lcov: `HTML_OPTS="--exclude boost"`.
+HTML_OPTS can override the genhtml options (which default to LCOV_OPTS).
 
 ```
 cmake -DHTML_OPTS="--exclude boost" -P build/Coverage.cmake

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -508,8 +508,12 @@ enabled by setting `LCOV_OPTS="--rc branch_coverage=1"`:
 cmake -DLCOV_OPTS="--rc branch_coverage=1" -P build/Coverage.cmake
 ```
 
-GENHTML_OPTS can be specified to provide options to genhtml, the program that generates the
-html report from lcov: `GENHTML_OPTS="--exclude boost"`.
+HTML_OPTS can be specified to provide options to genhtml, the program that generates the
+html report from lcov: `HTML_OPTS="--exclude boost"`.
+
+```
+cmake -DHTML_OPTS="--exclude boost" -P build/Coverage.cmake
+```
 
 To enable test parallelism:
 ```

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -508,10 +508,15 @@ enabled by setting `LCOV_OPTS="--rc branch_coverage=1"`:
 cmake -DLCOV_OPTS="--rc branch_coverage=1" -P build/Coverage.cmake
 ```
 
-HTML_OPTS can override the genhtml options (which default to LCOV_OPTS).
+HTML_OPTS can override the genhtml options (which default to LCOV_OPTS). If HTML_OPTS is omitted, LCOV_OPTS are implicitly passed to genhtml. If HTML_OPTS is provided but empty (e.g. -DHTML_OPTS=""), no options are passed to genhtml and LCOV_OPTS are not inherited.
 
+Examples:
 ```
-cmake -DHTML_OPTS="--exclude boost" -P build/Coverage.cmake
+# Override genhtml options explicitly
+cmake -DHTML_OPTS="--title 'Knots Coverage'" -P build/Coverage.cmake
+
+# Provide an empty override: pass nothing to genhtml (do not inherit LCOV_OPTS)
+cmake -DHTML_OPTS="" -P build/Coverage.cmake
 ```
 
 To enable test parallelism:

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -508,6 +508,9 @@ enabled by setting `LCOV_OPTS="--rc branch_coverage=1"`:
 cmake -DLCOV_OPTS="--rc branch_coverage=1" -P build/Coverage.cmake
 ```
 
+GENHTML_OPTS can be specified to provide options to genhtml, the program that generates the
+html report from lcov: `GENHTML_OPTS="--exclude boost"`.
+
 To enable test parallelism:
 ```
 cmake -DJOBS=$(nproc) -P build/Coverage.cmake


### PR DESCRIPTION
### Summary
Introduce `HTML_OPTS` for `genhtml` with a sensible default: inherit `LCOV_OPTS` when `HTML_OPTS` is not provided. This removes duplication for shared settings while keeping a clear escape hatch for `genhtml`-specific control.

### Background (previous behavior)
- The HTML report generator (`genhtml`) always received `LCOV_OPTS`.
- This worked well for shared runtime config (notably `--rc` flags like `branch_coverage=1`) but made it awkward to pass options that apply only to `genhtml`.

### What’s changing
- Add a dedicated variable, `HTML_OPTS`, for `genhtml`.
- Default behavior: if `HTML_OPTS` is omitted, pass `LCOV_OPTS` to `genhtml` (maintains the historical behavior and keeps shared config in sync).
- Override behavior: if `HTML_OPTS` is provided, use it instead of `LCOV_OPTS` for `genhtml`.
- Empty override: if `HTML_OPTS` is explicitly set to an empty string, pass no extra options to `genhtml` and do not inherit `LCOV_OPTS`.

### Why this change
- `lcov` and `genhtml` are separate tools with partially overlapping options.
- Many useful settings are shared (e.g., `--rc`), but some are `genhtml`-only (e.g., `--title`).
- This change avoids duplicating shared options while enabling precise control of `genhtml` when needed.

### User-facing behavior
- Omitted: `genhtml` receives `LCOV_OPTS` automatically.
- Provided: `genhtml` receives `HTML_OPTS` instead of `LCOV_OPTS`.
- Explicitly empty: `genhtml` receives no options; nothing is inherited.

### Examples
```sh
# Single place to enable branch coverage (LCOV 2.x) for both tools
cmake -DLCOV_OPTS="--rc branch_coverage=1" -P build/Coverage.cmake

# genhtml-only customization (does not affect lcov)
cmake -DHTML_OPTS="--title 'Knots Coverage'" -P build/Coverage.cmake

# Intentionally pass no genhtml options (do not inherit LCOV_OPTS)
cmake -DHTML_OPTS="" -P build/Coverage.cmake
```

### Implementation notes
- In `cmake/script/CoverageInclude.cmake.in`:
  - Detect whether `HTML_OPTS` was defined (even if empty) before splitting.
  - Set `GENHTML_OPTS` to `HTML_OPTS` when defined; otherwise fall back to `LCOV_OPTS`.
  - Build `GENHTML_COMMAND` with `GENHTML_OPTS`.

Key snippet:
```cmake
# HTML_OPTS is optionally passed via -D flag.
# If HTML_OPTS is not provided at all, implicitly pass LCOV_OPTS to genhtml.
# If HTML_OPTS is provided but empty (e.g. -DHTML_OPTS=""), use an empty list
# and do NOT inherit LCOV_OPTS.
set(_HTML_OPTS_WAS_DEFINED FALSE)
if(DEFINED HTML_OPTS)
  set(_HTML_OPTS_WAS_DEFINED TRUE)
endif()
separate_arguments(HTML_OPTS)
if(_HTML_OPTS_WAS_DEFINED)
  set(GENHTML_OPTS ${HTML_OPTS})
else()
  set(GENHTML_OPTS ${LCOV_OPTS})
endif()
set(GENHTML_COMMAND ${GENHTML_EXECUTABLE} --show-details ${GENHTML_OPTS})
```

### Backward compatibility
- Matches historical default: when `HTML_OPTS` is omitted, `genhtml` still receives `LCOV_OPTS`.
- Existing setups that already provided `HTML_OPTS` continue to behave as before.
- Adds a new, explicit way to pass no `genhtml` options via `-DHTML_OPTS=""`.

### Documentation
- Updated `doc/developer-notes.md` to describe the default inheritance, the explicit override, and the empty override, with examples using a `genhtml`-only flag (`--title`).

### Impact and risk
- Low risk, confined to coverage tooling. Improves consistency for shared settings while enabling `genhtml`-specific customization and intentional minimalism.


<img width="1721" height="977" alt="Screenshot 2025-10-16 at 02 23 36" src="https://github.com/user-attachments/assets/88de3917-a473-4446-be03-300b40977889" />


