### PR TITLE
qt: Fix min relay fee in mempool stats

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1686,7 +1686,7 @@ MempoolAcceptResult MemPoolAccept::AcceptSingleTransaction(const CTransactionRef
     AssertLockHeld(cs_main);
     LOCK(m_pool.cs); // mempool "read lock" (held through m_pool.m_opts.signals->TransactionAddedToMempool())
 
-    const CFeeRate mempool_min_fee_rate = m_pool.GetMinFee();
+    const CFeeRate mempool_min_fee_rate = std::max(m_pool.GetMinFee(), m_pool.m_opts.min_relay_feerate);
 
     Workspace ws(ptx);
     const std::vector<Wtxid> single_wtxid{ws.m_ptx->GetWitnessHash()};


### PR DESCRIPTION
It is always shown as zero in the mempool stats. I’m not sure if this line affects other things as well. 

<img width="475" height="407" alt="image" src="https://github.com/user-attachments/assets/5aeda5bb-188e-4c93-8484-09c696df2632" />