### PR TITLE
init: clean up load chainstate function

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5039,16 +5039,16 @@ void PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight
 bool Chainstate::LoadChainTip()
 {
     AssertLockHeld(cs_main);
-    const CCoinsViewCache& coins_cache = CoinsTip();
-    assert(!coins_cache.GetBestBlock().IsNull()); // Never called when the coins view is empty
+    uint256 coins_view_best_block_hash = CoinsTip().GetBestBlock();
+    assert(!coins_view_best_block_hash.IsNull()); // Never called when the coins view is empty
     CBlockIndex* tip = m_chain.Tip();
 
-    if (tip && tip->GetBlockHash() == coins_cache.GetBestBlock()) {
+    if (tip && tip->GetBlockHash() == coins_view_best_block_hash) {
         return true;
     }
 
     // Load pointer to end of best chain
-    CBlockIndex* pindex = m_blockman.LookupBlockIndex(coins_cache.GetBestBlock());
+    CBlockIndex* pindex = m_blockman.LookupBlockIndex(coins_view_best_block_hash);
     if (!pindex) {
         return false;
     }
@@ -5067,8 +5067,7 @@ bool Chainstate::LoadChainTip()
     }
     PruneBlockIndexCandidates();
 
-    tip = m_chain.Tip();
-    LogPrintf("Loaded best chain: hashBestChain=%s height=%d date=%s progress=%f\n",
+    LogInfo("Loaded best chain: hashBestChain=%s height=%d date=%s progress=%f",
               tip->GetBlockHash().ToString(),
               m_chain.Height(),
               FormatISO8601DateTime(tip->GetBlockTime()),


### PR DESCRIPTION
Cleaning up `LoadChainTip` function, had some unnecessary/redundant lines of code, more specifically:
- removing repetitive call to `GetBestBlock()`
- removing extra call to `tip = m_chain.Tip();`
- Changing call from `LogPrintf` to `LogInfo`
