### PR TITLE
rpc: add expiry field to getgeneralinfo

### DIFF
--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -209,6 +209,7 @@ static RPCHelpMan getgeneralinfo()
                         {RPCResult::Type::STR, "datadir", "Data directory path"},
                         {RPCResult::Type::STR, "blocksdir", "Blocks directory path"},
                         {RPCResult::Type::NUM, "startuptime", "Startup time"},
+                        {RPCResult::Type::NUM_TIME, "expiry", "Expiry timestamp (0 = disabled)"}
                     }
                 },
                 RPCExamples{
@@ -218,6 +219,7 @@ static RPCHelpMan getgeneralinfo()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
         const ArgsManager& args{EnsureAnyArgsman(request.context)};
+        int64_t expiry = g_software_expiry <= 0 ? 0 : g_software_expiry;
 
         UniValue obj(UniValue::VOBJ);
         obj.pushKV("clientversion", FormatFullVersion());
@@ -225,6 +227,8 @@ static RPCHelpMan getgeneralinfo()
         obj.pushKV("datadir", fs::PathToString(args.GetDataDirNet()));
         obj.pushKV("blocksdir", fs::PathToString(args.GetBlocksDirPath()));
         obj.pushKV("startuptime", TicksSinceEpoch<std::chrono::seconds>(NodeClock::now() - GetUptime()));
+        obj.pushKV("expiry", expiry);
+
         return obj;
 },
     };

--- a/test/functional/feature_softwareexpiry.py
+++ b/test/functional/feature_softwareexpiry.py
@@ -56,6 +56,25 @@ class SoftwareExpiryTest(BitcoinTestFramework):
         alerts_path.unlink()
         return stderr.rstrip()
 
+    def _test_getdisabledexpiry(self):
+        self.restart_node(0, extra_args=[
+            f'-mocktime={self.mocktime}',
+            '-softwareexpiry=3000000000',
+        ])
+        expiry = self.nodes[0].getgeneralinfo()
+        assert_equal(expiry['expiry'], 3000000000)
+        self.restart_node(0, extra_args=[
+            f'-mocktime={self.mocktime}',
+            '-softwareexpiry=0',
+        ])
+        expiry = self.nodes[0].getgeneralinfo()
+        assert_equal(expiry['expiry'], 0)
+        self.restart_node(0, extra_args=[
+            f'-mocktime={self.mocktime}',
+            '-softwareexpiry=-1',
+        ])
+        assert_equal(expiry['expiry'], 0)
+
     def run_test(self):
         nodes = self.nodes
         addr = nodes[0].get_deterministic_priv_key().address  # what address is irrelevant
@@ -149,6 +168,8 @@ class SoftwareExpiryTest(BitcoinTestFramework):
         self.log.info("Checking no unexpected alerts were triggered")
         assert not alerts_path.exists()
 
+        self.log.info("Checking expiry field when softwareexpiry is disabled in getgeneralinfo")
+        self._test_getdisabledexpiry()
 
 if __name__ == "__main__":
     SoftwareExpiryTest(__file__).main()


### PR DESCRIPTION
Useful for external software who want to be able to fetch when `bitcoind` will expire.
