### PR TITLE
script: initialise `fingerprint` in `KeyOriginInfo`

### DIFF
--- a/src/script/keyorigin.h
+++ b/src/script/keyorigin.h
@@ -10,7 +10,7 @@
 
 struct KeyOriginInfo
 {
-    unsigned char fingerprint[4]; //!< First 32 bits of the Hash160 of the public key at the root of the path
+    unsigned char fingerprint[4] = {}; //!< First 32 bits of the Hash160 of the public key at the root of the path
     std::vector<uint32_t> path;
 
     friend bool operator==(const KeyOriginInfo& a, const KeyOriginInfo& b)


### PR DESCRIPTION
Fix this compilation warning:

```
In file included from /home/<user>/bitcoin/src/script/signingprovider.cpp:6:
In copy constructor ‘constexpr KeyOriginInfo::KeyOriginInfo(const KeyOriginInfo&)’,
    inlined from ‘constexpr std::pair<_T1, _T2>::pair(_U1&&, _U2&&) [with _U1 = CPubKey&; _U2 = KeyOriginInfo&; _T1 = CPubKey; _T2 = KeyOriginInfo]’ at /usr/include/c++/12/bits/stl_pair.h:281:35,
    inlined from ‘constexpr std::pair<typename std::__strip_reference_wrapper<typename std::decay<_Tp>::type>::__type, typename std::__strip_reference_wrapper<typename std::decay<_Tp2>::type>::__type> std::make_pair(_T1&&, _T2&&) [with _T1 = CPubKey&; _T2 = KeyOriginInfo&]’ at /usr/include/c++/12/bits/stl_pair.h:746:72,
    inlined from ‘void FlatSigningProvider::AddMasterKey(const CExtKey&)’ at /home/<user>/bitcoin/src/script/signingprovider.cpp:93:33:
/home/<user>/bitcoin/src/script/keyorigin.h:11:8: warning: ‘origin.KeyOriginInfo::fingerprint’ may be used uninitialized [-Wmaybe-uninitialized]
   11 | struct KeyOriginInfo
      |        ^~~~~~~~~~~~~
/home/<user>/bitcoin/src/script/signingprovider.cpp: In member function ‘void FlatSigningProvider::AddMasterKey(const CExtKey&)’:
/home/<user>/bitcoin/src/script/signingprovider.cpp:91:19: note: ‘origin’ declared here
   91 |     KeyOriginInfo origin;
      |                   ^~~~~~
```