### PR TITLE
build: move hardening flags to dedicated cmake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,7 @@ add_library(external_lib_interface INTERFACE)
 
 include(TryAppendCXXFlags)
 include(TryAppendLinkerFlag)
+include(Hardening)
 
 try_append_linker_flag("-Wl,--no-undefined" TARGET external_lib_interface)
 
@@ -574,70 +575,8 @@ try_append_cxx_flags("-fmacro-prefix-map=A=B" TARGET core_interface SKIP_LINK
   IF_CHECK_PASSED "-fmacro-prefix-map=${PROJECT_SOURCE_DIR}/src=."
 )
 
-# Currently all versions of gcc are subject to a class of bugs, see the
-# gccbug_90348 test case (only reproduces on GCC 11 and earlier) and
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111843. To work around that, set
-# -fstack-reuse=none for all gcc builds. (Only gcc understands this flag).
-try_append_cxx_flags("-fstack-reuse=none" TARGET core_interface)
-
-if(ENABLE_HARDENING)
-  add_library(hardening_interface INTERFACE)
-  target_link_libraries(core_interface INTERFACE hardening_interface)
-  if(MSVC)
-    try_append_linker_flag("/DYNAMICBASE" TARGET hardening_interface)
-    try_append_linker_flag("/HIGHENTROPYVA" TARGET hardening_interface)
-    try_append_linker_flag("/NXCOMPAT" TARGET hardening_interface)
-  else()
-
-    # _FORTIFY_SOURCE requires that there is some level of optimization,
-    # otherwise it does nothing and just creates a compiler warning.
-    try_append_cxx_flags("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"
-      RESULT_VAR cxx_supports_fortify_source
-      SOURCE "int main() {
-              # if !defined __OPTIMIZE__ || __OPTIMIZE__ <= 0
-                #error
-              #endif
-              }"
-    )
-    if(cxx_supports_fortify_source)
-      target_compile_options(hardening_interface INTERFACE
-        -U_FORTIFY_SOURCE
-        -D_FORTIFY_SOURCE=3
-      )
-    endif()
-    unset(cxx_supports_fortify_source)
-
-    try_append_cxx_flags("-Wstack-protector" TARGET hardening_interface SKIP_LINK)
-    try_append_cxx_flags("-fstack-protector-all" TARGET hardening_interface)
-    try_append_cxx_flags("-fcf-protection=full" TARGET hardening_interface)
-
-    if(MINGW)
-      # stack-clash-protection is a no-op for Windows.
-      # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458 for more details.
-    else()
-      try_append_cxx_flags("-fstack-clash-protection" TARGET hardening_interface)
-    endif()
-
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-      if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-        try_append_cxx_flags("-mbranch-protection=bti" TARGET hardening_interface SKIP_LINK)
-      else()
-        try_append_cxx_flags("-mbranch-protection=standard" TARGET hardening_interface SKIP_LINK)
-      endif()
-    endif()
-
-    try_append_linker_flag("-Wl,--enable-reloc-section" TARGET hardening_interface)
-    try_append_linker_flag("-Wl,--dynamicbase" TARGET hardening_interface)
-    try_append_linker_flag("-Wl,--nxcompat" TARGET hardening_interface)
-    try_append_linker_flag("-Wl,--high-entropy-va" TARGET hardening_interface)
-    try_append_linker_flag("-Wl,-z,relro" TARGET hardening_interface)
-    try_append_linker_flag("-Wl,-z,now" TARGET hardening_interface)
-    try_append_linker_flag("-Wl,-z,separate-code" TARGET hardening_interface)
-    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-      try_append_linker_flag("-Wl,-fixup_chains" TARGET hardening_interface)
-    endif()
-  endif()
-endif()
+setup_hardening()
+target_link_libraries(core_interface INTERFACE hardening_interface)
 
 if(REDUCE_EXPORTS)
   set(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/cmake/module/Hardening.cmake
+++ b/cmake/module/Hardening.cmake
@@ -1,0 +1,64 @@
+# Copyright (c) 2023-present The Bitcoin Core developers
+# Copyright (c) 2026-present The Bitcoin Knots developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+include_guard(GLOBAL)
+
+function(setup_hardening)
+  add_library(compiler_workarounds INTERFACE)
+  try_append_cxx_flags("-fstack-reuse=none" TARGET compiler_workarounds)
+
+  add_library(hardening_interface INTERFACE)
+  target_link_libraries(hardening_interface INTERFACE compiler_workarounds)
+
+  if(ENABLE_HARDENING)
+    if(MSVC)
+      try_append_linker_flag("/DYNAMICBASE" TARGET hardening_interface)
+      try_append_linker_flag("/HIGHENTROPYVA" TARGET hardening_interface)
+      try_append_linker_flag("/NXCOMPAT" TARGET hardening_interface)
+    else()
+      try_append_cxx_flags("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"
+        RESULT_VAR cxx_supports_fortify_source
+        SOURCE "int main() {
+                # if !defined __OPTIMIZE__ || __OPTIMIZE__ <= 0
+                  #error
+                #endif
+                }"
+      )
+      if(cxx_supports_fortify_source)
+        target_compile_options(hardening_interface INTERFACE
+          -U_FORTIFY_SOURCE
+          -D_FORTIFY_SOURCE=3
+        )
+      endif()
+
+      try_append_cxx_flags("-Wstack-protector" TARGET hardening_interface SKIP_LINK)
+      try_append_cxx_flags("-fstack-protector-all" TARGET hardening_interface)
+      try_append_cxx_flags("-fcf-protection=full" TARGET hardening_interface)
+
+      if(NOT MINGW)
+        try_append_cxx_flags("-fstack-clash-protection" TARGET hardening_interface)
+      endif()
+
+      if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+        if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+          try_append_cxx_flags("-mbranch-protection=bti" TARGET hardening_interface SKIP_LINK)
+        else()
+          try_append_cxx_flags("-mbranch-protection=standard" TARGET hardening_interface SKIP_LINK)
+        endif()
+      endif()
+
+      try_append_linker_flag("-Wl,--enable-reloc-section" TARGET hardening_interface)
+      try_append_linker_flag("-Wl,--dynamicbase" TARGET hardening_interface)
+      try_append_linker_flag("-Wl,--nxcompat" TARGET hardening_interface)
+      try_append_linker_flag("-Wl,--high-entropy-va" TARGET hardening_interface)
+      try_append_linker_flag("-Wl,-z,relro" TARGET hardening_interface)
+      try_append_linker_flag("-Wl,-z,now" TARGET hardening_interface)
+      try_append_linker_flag("-Wl,-z,separate-code" TARGET hardening_interface)
+      if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        try_append_linker_flag("-Wl,-fixup_chains" TARGET hardening_interface)
+      endif()
+    endif()
+  endif()
+endfunction()


### PR DESCRIPTION
Moves the hardening flag logic out of `CMakeLists.txt` into `cmake/module/Hardening.cmake`.

`setup_hardening()` builds the `hardening_interface` target that `core_interface` links. The flags are moved verbatim, so nothing changes about what gets applied; the point is that the same logic can be reused instead of duplicated.

Split out of https://github.com/bitcoinknots/bitcoin/pull/237#pullrequestreview-3699533477
