### PR TITLE
COPYING: Fix copyright notice dating and add Bitcoin Knots attribution

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,8 @@
 The MIT License (MIT)
 
-Copyright (c) 2009-2025 The Bitcoin Core developers
-Copyright (c) 2009-2025 Bitcoin Developers
+Copyright (c) 2009-2014 Bitcoin Developers
+Copyright (c) 2014-2026 The Bitcoin Core developers
+Copyright (c) 2011-2026 Bitcoin Knots developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Fixes inaccurate copyright date ranges, updates to 2026, and adds missing Bitcoin Knots attribution.

Closes #257

## Changes

**Before:**
```
Copyright (c) 2009-2025 The Bitcoin Core developers
Copyright (c) 2009-2025 Bitcoin Developers
```

**After:**
```
Copyright (c) 2009-2014 Bitcoin Developers
Copyright (c) 2014-2026 The Bitcoin Core developers
Copyright (c) 2011-2026 Bitcoin Knots developers
```

## Rationale

The git history of `bitcoin/bitcoin` shows:
- Satoshi's original notice was `Copyright (c) 2009 Satoshi Nakamoto`
- Satoshi himself changed it to `Bitcoin Developers` in his final v0.3.19 release (`fc73ad644f0b`, Dec 2010)
- The project continued as "Bitcoin" with "Bitcoin Developers" until the rebrand to "Bitcoin Core" in v0.9.0 (March 2014)
- In 2015, a third party replaced it with `The Bitcoin Core developers` backdated to 2009 — a project name that didn't exist until ~2014
- gmaxwell partially fixed this in 2017 (bitcoin/bitcoin#11318) by restoring `Bitcoin Developers` as a second line, but the backdating was never corrected

This PR:
1. Restores `Bitcoin Developers` (Satoshi's chosen notice) to first position with accurate dates (2009-2014, the pre-Core era)
2. Corrects `The Bitcoin Core developers` date range to 2014+ when that project name actually existed
3. Adds `Bitcoin Knots developers` attribution for Knots-specific contributions since 2011
4. Updates copyright years to 2026