### PR TITLE
init: improve error message when index needs pruned block data

### DIFF
--- a/src/index/base.h
+++ b/src/index/base.h
@@ -10,6 +10,7 @@
 #include <interfaces/types.h>
 #include <util/string.h>
 #include <util/threadinterrupt.h>
+#include <util/translation.h>
 #include <validationinterface.h>
 
 #include <string>
@@ -133,6 +134,10 @@ public:
 
     /// Get the name of the index for display in logs.
     const std::string& GetName() const LIFETIMEBOUND { return m_name; }
+
+    /// Get the action the user should take to disable this index, including the verb
+    /// (e.g., "set -txindex=0" or "remove 'basic' from -blockfilterindex").
+    virtual bilingual_str GetDisableAction() const = 0;
 
     /// Blocks the current thread until the index is caught up to the current
     /// state of the block chain. This only blocks if the index has gotten in

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -112,6 +112,11 @@ BlockFilterIndex::BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, Blo
     m_filter_fileseq = std::make_unique<FlatFileSeq>(std::move(path), "fltr", FLTR_FILE_CHUNK_SIZE);
 }
 
+bilingual_str BlockFilterIndex::GetDisableAction() const
+{
+    return strprintf(_("remove \"%s\" from -blockfilterindex"), BlockFilterTypeName(m_filter_type));
+}
+
 bool BlockFilterIndex::CustomInit(const std::optional<interfaces::BlockRef>& block)
 {
     if (!m_db->Read(DB_FILTER_POS, m_next_filter_pos)) {

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -46,6 +46,7 @@ private:
     uint256 m_last_header{};
 
     bool AllowPrune() const override { return true; }
+    bilingual_str GetDisableAction() const override;
 
     bool Write(const BlockFilter& filter, uint32_t block_height, const uint256& filter_header);
 

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -41,6 +41,7 @@ private:
     [[nodiscard]] bool ReverseBlock(const CBlock& block, const CBlockIndex* pindex);
 
     bool AllowPrune() const override { return true; }
+    bilingual_str GetDisableAction() const override { return _("set -coinstatsindex=0"); }
 
 protected:
     bool CustomInit(const std::optional<interfaces::BlockRef>& block) override;

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -23,6 +23,7 @@ private:
     const std::unique_ptr<DB> m_db;
 
     bool AllowPrune() const override { return false; }
+    bilingual_str GetDisableAction() const override { return _("set -txindex=0"); }
 
 protected:
     bool CustomAppend(const interfaces::BlockInfo& block) override;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2091,7 +2091,7 @@ bool StartIndexBackgroundSync(NodeContext& node)
     // starting from that point up to the current tip.
     // indexes_start_block='nullptr' means "start from height 0".
     std::optional<const CBlockIndex*> indexes_start_block;
-    std::string older_index_name;
+    BaseIndex* older_index{nullptr};
     ChainstateManager& chainman = *Assert(node.chainman);
     const Chainstate& chainstate = WITH_LOCK(::cs_main, return chainman.GetChainstateForIndexing());
     const CChain& index_chain = chainstate.m_chain;
@@ -2109,7 +2109,7 @@ bool StartIndexBackgroundSync(NodeContext& node)
 
         if (!indexes_start_block || !pindex || pindex->nHeight < indexes_start_block.value()->nHeight) {
             indexes_start_block = pindex;
-            older_index_name = summary.name;
+            older_index = index;
             if (!pindex) break; // Starting from genesis so no need to look for earlier block.
         }
     };
@@ -2120,7 +2120,9 @@ bool StartIndexBackgroundSync(NodeContext& node)
         const CBlockIndex* start_block = *indexes_start_block;
         if (!start_block) start_block = chainman.ActiveChain().Genesis();
         if (!chainman.m_blockman.CheckBlockDataAvailability(*index_chain.Tip(), *Assert(start_block))) {
-            return InitError(Untranslated(strprintf("%s best block of the index goes beyond pruned data. Please disable the index or reindex (which will download the whole blockchain again)", older_index_name)));
+            return InitError(strprintf(
+                _("Index \"%s\" needs block data that has been pruned.\nRestart with -reindex to rebuild (re-downloading the entire blockchain), or %s to disable."),
+                older_index->GetName(), older_index->GetDisableAction()));
         }
     }
 

--- a/test/functional/feature_index_prune.py
+++ b/test/functional/feature_index_prune.py
@@ -130,8 +130,8 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
             self.stop_node(i)
 
         self.log.info("make sure we get an init error when starting the nodes again with the indices")
-        filter_msg = "Error: basic block filter index best block of the index goes beyond pruned data. Please disable the index or reindex (which will download the whole blockchain again)"
-        stats_msg = "Error: coinstatsindex best block of the index goes beyond pruned data. Please disable the index or reindex (which will download the whole blockchain again)"
+        filter_msg = f"Error: Index \"basic block filter index\" needs block data that has been pruned.{os.linesep}Restart with -reindex to rebuild (re-downloading the entire blockchain), or remove \"basic\" from -blockfilterindex to disable."
+        stats_msg = f"Error: Index \"coinstatsindex\" needs block data that has been pruned.{os.linesep}Restart with -reindex to rebuild (re-downloading the entire blockchain), or set -coinstatsindex=0 to disable."
         end_msg = f"{os.linesep}Error: A fatal internal error occurred, see debug.log for details: Failed to start indexes, shutting down.."
         for i, msg in enumerate([filter_msg, stats_msg, filter_msg]):
             self.nodes[i].assert_start_raises_init_error(extra_args=self.extra_args[i], expected_msg=msg+end_msg)


### PR DESCRIPTION
Fixes #87

Replaces the vague pruned data error with an actionable message showing the specific flag to disable the index or -reindex to rebuild.