### PR TITLE
net: redact SOCKS5 proxy password from debug log

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -436,7 +436,7 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
             vAuth.push_back(auth->password.size());
             vAuth.insert(vAuth.end(), auth->password.begin(), auth->password.end());
             sock.SendComplete(vAuth, g_socks5_recv_timeout, g_socks5_interrupt);
-            LogDebug(BCLog::PROXY, "SOCKS5 sending proxy authentication %s:%s\n", auth->username, auth->password);
+            LogDebug(BCLog::PROXY, "SOCKS5 sending proxy authentication %s:****\n", auth->username);
             uint8_t pchRetA[2];
             if (InterruptibleRecv(pchRetA, 2, g_socks5_recv_timeout, sock) != IntrRecvError::OK) {
                 LogError("Error reading proxy authentication response\n");


### PR DESCRIPTION
SOCKS5 proxy password is logged in plaintext when `-debug=proxy` is enabled (`netbase.cpp:439`). Redact the password field to prevent credential exposure in log files.