### PR TITLE
external_signer: validate fingerprint is hex before shell command use

### DIFF
--- a/src/external_signer.cpp
+++ b/src/external_signer.cpp
@@ -44,6 +44,9 @@ bool ExternalSigner::Enumerate(const std::string& command, std::vector<ExternalS
             throw std::runtime_error(strprintf("'%s' received invalid response, missing signer fingerprint", command));
         }
         const std::string& fingerprintStr{fingerprint.get_str()};
+        if (fingerprintStr.empty() || !IsHex(fingerprintStr)) {
+            throw std::runtime_error(strprintf("'%s' received invalid fingerprint '%s'", command, fingerprintStr));
+        }
         // Skip duplicate signer
         bool duplicate = false;
         for (const ExternalSigner& signer : signers) {

--- a/src/external_signer.cpp
+++ b/src/external_signer.cpp
@@ -44,8 +44,8 @@ bool ExternalSigner::Enumerate(const std::string& command, std::vector<ExternalS
             throw std::runtime_error(strprintf("'%s' received invalid response, missing signer fingerprint", command));
         }
         const std::string& fingerprintStr{fingerprint.get_str()};
-        if (fingerprintStr.empty() || !IsHex(fingerprintStr)) {
-            throw std::runtime_error(strprintf("'%s' received invalid fingerprint", command));
+        if (fingerprintStr.size() != 8 || !IsHex(fingerprintStr)) {
+            throw std::runtime_error(strprintf("'%s' received invalid fingerprint: must be exactly 8 hex characters", command));
         }
         // Skip duplicate signer
         bool duplicate = false;

--- a/src/external_signer.cpp
+++ b/src/external_signer.cpp
@@ -45,7 +45,7 @@ bool ExternalSigner::Enumerate(const std::string& command, std::vector<ExternalS
         }
         const std::string& fingerprintStr{fingerprint.get_str()};
         if (fingerprintStr.empty() || !IsHex(fingerprintStr)) {
-            throw std::runtime_error(strprintf("'%s' received invalid fingerprint '%s'", command, fingerprintStr));
+            throw std::runtime_error(strprintf("'%s' received invalid fingerprint", command));
         }
         // Skip duplicate signer
         bool duplicate = false;

--- a/test/functional/rpc_signer.py
+++ b/test/functional/rpc_signer.py
@@ -86,6 +86,20 @@ class RPCSignerTest(BitcoinTestFramework):
         )
         self.clear_mock_result(self.nodes[1])
 
+        # Too-short hex fingerprint must be rejected (7 chars)
+        self.set_mock_result(self.nodes[1], '0 [{"type": "trezor", "model": "trezor_t", "fingerprint": "0000001"}]')
+        assert_raises_rpc_error(-1, 'received invalid fingerprint',
+            self.nodes[1].enumeratesigners
+        )
+        self.clear_mock_result(self.nodes[1])
+
+        # Too-long hex fingerprint must be rejected (9 chars)
+        self.set_mock_result(self.nodes[1], '0 [{"type": "trezor", "model": "trezor_t", "fingerprint": "000000001"}]')
+        assert_raises_rpc_error(-1, 'received invalid fingerprint',
+            self.nodes[1].enumeratesigners
+        )
+        self.clear_mock_result(self.nodes[1])
+
         assert_equal({'fingerprint': '00000001', 'name': 'trezor_t'} in self.nodes[1].enumeratesigners()['signers'], True)
 
 if __name__ == '__main__':

--- a/test/functional/rpc_signer.py
+++ b/test/functional/rpc_signer.py
@@ -72,6 +72,20 @@ class RPCSignerTest(BitcoinTestFramework):
         )
         self.clear_mock_result(self.nodes[1])
 
+        # Malicious fingerprint with shell metacharacters must be rejected
+        self.set_mock_result(self.nodes[1], '0 [{"type": "trezor", "model": "trezor_t", "fingerprint": "00000001; rm -rf /"}]')
+        assert_raises_rpc_error(-1, 'received invalid fingerprint',
+            self.nodes[1].enumeratesigners
+        )
+        self.clear_mock_result(self.nodes[1])
+
+        # Empty fingerprint must be rejected
+        self.set_mock_result(self.nodes[1], '0 [{"type": "trezor", "model": "trezor_t", "fingerprint": ""}]')
+        assert_raises_rpc_error(-1, 'received invalid fingerprint',
+            self.nodes[1].enumeratesigners
+        )
+        self.clear_mock_result(self.nodes[1])
+
         assert_equal({'fingerprint': '00000001', 'name': 'trezor_t'} in self.nodes[1].enumeratesigners()['signers'], True)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Validate that the fingerprint returned by the external signer is hex-only before using it in shell command construction
- Adds test cases for malicious and empty fingerprints

## Test plan
- [x] `rpc_signer.py` passes (includes new test cases for `"00000001; rm -rf /"` and empty string)
- [x] `wallet_signer.py` passes, no regressions