### PR TITLE
codex32: early return on validation error to prevent OOB read

### DIFF
--- a/src/codex32.cpp
+++ b/src/codex32.cpp
@@ -390,6 +390,8 @@ Result::Result(const std::vector<Result>& shares, char output_idx) {
         }
     }
 
+    if (m_valid != OK) return;
+
     m_hrp = shares[0].m_hrp;
     m_data.reserve(shares[0].m_data.size());
     for (size_t j = 0; j < shares[0].m_data.size(); ++j) {


### PR DESCRIPTION
## Summary
- Add early return in codex32 share interpolation constructor when validation fails
- Prevents out-of-bounds heap read when shares have mismatched payload lengths
- Prevents assert/crash on duplicate share indices (division by zero in gf32_div)