### PR TITLE
Saturate CalculateExtraTxWeight and cap GUI datacarriercost to 1024

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -583,7 +584,7 @@ std::pair<size_t, size_t> DatacarrierBytes(const CTransaction& tx, const CCoinsV
 
 int32_t CalculateExtraTxWeight(const CTransaction& tx, const CCoinsViewCache& view, const unsigned int weight_per_data_byte)
 {
-    int32_t mod_weight{0};
+    int64_t mod_weight{0};
 
     // Add in any extra weight for data bytes
     if (weight_per_data_byte > 1) {
@@ -592,17 +593,17 @@ int32_t CalculateExtraTxWeight(const CTransaction& tx, const CCoinsViewCache& vi
             auto[script, consensus_weight_per_byte] = GetScriptForTransactionInput(utxo.scriptPubKey, txin);
             if (weight_per_data_byte > consensus_weight_per_byte) {
                 const auto dcb = script.DatacarrierBytes(0);
-                mod_weight += (dcb.first + dcb.second) * (weight_per_data_byte - consensus_weight_per_byte);
+                mod_weight += int64_t(dcb.first + dcb.second) * (weight_per_data_byte - consensus_weight_per_byte);
             }
         }
         if (weight_per_data_byte > WITNESS_SCALE_FACTOR) {
             for (size_t i{tx.vout.size()}; i; ) {
                 const CTxOut& txout = tx.vout[--i];
                 const auto dcb = txout.scriptPubKey.DatacarrierBytes(tx.vout.size() - i);
-                mod_weight += (dcb.first + dcb.second) * (weight_per_data_byte - WITNESS_SCALE_FACTOR);
+                mod_weight += int64_t(dcb.first + dcb.second) * (weight_per_data_byte - WITNESS_SCALE_FACTOR);
             }
         }
     }
 
-    return mod_weight;
+    return int32_t(std::min(mod_weight, int64_t{std::numeric_limits<int32_t>::max()}));
 }

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -535,7 +535,7 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
     datacarriercost->setStepType(QAbstractSpinBox::DefaultStepType);
     datacarriercost->setSingleStep(0.25);
     datacarriercost->setMinimum(0.25);
-    datacarriercost->setMaximum(MAX_BLOCK_SERIALIZED_SIZE);
+    datacarriercost->setMaximum(1024);
     datacarriercost->setToolTip(tr("As an alternative to, or in addition to, limiting the size of disguised data, you can also configure how it is accounted for in comparison to legitimate transaction data. For example, 1 vbyte per actual byte would count it as equivalent to ordinary transaction data; 0.25 vB/B would allow it to benefit from the so-called \"segwit discount\"; or 2 vB/B would establish a bias toward legitimate transactions."));
     CreateOptionUI(verticalLayout_Spamfiltering, datacarriercost, tr("Weigh embedded data as %s virtual bytes per actual byte."));
     connect(datacarriercost, QOverload<double>::of(&QDoubleSpinBox::valueChanged), [&](double d){


### PR DESCRIPTION
## Summary
- Saturate `mod_weight` in `CalculateExtraTxWeight to prevent `int32_t` overflow wrapping negative
- Cap GUI `datacarriercost` maximum from `MAX_BLOCK_SERIALIZED_SIZE` to `1024`