### PR TITLE
Add compile_tr() for Taptree-native policy compilation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -181,6 +181,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   script/descriptor.cpp
   script/miniscript.cpp
   script/parsing.cpp
+  script/policy.cpp
   script/sign.cpp
   script/signingprovider.cpp
   script/solver.cpp

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -9,6 +9,7 @@
 #include <pubkey.h>
 #include <script/miniscript.h>
 #include <script/parsing.h>
+#include <script/policy.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
 #include <script/solver.h>
@@ -1939,6 +1940,85 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
         return ret;
     } else if (Func("addr", expr)) {
         error = "Can only have addr() at top level";
+        return {};
+    }
+    if (ctx == ParseScriptContext::TOP && Func("compile_tr", expr)) {
+        auto arg = Expr(expr);
+        auto internal_keys = ParsePubkey(key_exp_index, arg, ParseScriptContext::P2TR, out, error);
+        if (internal_keys.empty()) {
+            error = strprintf("compile_tr(): %s", error);
+            return {};
+        }
+        ++key_exp_index;
+        if (!Const(",", expr)) {
+            error = "compile_tr(): expected ',' after internal key";
+            return {};
+        }
+
+        KeyParser parser(/*out=*/&out, /*in=*/nullptr, /*ctx=*/miniscript::MiniscriptContext::TAPSCRIPT, key_exp_index);
+        auto pol = policy::ParsePolicy<uint32_t>(expr, parser);
+        if (!pol || !expr.empty()) {
+            error = "compile_tr(): invalid policy expression";
+            if (!parser.m_key_parsing_error.empty()) error = strprintf("compile_tr(): %s", parser.m_key_parsing_error);
+            return {};
+        }
+
+        auto result = policy::CompileTrNative<uint32_t>(*pol);
+        if (!result) {
+            error = "compile_tr(): policy compilation failed (too many leaves or unsupported policy)";
+            return {};
+        }
+
+        auto& [scripts, depths] = *result;
+
+        size_t max_providers_len = internal_keys.size();
+        if (!parser.m_keys.empty()) {
+            max_providers_len = std::max(max_providers_len, std::max_element(parser.m_keys.begin(), parser.m_keys.end(),
+                    [](const std::vector<std::unique_ptr<PubkeyProvider>>& a, const std::vector<std::unique_ptr<PubkeyProvider>>& b) {
+                        return a.size() < b.size();
+                    })->size());
+        }
+
+        for (auto& vec : parser.m_keys) {
+            if (vec.size() == 1) {
+                for (size_t j = 1; j < max_providers_len; ++j) {
+                    vec.emplace_back(vec.at(0)->Clone());
+                }
+            } else if (vec.size() != max_providers_len) {
+                error = "compile_tr(): multipath derivation paths have mismatched lengths";
+                return {};
+            }
+        }
+
+        if (internal_keys.size() > 1 && internal_keys.size() != max_providers_len) {
+            error = "compile_tr(): multipath internal key mismatches multipath subscripts lengths";
+            return {};
+        }
+        while (internal_keys.size() < max_providers_len) {
+            internal_keys.emplace_back(internal_keys.at(0)->Clone());
+        }
+
+        key_exp_index += parser.m_keys.size();
+        assert(TaprootBuilder::ValidDepths(depths));
+
+        for (size_t mp = 0; mp < max_providers_len; ++mp) {
+            std::vector<std::unique_ptr<DescriptorImpl>> descs;
+            descs.reserve(scripts.size());
+            for (size_t i = 0; i < scripts.size(); ++i) {
+                std::vector<std::unique_ptr<PubkeyProvider>> leaf_keys;
+                leaf_keys.reserve(parser.m_keys.size());
+                for (auto& key_vec : parser.m_keys) {
+                    leaf_keys.push_back(key_vec.at(mp)->Clone());
+                }
+                descs.push_back(std::make_unique<MiniscriptDescriptor>(
+                    std::move(leaf_keys), (mp == max_providers_len - 1) ? std::move(scripts[i]) : scripts[i]->Clone()));
+            }
+            ret.emplace_back(std::make_unique<TRDescriptor>(std::move(internal_keys.at(mp)), std::move(descs), depths));
+        }
+        return ret;
+
+    } else if (Func("compile_tr", expr)) {
+        error = "Can only have compile_tr at top level";
         return {};
     }
     if (ctx == ParseScriptContext::TOP && Func("tr", expr)) {

--- a/src/script/miniscript.h
+++ b/src/script/miniscript.h
@@ -1642,6 +1642,28 @@ public:
     //! Check whether this node is safe as a script on its own.
     bool IsSane() const { return IsValidTopLevel() && IsSaneSubexpression() && NeedsSignature(); }
 
+    //! Check whether this node or any sub-node contains OP_IF/NOTIF-emitting fragments
+    //! (WRAP_D, WRAP_J, ANDOR, OR_C, OR_D, OR_I). In Tapscript, these should be replaced
+    //! by separate Taptree leaves for better privacy and efficiency.
+    bool HasBranchingOpcodes(size_t depth = 0) const {
+        if (depth > 100) return true;
+        switch (fragment) {
+        case Fragment::WRAP_D:
+        case Fragment::WRAP_J:
+        case Fragment::ANDOR:
+        case Fragment::OR_C:
+        case Fragment::OR_D:
+        case Fragment::OR_I:
+            return true;
+        default:
+            break;
+        }
+        for (const auto& sub : subs) {
+            if (sub->HasBranchingOpcodes(depth + 1)) return true;
+        }
+        return false;
+    }
+
     //! Produce a witness for this script, if possible and given the information available in the context.
     //! The non-malleable satisfaction is guaranteed to be valid if it exists, and ValidSatisfaction()
     //! is true. If IsSane() holds, this satisfaction is guaranteed to succeed in case the node's

--- a/src/script/policy.cpp
+++ b/src/script/policy.cpp
@@ -1,0 +1,5 @@
+// Copyright (c) 2026 The Bitcoin Knots developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/policy.h>

--- a/src/script/policy.h
+++ b/src/script/policy.h
@@ -5,14 +5,19 @@
 #ifndef BITCOIN_SCRIPT_POLICY_H
 #define BITCOIN_SCRIPT_POLICY_H
 
+#include <script/interpreter.h>
+#include <script/miniscript.h>
 #include <script/parsing.h>
 #include <span.h>
 #include <util/strencodings.h>
+#include <util/vector.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <queue>
 #include <string>
 #include <utility>
 #include <vector>
@@ -129,6 +134,9 @@ struct Policy {
         return p;
     }
 };
+
+template<typename Key>
+using WeightedPolicy = std::pair<double, std::shared_ptr<const Policy<Key>>>;
 
 namespace detail {
 
@@ -288,6 +296,315 @@ std::shared_ptr<const Policy<Key>> ParsePolicy(Span<const char>& sp, const Ctx& 
     }
 
     return nullptr;
+}
+
+template<typename Key>
+std::vector<WeightedPolicy<Key>> EnumeratePolNative(double prob, const Policy<Key>& pol) {
+    using Pol = Policy<Key>;
+    using WP = WeightedPolicy<Key>;
+
+    switch (pol.type) {
+    case PolicyType::OR: {
+        std::vector<WP> result;
+        double total = 0.0;
+        for (double w : pol.weights) total += w;
+        for (size_t i = 0; i < pol.subs.size(); ++i) {
+            double child_prob = (total > 0) ? prob * pol.weights[i] / total : prob / pol.subs.size();
+            result.emplace_back(child_prob, pol.subs[i]);
+        }
+        return result;
+    }
+    case PolicyType::THRESH: {
+        size_t n = pol.subs.size();
+        uint32_t k = pol.k;
+        if (k == 1) {
+            std::vector<WP> result;
+            for (size_t i = 0; i < n; ++i) {
+                result.emplace_back(prob / n, pol.subs[i]);
+            }
+            return result;
+        }
+        if (k == n) {
+            return {{prob, std::make_shared<Pol>(pol)}};
+        }
+        std::vector<std::vector<size_t>> combos;
+        if (!detail::Combinations(n, k, combos)) return {{prob, std::make_shared<Pol>(pol)}};
+        std::vector<WP> result;
+        double combo_prob = prob / combos.size();
+        for (const auto& combo : combos) {
+            std::vector<std::shared_ptr<const Pol>> selected;
+            for (size_t idx : combo) {
+                selected.push_back(pol.subs[idx]);
+            }
+            if (selected.size() == 1) {
+                result.emplace_back(combo_prob, selected[0]);
+            } else {
+                result.emplace_back(combo_prob, Pol::MakeAnd(std::move(selected)));
+            }
+        }
+        return result;
+    }
+    case PolicyType::AND: {
+        for (size_t i = 0; i < pol.subs.size(); ++i) {
+            auto expanded = EnumeratePolNative(1.0, *pol.subs[i]);
+            if (expanded.size() > 1) {
+                std::vector<WP> result;
+                for (auto& [child_prob, child_pol] : expanded) {
+                    std::vector<std::shared_ptr<const Pol>> new_children;
+                    for (size_t j = 0; j < pol.subs.size(); ++j) {
+                        if (j == i) {
+                            new_children.push_back(child_pol);
+                        } else {
+                            new_children.push_back(pol.subs[j]);
+                        }
+                    }
+                    result.emplace_back(prob * child_prob, Pol::MakeAnd(std::move(new_children)));
+                }
+                return result;
+            }
+        }
+        return {{prob, std::make_shared<Pol>(pol)}};
+    }
+    default:
+        return {{prob, std::make_shared<Pol>(pol)}};
+    }
+}
+
+template<typename Key>
+std::vector<WeightedPolicy<Key>> EnumerateLeaves(const Policy<Key>& pol, size_t max_leaves = 1024) {
+    using WP = WeightedPolicy<Key>;
+
+    std::vector<WP> working;
+    working.emplace_back(1.0, std::make_shared<Policy<Key>>(pol));
+
+    while (working.size() < max_leaves) {
+        int best_idx = -1;
+        double best_prob = -1.0;
+        std::vector<WP> best_expansion;
+
+        for (size_t i = 0; i < working.size(); ++i) {
+            auto expanded = EnumeratePolNative(working[i].first, *working[i].second);
+            if (expanded.size() > 1) {
+                if (working[i].first > best_prob) {
+                    best_prob = working[i].first;
+                    best_idx = static_cast<int>(i);
+                    best_expansion = std::move(expanded);
+                }
+            }
+        }
+
+        if (best_idx < 0) break;
+        if (working.size() - 1 + best_expansion.size() > max_leaves) break;
+
+        working[best_idx] = std::move(working.back());
+        working.pop_back();
+        working.insert(working.end(), best_expansion.begin(), best_expansion.end());
+    }
+
+    return working;
+}
+
+template<typename Key>
+bool FlattenAnd(const Policy<Key>& pol, std::vector<std::shared_ptr<const Policy<Key>>>& out, size_t depth = 0) {
+    if (depth > MAX_POLICY_DEPTH) return false;
+    if (pol.type == PolicyType::AND) {
+        for (const auto& sub : pol.subs) {
+            if (!FlattenAnd(*sub, out, depth + 1)) return false;
+        }
+    } else {
+        out.push_back(std::make_shared<Policy<Key>>(pol));
+    }
+    return true;
+}
+
+template<typename Key>
+miniscript::NodeRef<Key> CompileLeaf(const Policy<Key>& leaf, size_t depth = 0);
+
+template<typename Key>
+miniscript::NodeRef<Key> CompileAtom(const Policy<Key>& leaf) {
+    using namespace miniscript;
+    constexpr auto CTX = MiniscriptContext::TAPSCRIPT;
+
+    switch (leaf.type) {
+    case PolicyType::PK:
+        return MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::WRAP_C,
+            Vector(MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::PK_K, std::vector<Key>{leaf.keys[0]})));
+    case PolicyType::OLDER:
+        return MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::OLDER, leaf.k);
+    case PolicyType::AFTER:
+        return MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::AFTER, leaf.k);
+    case PolicyType::SHA256:
+        return MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::SHA256, leaf.data);
+    case PolicyType::HASH256:
+        return MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::HASH256, leaf.data);
+    case PolicyType::RIPEMD160:
+        return MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::RIPEMD160, leaf.data);
+    case PolicyType::HASH160:
+        return MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::HASH160, leaf.data);
+    default:
+        return {};
+    }
+}
+
+template<typename Key>
+miniscript::NodeRef<Key> CompileLeaf(const Policy<Key>& leaf, size_t depth) {
+    if (depth > MAX_POLICY_DEPTH) return {};
+    using namespace miniscript;
+    constexpr auto CTX = MiniscriptContext::TAPSCRIPT;
+
+    switch (leaf.type) {
+    case PolicyType::PK:
+    case PolicyType::OLDER:
+    case PolicyType::AFTER:
+    case PolicyType::SHA256:
+    case PolicyType::HASH256:
+    case PolicyType::RIPEMD160:
+    case PolicyType::HASH160:
+        return CompileAtom<Key>(leaf);
+
+    case PolicyType::AND: {
+        std::vector<std::shared_ptr<const Policy<Key>>> flat;
+        if (!FlattenAnd(leaf, flat, depth)) return {};
+
+        if (flat.empty()) return {};
+
+        std::vector<NodeRef<Key>> compiled;
+        for (const auto& child : flat) {
+            auto ms = CompileLeaf<Key>(*child, depth + 1);
+            if (!ms) return {};
+            compiled.push_back(std::move(ms));
+        }
+
+        if (compiled.size() == 1) return std::move(compiled[0]);
+
+        auto result = std::move(compiled.back());
+        for (int i = static_cast<int>(compiled.size()) - 2; i >= 0; --i) {
+            auto v_wrapped = MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::WRAP_V,
+                Vector(std::move(compiled[i])));
+            result = MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::AND_V,
+                Vector(std::move(v_wrapped), std::move(result)));
+        }
+        return result;
+    }
+
+    case PolicyType::THRESH: {
+        uint32_t k = leaf.k;
+        size_t n = leaf.subs.size();
+
+        bool all_pk = std::all_of(leaf.subs.begin(), leaf.subs.end(),
+            [](const auto& sub) { return sub->type == PolicyType::PK; });
+
+        if (all_pk) {
+            std::vector<Key> all_keys;
+            for (const auto& sub : leaf.subs) {
+                all_keys.push_back(sub->keys[0]);
+            }
+            return MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::MULTI_A, std::move(all_keys), k);
+        }
+
+        std::vector<NodeRef<Key>> compiled;
+        for (size_t i = 0; i < n; ++i) {
+            auto ms = CompileLeaf<Key>(*leaf.subs[i], depth + 1);
+            if (!ms) return {};
+
+            if (i == 0) {
+                compiled.push_back(std::move(ms));
+            } else {
+                if (leaf.subs[i]->type == PolicyType::PK) {
+                    compiled.push_back(MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::WRAP_S,
+                        Vector(std::move(ms))));
+                } else {
+                    compiled.push_back(MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::WRAP_A,
+                        Vector(std::move(ms))));
+                }
+            }
+        }
+
+        return MakeNodeRef<Key>(internal::NoDupCheck{}, CTX, Fragment::THRESH, std::move(compiled), k);
+    }
+
+    case PolicyType::OR:
+        return {};
+    }
+
+    return {};
+}
+
+struct HuffmanNode {
+    double weight;
+    int index;
+    int left{-1};
+    int right{-1};
+};
+
+inline std::vector<std::pair<int, int>> HuffmanTree(const std::vector<double>& weights) {
+    size_t n = weights.size();
+    if (n == 0) return {};
+    if (n == 1) return {{0, 0}};
+
+    std::vector<HuffmanNode> nodes;
+    nodes.reserve(2 * n);
+
+    auto cmp = [&](int a, int b) { return nodes[a].weight > nodes[b].weight; };
+    std::priority_queue<int, std::vector<int>, decltype(cmp)> pq(cmp);
+
+    for (size_t i = 0; i < n; ++i) {
+        nodes.push_back({weights[i], static_cast<int>(i)});
+        pq.push(static_cast<int>(i));
+    }
+
+    while (pq.size() > 1) {
+        int a = pq.top(); pq.pop();
+        int b = pq.top(); pq.pop();
+        int idx = static_cast<int>(nodes.size());
+        nodes.push_back({nodes[a].weight + nodes[b].weight, -1, a, b});
+        pq.push(idx);
+    }
+
+    std::vector<std::pair<int, int>> result;
+    std::vector<std::pair<int, int>> stack{{pq.top(), 0}};
+    while (!stack.empty()) {
+        auto [ni, d] = stack.back();
+        stack.pop_back();
+        if (nodes[ni].index >= 0) {
+            result.emplace_back(nodes[ni].index, d);
+        } else {
+            stack.push_back({nodes[ni].right, d + 1});
+            stack.push_back({nodes[ni].left, d + 1});
+        }
+    }
+
+    return result;
+}
+
+template<typename Key>
+std::optional<std::pair<std::vector<miniscript::NodeRef<Key>>, std::vector<int>>>
+CompileTrNative(const Policy<Key>& pol, size_t max_depth = TAPROOT_CONTROL_MAX_NODE_COUNT, size_t max_leaves = 1024) {
+    size_t effective_max_leaves = std::min(max_leaves, size_t{1} << std::min(max_depth, size_t{20}));
+    auto leaves = EnumerateLeaves(pol, effective_max_leaves);
+    if (leaves.empty()) return std::nullopt;
+
+    std::vector<double> leaf_weights;
+    std::vector<miniscript::NodeRef<Key>> compiled;
+
+    for (auto& [weight, leaf_pol] : leaves) {
+        auto ms = CompileLeaf<Key>(*leaf_pol);
+        if (!ms || !ms->IsValid() || !ms->IsNonMalleable() || !ms->CheckTimeLocksMix() || ms->HasBranchingOpcodes()) return std::nullopt;
+        leaf_weights.push_back(weight);
+        compiled.push_back(std::move(ms));
+    }
+
+    auto tree = HuffmanTree(leaf_weights);
+
+    std::vector<miniscript::NodeRef<Key>> scripts;
+    std::vector<int> depths;
+    for (auto& [leaf_idx, depth] : tree) {
+        if (depth < 0 || static_cast<size_t>(depth) > max_depth) return std::nullopt;
+        scripts.push_back(std::move(compiled[leaf_idx]));
+        depths.push_back(depth);
+    }
+
+    return std::make_pair(std::move(scripts), std::move(depths));
 }
 
 } // namespace policy

--- a/src/script/policy.h
+++ b/src/script/policy.h
@@ -1,0 +1,295 @@
+// Copyright (c) 2026 The Bitcoin Knots developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SCRIPT_POLICY_H
+#define BITCOIN_SCRIPT_POLICY_H
+
+#include <script/parsing.h>
+#include <span.h>
+#include <util/strencodings.h>
+
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace policy {
+
+inline constexpr size_t MAX_POLICY_DEPTH = 100;
+inline constexpr size_t MAX_THRESH_CHILDREN = 20;
+inline constexpr size_t MAX_COMBINATIONS = 10000;
+
+enum class PolicyType {
+    PK,
+    OLDER,
+    AFTER,
+    SHA256,
+    HASH256,
+    RIPEMD160,
+    HASH160,
+    AND,
+    OR,
+    THRESH,
+};
+
+template<typename Key>
+struct Policy {
+    PolicyType type;
+    uint32_t k{0};
+    std::vector<Key> keys;
+    std::vector<unsigned char> data;
+    std::vector<std::shared_ptr<const Policy>> subs;
+    std::vector<double> weights;
+
+    bool operator==(const Policy& o) const {
+        if (type != o.type || k != o.k || keys != o.keys || data != o.data) return false;
+        if (subs.size() != o.subs.size() || weights != o.weights) return false;
+        for (size_t i = 0; i < subs.size(); ++i) {
+            if (!(*subs[i] == *o.subs[i])) return false;
+        }
+        return true;
+    }
+
+    bool operator<(const Policy& o) const {
+        if (type != o.type) return type < o.type;
+        if (k != o.k) return k < o.k;
+        if (keys != o.keys) return keys < o.keys;
+        if (data != o.data) return data < o.data;
+        if (subs.size() != o.subs.size()) return subs.size() < o.subs.size();
+        for (size_t i = 0; i < subs.size(); ++i) {
+            if (*subs[i] < *o.subs[i]) return true;
+            if (*o.subs[i] < *subs[i]) return false;
+        }
+        if (weights != o.weights) return weights < o.weights;
+        return false;
+    }
+
+    static std::shared_ptr<const Policy> MakePk(Key key) {
+        auto p = std::make_shared<Policy>();
+        p->type = PolicyType::PK;
+        p->keys.push_back(std::move(key));
+        return p;
+    }
+
+    static std::shared_ptr<const Policy> MakeOlder(uint32_t n) {
+        auto p = std::make_shared<Policy>();
+        p->type = PolicyType::OLDER;
+        p->k = n;
+        return p;
+    }
+
+    static std::shared_ptr<const Policy> MakeAfter(uint32_t n) {
+        auto p = std::make_shared<Policy>();
+        p->type = PolicyType::AFTER;
+        p->k = n;
+        return p;
+    }
+
+    static std::shared_ptr<const Policy> MakeHash(PolicyType ht, std::vector<unsigned char> hash) {
+        auto p = std::make_shared<Policy>();
+        p->type = ht;
+        p->data = std::move(hash);
+        return p;
+    }
+
+    static std::shared_ptr<const Policy> MakeAnd(std::shared_ptr<const Policy> a, std::shared_ptr<const Policy> b) {
+        auto p = std::make_shared<Policy>();
+        p->type = PolicyType::AND;
+        p->subs.push_back(std::move(a));
+        p->subs.push_back(std::move(b));
+        return p;
+    }
+
+    static std::shared_ptr<const Policy> MakeAnd(std::vector<std::shared_ptr<const Policy>> children) {
+        auto p = std::make_shared<Policy>();
+        p->type = PolicyType::AND;
+        p->subs = std::move(children);
+        return p;
+    }
+
+    static std::shared_ptr<const Policy> MakeOr(std::vector<std::pair<double, std::shared_ptr<const Policy>>> weighted_children) {
+        auto p = std::make_shared<Policy>();
+        p->type = PolicyType::OR;
+        for (auto& [w, child] : weighted_children) {
+            p->weights.push_back(w);
+            p->subs.push_back(std::move(child));
+        }
+        return p;
+    }
+
+    static std::shared_ptr<const Policy> MakeThresh(uint32_t thresh_k, std::vector<std::shared_ptr<const Policy>> children) {
+        auto p = std::make_shared<Policy>();
+        p->type = PolicyType::THRESH;
+        p->k = thresh_k;
+        p->subs = std::move(children);
+        return p;
+    }
+};
+
+namespace detail {
+
+inline bool ParseUint32(Span<const char>& sp, uint32_t& out) {
+    uint32_t val = 0;
+    if (sp.empty() || sp[0] < '0' || sp[0] > '9') return false;
+    if (sp[0] == '0' && sp.size() > 1 && sp[1] >= '0' && sp[1] <= '9') return false;
+    while (!sp.empty() && sp[0] >= '0' && sp[0] <= '9') {
+        uint64_t next = static_cast<uint64_t>(val) * 10 + (sp[0] - '0');
+        if (next > 0xFFFFFFFF) return false;
+        val = static_cast<uint32_t>(next);
+        sp = sp.subspan(1);
+    }
+    out = val;
+    return true;
+}
+
+inline bool Combinations(size_t n, size_t k, std::vector<std::vector<size_t>>& result, size_t max_results = MAX_COMBINATIONS) {
+    if (k == 0) {
+        result.push_back({});
+        return true;
+    }
+    if (k > n) return false;
+    std::vector<size_t> indices(k);
+    std::iota(indices.begin(), indices.end(), 0);
+    while (true) {
+        result.push_back(indices);
+        if (result.size() > max_results) return false;
+        size_t i = k;
+        while (i > 0) {
+            --i;
+            if (indices[i] != i + n - k) break;
+            if (i == 0 && indices[i] == n - k) return true;
+        }
+        ++indices[i];
+        for (size_t j = i + 1; j < k; ++j) {
+            indices[j] = indices[j - 1] + 1;
+        }
+    }
+}
+
+} // namespace detail
+
+template<typename Key, typename Ctx>
+std::shared_ptr<const Policy<Key>> ParsePolicy(Span<const char>& sp, const Ctx& ctx, size_t depth = 0) {
+    if (depth > MAX_POLICY_DEPTH) return nullptr;
+    using Pol = Policy<Key>;
+
+    auto parse_key = [&](Span<const char>& in) -> std::optional<Key> {
+        auto expr = script::Expr(in);
+        std::string key_str(expr.begin(), expr.end());
+        return ctx.FromString(key_str.begin(), key_str.end());
+    };
+
+    auto parse_hex = [](Span<const char>& in, size_t expected_bytes) -> std::optional<std::vector<unsigned char>> {
+        auto expr = script::Expr(in);
+        std::string hex_str(expr.begin(), expr.end());
+        auto bytes = TryParseHex<unsigned char>(hex_str);
+        if (!bytes || bytes->size() != expected_bytes) return std::nullopt;
+        return bytes;
+    };
+
+    if (script::Func("pk", sp)) {
+        auto key = parse_key(sp);
+        if (!key) return nullptr;
+        return Pol::MakePk(std::move(*key));
+    }
+
+    if (script::Func("older", sp)) {
+        uint32_t n{0};
+        if (!detail::ParseUint32(sp, n)) return nullptr;
+        if (n < 1 || n >= 0x80000000UL) return nullptr;
+        return Pol::MakeOlder(n);
+    }
+
+    if (script::Func("after", sp)) {
+        uint32_t n{0};
+        if (!detail::ParseUint32(sp, n)) return nullptr;
+        if (n < 1 || n >= 0x80000000UL) return nullptr;
+        return Pol::MakeAfter(n);
+    }
+
+    if (script::Func("sha256", sp)) {
+        auto h = parse_hex(sp, 32);
+        if (!h) return nullptr;
+        return Pol::MakeHash(PolicyType::SHA256, std::move(*h));
+    }
+
+    if (script::Func("hash256", sp)) {
+        auto h = parse_hex(sp, 32);
+        if (!h) return nullptr;
+        return Pol::MakeHash(PolicyType::HASH256, std::move(*h));
+    }
+
+    if (script::Func("ripemd160", sp)) {
+        auto h = parse_hex(sp, 20);
+        if (!h) return nullptr;
+        return Pol::MakeHash(PolicyType::RIPEMD160, std::move(*h));
+    }
+
+    if (script::Func("hash160", sp)) {
+        auto h = parse_hex(sp, 20);
+        if (!h) return nullptr;
+        return Pol::MakeHash(PolicyType::HASH160, std::move(*h));
+    }
+
+    if (script::Func("and", sp)) {
+        auto left_expr = script::Expr(sp);
+        auto left = ParsePolicy<Key, Ctx>(left_expr, ctx, depth + 1);
+        if (!left) return nullptr;
+        if (!script::Const(",", sp)) return nullptr;
+        auto right_expr = script::Expr(sp);
+        auto right = ParsePolicy<Key, Ctx>(right_expr, ctx, depth + 1);
+        if (!right) return nullptr;
+        return Pol::MakeAnd(std::move(left), std::move(right));
+    }
+
+    if (script::Func("or", sp)) {
+        std::vector<std::pair<double, std::shared_ptr<const Policy<Key>>>> children;
+        while (true) {
+            double weight = 1.0;
+            auto expr = script::Expr(sp);
+
+            Span<const char> probe = expr;
+            uint32_t w{0};
+            if (detail::ParseUint32(probe, w) && !probe.empty() && probe[0] == '@') {
+                weight = static_cast<double>(w);
+                probe = probe.subspan(1);
+                expr = probe;
+            }
+
+            auto child = ParsePolicy<Key, Ctx>(expr, ctx, depth + 1);
+            if (!child) return nullptr;
+            children.emplace_back(weight, std::move(child));
+
+            if (!script::Const(",", sp)) break;
+        }
+        if (children.size() < 2) return nullptr;
+        return Pol::MakeOr(std::move(children));
+    }
+
+    if (script::Func("thresh", sp)) {
+        auto k_expr = script::Expr(sp);
+        uint32_t thresh_k{0};
+        if (!detail::ParseUint32(k_expr, thresh_k)) return nullptr;
+
+        std::vector<std::shared_ptr<const Policy<Key>>> children;
+        while (script::Const(",", sp)) {
+            auto child_expr = script::Expr(sp);
+            auto child = ParsePolicy<Key, Ctx>(child_expr, ctx, depth + 1);
+            if (!child) return nullptr;
+            children.push_back(std::move(child));
+        }
+        if (children.empty() || thresh_k == 0 || thresh_k > children.size()) return nullptr;
+        if (children.size() > MAX_THRESH_CHILDREN) return nullptr;
+        return Pol::MakeThresh(thresh_k, std::move(children));
+    }
+
+    return nullptr;
+}
+
+} // namespace policy
+
+#endif // BITCOIN_SCRIPT_POLICY_H

--- a/src/script/policy.h
+++ b/src/script/policy.h
@@ -133,6 +133,111 @@ struct Policy {
         p->subs = std::move(children);
         return p;
     }
+
+    enum TimelockKind : uint8_t {
+        TL_NONE = 0,
+        TL_HEIGHT = 1,
+        TL_TIME = 2,
+        TL_BOTH = 3,
+    };
+
+    TimelockKind GetTimelockKind() const {
+        switch (type) {
+        case PolicyType::OLDER:
+        case PolicyType::AFTER:
+            return (k < 500000000UL) ? TL_HEIGHT : TL_TIME;
+        case PolicyType::AND: {
+            uint8_t combined = TL_NONE;
+            for (const auto& sub : subs) combined |= sub->GetTimelockKind();
+            return static_cast<TimelockKind>(combined);
+        }
+        case PolicyType::OR: {
+            uint8_t combined = TL_NONE;
+            for (const auto& sub : subs) combined |= sub->GetTimelockKind();
+            return static_cast<TimelockKind>(combined);
+        }
+        case PolicyType::THRESH: {
+            uint8_t combined = TL_NONE;
+            for (const auto& sub : subs) combined |= sub->GetTimelockKind();
+            return static_cast<TimelockKind>(combined);
+        }
+        default:
+            return TL_NONE;
+        }
+    }
+
+    bool CheckTimelockMix(size_t depth = 0) const {
+        if (depth > MAX_POLICY_DEPTH) return false;
+        switch (type) {
+        case PolicyType::AND: {
+            uint8_t combined = TL_NONE;
+            for (const auto& sub : subs) {
+                if (!sub->CheckTimelockMix(depth + 1)) return false;
+                combined |= sub->GetTimelockKind();
+            }
+            return combined != TL_BOTH;
+        }
+        case PolicyType::OR:
+            for (const auto& sub : subs) {
+                if (!sub->CheckTimelockMix(depth + 1)) return false;
+            }
+            return true;
+        case PolicyType::THRESH: {
+            for (const auto& sub : subs) {
+                if (!sub->CheckTimelockMix(depth + 1)) return false;
+            }
+            if (k >= 2) {
+                uint8_t combined = TL_NONE;
+                for (const auto& sub : subs) combined |= sub->GetTimelockKind();
+                return combined != TL_BOTH;
+            }
+            return true;
+        }
+        default:
+            return true;
+        }
+    }
+
+    bool IsValid(size_t depth = 0) const {
+        if (depth > MAX_POLICY_DEPTH) return false;
+        switch (type) {
+        case PolicyType::PK:
+            return keys.size() == 1;
+        case PolicyType::OLDER:
+        case PolicyType::AFTER:
+            return k >= 1 && k < 0x80000000UL;
+        case PolicyType::SHA256:
+        case PolicyType::HASH256:
+            return data.size() == 32;
+        case PolicyType::RIPEMD160:
+        case PolicyType::HASH160:
+            return data.size() == 20;
+        case PolicyType::AND:
+            if (subs.size() < 2) return false;
+            for (const auto& sub : subs) {
+                if (!sub || !sub->IsValid(depth + 1)) return false;
+            }
+            return true;
+        case PolicyType::OR:
+            if (subs.size() < 2) return false;
+            if (weights.size() != subs.size()) return false;
+            for (double w : weights) {
+                if (w <= 0) return false;
+            }
+            for (const auto& sub : subs) {
+                if (!sub || !sub->IsValid(depth + 1)) return false;
+            }
+            return true;
+        case PolicyType::THRESH:
+            if (subs.empty()) return false;
+            if (k < 1 || k > subs.size()) return false;
+            for (const auto& sub : subs) {
+                if (!sub || !sub->IsValid(depth + 1)) return false;
+            }
+            return true;
+        }
+        return false;
+    }
 };
 
 template<typename Key>
@@ -580,6 +685,8 @@ inline std::vector<std::pair<int, int>> HuffmanTree(const std::vector<double>& w
 template<typename Key>
 std::optional<std::pair<std::vector<miniscript::NodeRef<Key>>, std::vector<int>>>
 CompileTrNative(const Policy<Key>& pol, size_t max_depth = TAPROOT_CONTROL_MAX_NODE_COUNT, size_t max_leaves = 1024) {
+    if (!pol.IsValid() || !pol.CheckTimelockMix()) return std::nullopt;
+
     size_t effective_max_leaves = std::min(max_leaves, size_t{1} << std::min(max_depth, size_t{20}));
     auto leaves = EnumerateLeaves(pol, effective_max_leaves);
     if (leaves.empty()) return std::nullopt;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(test_bitcoin
   peerman_tests.cpp
   pmt_tests.cpp
   policy_fee_tests.cpp
+  policy_tests.cpp
   policyestimator_tests.cpp
   pool_tests.cpp
   pow_tests.cpp

--- a/src/test/policy_tests.cpp
+++ b/src/test/policy_tests.cpp
@@ -431,6 +431,114 @@ BOOST_AUTO_TEST_CASE(standard_depth_allows_more_leaves)
     BOOST_CHECK_EQUAL(scripts.size(), 129U);
 }
 
+BOOST_AUTO_TEST_CASE(policy_is_valid)
+{
+    BOOST_CHECK(Parse("pk(A)")->IsValid());
+    BOOST_CHECK(Parse("older(100)")->IsValid());
+    BOOST_CHECK(Parse("after(500000)")->IsValid());
+    BOOST_CHECK(Parse("and(pk(A),pk(B))")->IsValid());
+    BOOST_CHECK(Parse("or(pk(A),pk(B))")->IsValid());
+    BOOST_CHECK(Parse("thresh(2,pk(A),pk(B),pk(C))")->IsValid());
+
+    {
+        auto p = std::make_shared<policy::Policy<std::string>>();
+        p->type = policy::PolicyType::AND;
+        p->subs.push_back(policy::Policy<std::string>::MakePk("A"));
+        BOOST_CHECK(!p->IsValid());
+    }
+
+    {
+        auto p = std::make_shared<policy::Policy<std::string>>();
+        p->type = policy::PolicyType::OR;
+        p->subs.push_back(policy::Policy<std::string>::MakePk("A"));
+        p->weights.push_back(1.0);
+        BOOST_CHECK(!p->IsValid());
+    }
+
+    {
+        auto p = std::make_shared<policy::Policy<std::string>>();
+        p->type = policy::PolicyType::OR;
+        p->subs.push_back(policy::Policy<std::string>::MakePk("A"));
+        p->subs.push_back(policy::Policy<std::string>::MakePk("B"));
+        p->weights.push_back(0.0);
+        p->weights.push_back(1.0);
+        BOOST_CHECK(!p->IsValid());
+    }
+
+    {
+        auto p = std::make_shared<policy::Policy<std::string>>();
+        p->type = policy::PolicyType::THRESH;
+        p->k = 0;
+        p->subs.push_back(policy::Policy<std::string>::MakePk("A"));
+        BOOST_CHECK(!p->IsValid());
+    }
+
+    {
+        auto p = std::make_shared<policy::Policy<std::string>>();
+        p->type = policy::PolicyType::THRESH;
+        p->k = 3;
+        p->subs.push_back(policy::Policy<std::string>::MakePk("A"));
+        p->subs.push_back(policy::Policy<std::string>::MakePk("B"));
+        BOOST_CHECK(!p->IsValid());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(policy_timelock_mix)
+{
+    auto valid_and = Parse("and(pk(A),older(100))");
+    BOOST_REQUIRE(valid_and);
+    BOOST_CHECK(valid_and->CheckTimelockMix());
+
+    auto valid_or_mix = Parse("or(older(100),after(500000001))");
+    BOOST_REQUIRE(valid_or_mix);
+    BOOST_CHECK(valid_or_mix->CheckTimelockMix());
+
+    auto bad_and = Parse("and(older(100),after(500000001))");
+    BOOST_REQUIRE(bad_and);
+    BOOST_CHECK(!bad_and->CheckTimelockMix());
+
+    auto nested_bad = Parse("and(pk(A),and(older(100),after(500000001)))");
+    BOOST_REQUIRE(nested_bad);
+    BOOST_CHECK(!nested_bad->CheckTimelockMix());
+
+    auto thresh_bad = Parse("thresh(2,older(100),after(500000001),pk(A))");
+    BOOST_REQUIRE(thresh_bad);
+    BOOST_CHECK(!thresh_bad->CheckTimelockMix());
+
+    auto thresh_1_ok = policy::Policy<std::string>::MakeThresh(1, {
+        policy::Policy<std::string>::MakeOlder(100),
+        policy::Policy<std::string>::MakeAfter(500000001),
+    });
+    BOOST_CHECK(thresh_1_ok->CheckTimelockMix());
+}
+
+BOOST_AUTO_TEST_CASE(compile_rejects_invalid_policy)
+{
+    {
+        auto bad_and = Parse("and(older(100),after(500000001))");
+        BOOST_REQUIRE(bad_and);
+        auto result = policy::CompileTrNative<std::string>(*bad_and);
+        BOOST_CHECK(!result.has_value());
+    }
+
+    {
+        policy::Policy<std::string> bad;
+        bad.type = policy::PolicyType::AND;
+        bad.subs.push_back(policy::Policy<std::string>::MakePk("A"));
+        auto result = policy::CompileTrNative<std::string>(bad);
+        BOOST_CHECK(!result.has_value());
+    }
+
+    {
+        policy::Policy<std::string> bad;
+        bad.type = policy::PolicyType::THRESH;
+        bad.k = 0;
+        bad.subs.push_back(policy::Policy<std::string>::MakePk("A"));
+        auto result = policy::CompileTrNative<std::string>(bad);
+        BOOST_CHECK(!result.has_value());
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } // namespace policy_tests

--- a/src/test/policy_tests.cpp
+++ b/src/test/policy_tests.cpp
@@ -2,9 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <script/miniscript.h>
 #include <script/policy.h>
+#include <script/signingprovider.h>
 #include <test/util/setup_common.h>
+#include <util/string.h>
 
+#include <cmath>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -79,6 +84,188 @@ BOOST_AUTO_TEST_CASE(parse_basic)
     BOOST_CHECK(!invalid);
 }
 
+BOOST_AUTO_TEST_CASE(decompose_or)
+{
+    auto or_pol = Parse("or(pk(A),pk(B))");
+    BOOST_REQUIRE(or_pol);
+    auto entries = policy::EnumeratePolNative(1.0, *or_pol);
+    BOOST_CHECK_EQUAL(entries.size(), 2U);
+
+    auto or_weighted = Parse("or(3@pk(A),1@pk(B))");
+    BOOST_REQUIRE(or_weighted);
+    auto w_entries = policy::EnumeratePolNative(1.0, *or_weighted);
+    BOOST_CHECK_EQUAL(w_entries.size(), 2U);
+    BOOST_CHECK_CLOSE(w_entries[0].first, 0.75, 0.01);
+    BOOST_CHECK_CLOSE(w_entries[1].first, 0.25, 0.01);
+}
+
+BOOST_AUTO_TEST_CASE(decompose_and_or)
+{
+    auto pol = Parse("and(or(pk(A),pk(B)),pk(C))");
+    BOOST_REQUIRE(pol);
+    auto entries = policy::EnumeratePolNative(1.0, *pol);
+    BOOST_CHECK_EQUAL(entries.size(), 2U);
+    for (const auto& [prob, sub] : entries) {
+        BOOST_CHECK(sub->type == policy::PolicyType::AND);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(enumerate_leaves_full)
+{
+    auto or2 = Parse("or(pk(A),pk(B))");
+    BOOST_REQUIRE(or2);
+    auto leaves2 = policy::EnumerateLeaves(*or2);
+    BOOST_CHECK_EQUAL(leaves2.size(), 2U);
+
+    auto and_or = Parse("and(or(pk(A),pk(B)),pk(C))");
+    BOOST_REQUIRE(and_or);
+    auto leaves_and_or = policy::EnumerateLeaves(*and_or);
+    BOOST_CHECK_EQUAL(leaves_and_or.size(), 2U);
+
+    auto nested_or = Parse("or(pk(A),or(pk(B),pk(C)))");
+    BOOST_REQUIRE(nested_or);
+    auto leaves3 = policy::EnumerateLeaves(*nested_or);
+    BOOST_CHECK_EQUAL(leaves3.size(), 3U);
+
+    auto thresh = Parse("thresh(2,pk(A),pk(B),pk(C))");
+    BOOST_REQUIRE(thresh);
+    auto leaves_thresh = policy::EnumerateLeaves(*thresh);
+    BOOST_CHECK_EQUAL(leaves_thresh.size(), 3U);
+}
+
+BOOST_AUTO_TEST_CASE(compile_leaf_pk)
+{
+    auto pk_pol = Parse("pk(A)");
+    BOOST_REQUIRE(pk_pol);
+    auto node = policy::CompileLeaf<std::string>(*pk_pol);
+    BOOST_REQUIRE(node);
+    BOOST_CHECK(node->fragment == miniscript::Fragment::WRAP_C);
+    BOOST_CHECK_EQUAL(node->subs.size(), 1U);
+    BOOST_CHECK(node->subs[0]->fragment == miniscript::Fragment::PK_K);
+    BOOST_CHECK(node->IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(compile_leaf_and)
+{
+    auto and_pol = Parse("and(pk(A),pk(B))");
+    BOOST_REQUIRE(and_pol);
+    auto node = policy::CompileLeaf<std::string>(*and_pol);
+    BOOST_REQUIRE(node);
+    BOOST_CHECK(node->fragment == miniscript::Fragment::AND_V);
+    BOOST_CHECK_EQUAL(node->subs.size(), 2U);
+    BOOST_CHECK(node->subs[0]->fragment == miniscript::Fragment::WRAP_V);
+    BOOST_CHECK(node->subs[0]->subs[0]->fragment == miniscript::Fragment::WRAP_C);
+    BOOST_CHECK(node->subs[0]->subs[0]->subs[0]->fragment == miniscript::Fragment::PK_K);
+    BOOST_CHECK(node->subs[1]->fragment == miniscript::Fragment::WRAP_C);
+    BOOST_CHECK(node->subs[1]->subs[0]->fragment == miniscript::Fragment::PK_K);
+    BOOST_CHECK(node->IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(compile_leaf_multi_a)
+{
+    auto thresh_pol = Parse("thresh(2,pk(A),pk(B),pk(C))");
+    BOOST_REQUIRE(thresh_pol);
+    auto node = policy::CompileLeaf<std::string>(*thresh_pol);
+    BOOST_REQUIRE(node);
+    BOOST_CHECK(node->fragment == miniscript::Fragment::MULTI_A);
+    BOOST_CHECK(node->IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(has_if_fragment_clean)
+{
+    auto pk_pol = Parse("pk(A)");
+    BOOST_REQUIRE(pk_pol);
+    auto pk_node = policy::CompileLeaf<std::string>(*pk_pol);
+    BOOST_REQUIRE(pk_node);
+    BOOST_CHECK(!pk_node->HasBranchingOpcodes());
+
+    auto and_pol = Parse("and(pk(A),pk(B))");
+    BOOST_REQUIRE(and_pol);
+    auto and_node = policy::CompileLeaf<std::string>(*and_pol);
+    BOOST_REQUIRE(and_node);
+    BOOST_CHECK(!and_node->HasBranchingOpcodes());
+}
+
+BOOST_AUTO_TEST_CASE(huffman_basic)
+{
+    {
+        auto result = policy::HuffmanTree({1.0});
+        BOOST_CHECK_EQUAL(result.size(), 1U);
+        BOOST_CHECK_EQUAL(result[0].second, 0);
+    }
+
+    {
+        auto result = policy::HuffmanTree({1.0, 1.0});
+        BOOST_CHECK_EQUAL(result.size(), 2U);
+        BOOST_CHECK_EQUAL(result[0].second, 1);
+        BOOST_CHECK_EQUAL(result[1].second, 1);
+    }
+
+    {
+        auto result = policy::HuffmanTree({0.5, 0.25, 0.25});
+        BOOST_CHECK_EQUAL(result.size(), 3U);
+        std::vector<int> depths(3);
+        for (const auto& [idx, depth] : result) {
+            depths[idx] = depth;
+        }
+        BOOST_CHECK_EQUAL(depths[0], 1);
+        BOOST_CHECK_EQUAL(depths[1], 2);
+        BOOST_CHECK_EQUAL(depths[2], 2);
+    }
+
+    {
+        auto result = policy::HuffmanTree({1.0, 1.0, 1.0, 1.0});
+        BOOST_CHECK_EQUAL(result.size(), 4U);
+        for (const auto& [idx, depth] : result) {
+            BOOST_CHECK_EQUAL(depth, 2);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(compile_tr_native_full)
+{
+    {
+        auto pol = Parse("or(pk(A),pk(B))");
+        BOOST_REQUIRE(pol);
+        auto result = policy::CompileTrNative<std::string>(*pol);
+        BOOST_REQUIRE(result.has_value());
+        auto& [scripts, depths] = *result;
+        BOOST_CHECK_EQUAL(scripts.size(), 2U);
+        BOOST_CHECK_EQUAL(depths.size(), 2U);
+        for (size_t i = 0; i < scripts.size(); ++i) {
+            BOOST_CHECK(scripts[i]->IsValid());
+            BOOST_CHECK(!scripts[i]->HasBranchingOpcodes());
+        }
+        BOOST_CHECK(TaprootBuilder::ValidDepths(depths));
+    }
+
+    {
+        auto pol = Parse("and(or(pk(A),pk(B)),pk(C))");
+        BOOST_REQUIRE(pol);
+        auto result = policy::CompileTrNative<std::string>(*pol);
+        BOOST_REQUIRE(result.has_value());
+        auto& [scripts, depths] = *result;
+        BOOST_CHECK_EQUAL(scripts.size(), 2U);
+        BOOST_CHECK_EQUAL(depths.size(), 2U);
+        for (size_t i = 0; i < scripts.size(); ++i) {
+            BOOST_CHECK(scripts[i]->IsValid());
+            BOOST_CHECK(!scripts[i]->HasBranchingOpcodes());
+        }
+        BOOST_CHECK(TaprootBuilder::ValidDepths(depths));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(max_leaves_exceeded)
+{
+    auto pol = Parse("thresh(2,pk(A),pk(B),pk(C),pk(D),pk(E),pk(F),pk(G),pk(H),pk(I),pk(J))");
+    BOOST_REQUIRE(pol);
+    auto leaves = policy::EnumerateLeaves(*pol, 2);
+    BOOST_CHECK(leaves.size() <= 2U);
+
+    auto leaves_full = policy::EnumerateLeaves(*pol);
+    BOOST_CHECK(leaves_full.size() > 2U);
+}
+
 BOOST_AUTO_TEST_CASE(reject_invalid_timelock)
 {
     BOOST_CHECK(!Parse("older(0)"));
@@ -112,6 +299,70 @@ BOOST_AUTO_TEST_CASE(combinations_overflow_limit)
     BOOST_CHECK(!policy::detail::Combinations(20, 10, result, 5));
 }
 
+BOOST_AUTO_TEST_CASE(bolt3_to_local)
+{
+    auto pol = Parse("or(pk(R),and(pk(L),older(1008)))");
+    BOOST_REQUIRE(pol);
+    auto result = policy::CompileTrNative<std::string>(*pol);
+    BOOST_REQUIRE(result.has_value());
+    auto& [scripts, depths] = *result;
+    BOOST_CHECK_EQUAL(scripts.size(), 2U);
+    for (size_t i = 0; i < scripts.size(); ++i) {
+        BOOST_CHECK(scripts[i]->IsValid());
+        BOOST_CHECK(!scripts[i]->HasBranchingOpcodes());
+    }
+    BOOST_CHECK(TaprootBuilder::ValidDepths(depths));
+}
+
+BOOST_AUTO_TEST_CASE(cross_product_and_of_ors)
+{
+    auto pol = Parse("and(or(pk(A),pk(B)),or(pk(C),pk(D)))");
+    BOOST_REQUIRE(pol);
+    auto result = policy::CompileTrNative<std::string>(*pol);
+    BOOST_REQUIRE(result.has_value());
+    auto& [scripts, depths] = *result;
+    BOOST_CHECK_EQUAL(scripts.size(), 4U);
+    for (size_t i = 0; i < scripts.size(); ++i) {
+        BOOST_CHECK(scripts[i]->IsValid());
+        BOOST_CHECK(!scripts[i]->HasBranchingOpcodes());
+    }
+    BOOST_CHECK(TaprootBuilder::ValidDepths(depths));
+}
+
+BOOST_AUTO_TEST_CASE(thresh_2_of_4)
+{
+    auto pol = Parse("thresh(2,pk(A),pk(B),pk(C),pk(D))");
+    BOOST_REQUIRE(pol);
+    auto result = policy::CompileTrNative<std::string>(*pol);
+    BOOST_REQUIRE(result.has_value());
+    auto& [scripts, depths] = *result;
+    BOOST_CHECK_EQUAL(scripts.size(), 6U);
+    for (size_t i = 0; i < scripts.size(); ++i) {
+        BOOST_CHECK(scripts[i]->IsValid());
+        BOOST_CHECK(!scripts[i]->HasBranchingOpcodes());
+    }
+    BOOST_CHECK(TaprootBuilder::ValidDepths(depths));
+}
+
+BOOST_AUTO_TEST_CASE(has_branching_opcodes_positive)
+{
+    using namespace miniscript;
+    constexpr auto CTX = MiniscriptContext::TAPSCRIPT;
+
+    auto pk_a = MakeNodeRef<std::string>(internal::NoDupCheck{}, CTX, Fragment::WRAP_C,
+        Vector(MakeNodeRef<std::string>(internal::NoDupCheck{}, CTX, Fragment::PK_K,
+            std::vector<std::string>{"A"})));
+    auto pk_b = MakeNodeRef<std::string>(internal::NoDupCheck{}, CTX, Fragment::WRAP_C,
+        Vector(MakeNodeRef<std::string>(internal::NoDupCheck{}, CTX, Fragment::PK_K,
+            std::vector<std::string>{"B"})));
+
+    BOOST_CHECK(!pk_a->HasBranchingOpcodes());
+
+    auto or_i = MakeNodeRef<std::string>(internal::NoDupCheck{}, CTX, Fragment::OR_I,
+        Vector(std::move(pk_a), std::move(pk_b)));
+    BOOST_CHECK(or_i->HasBranchingOpcodes());
+}
+
 BOOST_AUTO_TEST_CASE(recursion_depth_limit)
 {
     std::string deep = "pk(A)";
@@ -120,6 +371,64 @@ BOOST_AUTO_TEST_CASE(recursion_depth_limit)
     }
     auto pol = Parse(deep);
     BOOST_CHECK(!pol);
+}
+
+BOOST_AUTO_TEST_CASE(taptree_depth_limit)
+{
+    {
+        auto pol = Parse("or(pk(A),pk(B))");
+        BOOST_REQUIRE(pol);
+        auto result = policy::CompileTrNative<std::string>(*pol, 7);
+        BOOST_REQUIRE(result.has_value());
+        auto& [scripts, depths] = *result;
+        for (int d : depths) {
+            BOOST_CHECK(d <= 7);
+        }
+    }
+
+    {
+        std::string pol_str = "or(pk(K0)";
+        for (int i = 1; i < 128; ++i) {
+            pol_str += ",pk(K" + util::ToString(i) + ")";
+        }
+        pol_str += ")";
+        auto pol = Parse(pol_str);
+        BOOST_REQUIRE(pol);
+        auto result = policy::CompileTrNative<std::string>(*pol, 7);
+        BOOST_REQUIRE(result.has_value());
+        auto& [scripts, depths] = *result;
+        BOOST_CHECK_EQUAL(scripts.size(), 128U);
+        for (int d : depths) {
+            BOOST_CHECK(d <= 7);
+        }
+    }
+
+    {
+        std::string pol_str = "or(pk(K0)";
+        for (int i = 1; i < 129; ++i) {
+            pol_str += ",pk(K" + util::ToString(i) + ")";
+        }
+        pol_str += ")";
+        auto pol = Parse(pol_str);
+        BOOST_REQUIRE(pol);
+        auto result = policy::CompileTrNative<std::string>(*pol, 7);
+        BOOST_CHECK(!result.has_value());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(standard_depth_allows_more_leaves)
+{
+    std::string pol_str = "or(pk(K0)";
+    for (int i = 1; i < 129; ++i) {
+        pol_str += ",pk(K" + util::ToString(i) + ")";
+    }
+    pol_str += ")";
+    auto pol = Parse(pol_str);
+    BOOST_REQUIRE(pol);
+    auto result = policy::CompileTrNative<std::string>(*pol, TAPROOT_CONTROL_MAX_NODE_COUNT);
+    BOOST_REQUIRE(result.has_value());
+    auto& [scripts, depths] = *result;
+    BOOST_CHECK_EQUAL(scripts.size(), 129U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/policy_tests.cpp
+++ b/src/test/policy_tests.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 The Bitcoin Knots developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/policy.h>
+#include <test/util/setup_common.h>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+namespace policy_tests {
+
+struct StringCtx {
+    template<typename I>
+    std::optional<std::string> FromString(I begin, I end) const {
+        std::string s(begin, end);
+        if (s.empty()) return std::nullopt;
+        return s;
+    }
+};
+
+static const StringCtx CTX{};
+
+static std::shared_ptr<const policy::Policy<std::string>> Parse(const std::string& str) {
+    Span<const char> sp{str.data(), str.size()};
+    return policy::ParsePolicy<std::string>(sp, CTX);
+}
+
+BOOST_FIXTURE_TEST_SUITE(policy_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(parse_basic)
+{
+    auto pk_a = Parse("pk(A)");
+    BOOST_REQUIRE(pk_a);
+    BOOST_CHECK(pk_a->type == policy::PolicyType::PK);
+    BOOST_CHECK_EQUAL(pk_a->keys.size(), 1U);
+    BOOST_CHECK_EQUAL(pk_a->keys[0], "A");
+
+    auto older = Parse("older(144)");
+    BOOST_REQUIRE(older);
+    BOOST_CHECK(older->type == policy::PolicyType::OLDER);
+    BOOST_CHECK_EQUAL(older->k, 144U);
+
+    auto after = Parse("after(500000)");
+    BOOST_REQUIRE(after);
+    BOOST_CHECK(after->type == policy::PolicyType::AFTER);
+    BOOST_CHECK_EQUAL(after->k, 500000U);
+
+    auto and_pol = Parse("and(pk(A),pk(B))");
+    BOOST_REQUIRE(and_pol);
+    BOOST_CHECK(and_pol->type == policy::PolicyType::AND);
+    BOOST_CHECK_EQUAL(and_pol->subs.size(), 2U);
+    BOOST_CHECK(and_pol->subs[0]->type == policy::PolicyType::PK);
+    BOOST_CHECK(and_pol->subs[1]->type == policy::PolicyType::PK);
+
+    auto or_pol = Parse("or(pk(A),pk(B))");
+    BOOST_REQUIRE(or_pol);
+    BOOST_CHECK(or_pol->type == policy::PolicyType::OR);
+    BOOST_CHECK_EQUAL(or_pol->subs.size(), 2U);
+    BOOST_CHECK_EQUAL(or_pol->weights[0], 1.0);
+    BOOST_CHECK_EQUAL(or_pol->weights[1], 1.0);
+
+    auto or_weighted = Parse("or(3@pk(A),1@pk(B))");
+    BOOST_REQUIRE(or_weighted);
+    BOOST_CHECK(or_weighted->type == policy::PolicyType::OR);
+    BOOST_CHECK_EQUAL(or_weighted->weights[0], 3.0);
+    BOOST_CHECK_EQUAL(or_weighted->weights[1], 1.0);
+
+    auto thresh = Parse("thresh(2,pk(A),pk(B),pk(C))");
+    BOOST_REQUIRE(thresh);
+    BOOST_CHECK(thresh->type == policy::PolicyType::THRESH);
+    BOOST_CHECK_EQUAL(thresh->k, 2U);
+    BOOST_CHECK_EQUAL(thresh->subs.size(), 3U);
+
+    auto invalid = Parse("garbage(stuff)");
+    BOOST_CHECK(!invalid);
+}
+
+BOOST_AUTO_TEST_CASE(reject_invalid_timelock)
+{
+    BOOST_CHECK(!Parse("older(0)"));
+    BOOST_CHECK(!Parse("after(0)"));
+    BOOST_CHECK(!Parse("older(2147483648)"));
+    BOOST_CHECK(!Parse("after(2147483648)"));
+    BOOST_CHECK(Parse("older(1)"));
+    BOOST_CHECK(Parse("after(1)"));
+    BOOST_CHECK(Parse("older(2147483647)"));
+    BOOST_CHECK(Parse("after(2147483647)"));
+}
+
+BOOST_AUTO_TEST_CASE(combinations_k_zero)
+{
+    std::vector<std::vector<size_t>> result;
+    BOOST_CHECK(policy::detail::Combinations(5, 0, result));
+    BOOST_CHECK_EQUAL(result.size(), 1U);
+    BOOST_CHECK(result[0].empty());
+}
+
+BOOST_AUTO_TEST_CASE(combinations_k_greater_than_n)
+{
+    std::vector<std::vector<size_t>> result;
+    BOOST_CHECK(!policy::detail::Combinations(3, 5, result));
+    BOOST_CHECK(result.empty());
+}
+
+BOOST_AUTO_TEST_CASE(combinations_overflow_limit)
+{
+    std::vector<std::vector<size_t>> result;
+    BOOST_CHECK(!policy::detail::Combinations(20, 10, result, 5));
+}
+
+BOOST_AUTO_TEST_CASE(recursion_depth_limit)
+{
+    std::string deep = "pk(A)";
+    for (int i = 0; i < 150; ++i) {
+        deep = "and(" + deep + ",pk(A))";
+    }
+    auto pol = Parse(deep);
+    BOOST_CHECK(!pol);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace policy_tests


### PR DESCRIPTION
Adds `compile_tr()` which decomposes all `Or` and `Thresh` branches into separate TapTree leaves instead of using `OP_IF`/`OP_NOTIF` within a single leaf. Each leaf is compiled to branch-free Tapscript and assembled into a Huffman-weighted TapTree.

Also adds `HasBranchingOpcodes()` to `miniscript::Node` for detecting `OP_IF`/`OP_NOTIF`-emitting fragments in compiled Tapscript.

For reference: https://github.com/rust-bitcoin/rust-miniscript/pull/906