### PR TITLE
qt: Toggle banned peers visibility

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -889,6 +889,9 @@
        <string>&amp;Peers</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_6">
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item>
         <widget class="QSplitter" name="splitter">
          <property name="orientation">
@@ -911,6 +914,9 @@
            </size>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_7">
+           <property name="bottomMargin">
+            <number>15</number>  <!-- Remove bottom margin -->
+           </property>
            <item>
             <widget class="QTableView" name="peerWidget">
              <property name="tabKeyNavigation">
@@ -934,46 +940,82 @@
             </widget>
            </item>
            <item>
-            <widget class="QLabel" name="banHeading">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+            <layout class="QHBoxLayout" name="banHeadingLayout">
+             <property name="spacing">
+              <number>8</number>
              </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>32</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>32</height>
-              </size>
-             </property>
-             <property name="font">
-              <font>
-               <pointsize>12</pointsize>
-              </font>
-             </property>
-             <property name="cursor">
-              <cursorShape>IBeamCursor</cursorShape>
-             </property>
-             <property name="text">
-              <string>Banned peers</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-             <property name="textInteractionFlags">
-              <set>Qt::NoTextInteraction</set>
-             </property>
-            </widget>
+             <item>
+              <widget class="QLabel" name="banHeading">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>32</height>
+                </size>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>12</pointsize>
+                </font>
+               </property>
+               <property name="cursor">
+                <cursorShape>IBeamCursor</cursorShape>
+               </property>
+               <property name="text">
+                <string>Banned peers</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::NoTextInteraction</set>
+               </property>
+              </widget>
+             </item>
+             <item alignment="Qt::AlignBottom">
+              <widget class="QPushButton" name="banToggleButton">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>60</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="cursor">
+                <cursorShape>PointingHandCursor</cursorShape>
+               </property>
+               <property name="text">
+                <string>Hide</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="banHeadingSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
            </item>
            <item>
             <widget class="QTableView" name="banlistWidget">
@@ -1007,117 +1049,117 @@
            </size>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_8">
-            <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_8">
-                <property name="topMargin">
-                  <number>0</number>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_8">
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="peerHeading">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>32</height>
+                </size>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="cursor">
+                <cursorShape>IBeamCursor</cursorShape>
+               </property>
+               <property name="text">
+                <string>Select a peer to view detailed information.</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignHCenter|Qt::AlignTop</set>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QWidget" name="hidePeersDetail" native="true">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>32</width>
+                 <height>32</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>32</width>
+                 <height>32</height>
+                </size>
+               </property>
+               <widget class="QToolButton" name="hidePeersDetailButton">
+                <property name="geometry">
+                 <rect>
+                  <x>0</x>
+                  <y>0</y>
+                  <width>32</width>
+                  <height>32</height>
+                 </rect>
                 </property>
-                <property name="bottomMargin">
-                  <number>0</number>
+                <property name="minimumSize">
+                 <size>
+                  <width>32</width>
+                  <height>32</height>
+                 </size>
                 </property>
-                <item>
-                  <widget class="QLabel" name="peerHeading">
-                  <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                    </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                    <size>
-                    <width>0</width>
-                    <height>32</height>
-                    </size>
-                  </property>
-                  <property name="font">
-                    <font>
-                    <pointsize>10</pointsize>
-                    </font>
-                  </property>
-                  <property name="cursor">
-                    <cursorShape>IBeamCursor</cursorShape>
-                  </property>
-                  <property name="text">
-                    <string>Select a peer to view detailed information.</string>
-                  </property>
-                  <property name="alignment">
-                    <set>Qt::AlignHCenter|Qt::AlignTop</set>
-                  </property>
-                  <property name="wordWrap">
-                    <bool>true</bool>
-                  </property>
-                  <property name="textInteractionFlags">
-                    <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                  </property>
-                  </widget>
-                </item>
-                <item>
-                  <widget class="QWidget" name="hidePeersDetail" native="true">
-                    <property name="enabled">
-                      <bool>true</bool>
-                    </property>
-                    <property name="minimumSize">
-                      <size>
-                        <width>32</width>
-                        <height>32</height>
-                      </size>
-                    </property>
-                    <property name="maximumSize">
-                      <size>
-                        <width>32</width>
-                        <height>32</height>
-                      </size>
-                    </property>
-                    <widget class="QToolButton" name="hidePeersDetailButton">
-                      <property name="geometry">
-                        <rect>
-                          <x>0</x>
-                          <y>0</y>
-                          <width>32</width>
-                          <height>32</height>
-                        </rect>
-                      </property>
-                      <property name="minimumSize">
-                        <size>
-                          <width>32</width>
-                          <height>32</height>
-                        </size>
-                      </property>
-                      <property name="baseSize">
-                        <size>
-                          <width>32</width>
-                          <height>32</height>
-                        </size>
-                      </property>
-                      <property name="toolTip">
-                        <string>Hide Peers Detail</string>
-                      </property>
-                      <property name="layoutDirection">
-                        <enum>Qt::LeftToRight</enum>
-                      </property>
-                      <property name="text">
-                        <string />
-                      </property>
-                      <property name="icon">
-                        <iconset resource="../bitcoin.qrc">
-                          <normaloff>:/icons/remove</normaloff>
-                          :/icons/remove
-                        </iconset>
-                      </property>
-                      <property name="iconSize">
-                        <size>
-                          <width>22</width>
-                          <height>22</height>
-                        </size>
-                      </property>
-                      <property name="shortcut">
-                        <string>Ctrl+X</string>
-                      </property>
-                    </widget>
-                  </widget>
-                </item>
-              </layout>
-            </item>
+                <property name="baseSize">
+                 <size>
+                  <width>32</width>
+                  <height>32</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string>Hide Peers Detail</string>
+                </property>
+                <property name="layoutDirection">
+                 <enum>Qt::LeftToRight</enum>
+                </property>
+                <property name="text">
+                 <string />
+                </property>
+                <property name="icon">
+                 <iconset resource="../bitcoin.qrc">
+                  <normaloff>:/icons/remove</normaloff>
+                  :/icons/remove                        
+                 </iconset>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>22</width>
+                  <height>22</height>
+                 </size>
+                </property>
+                <property name="shortcut">
+                 <string>Ctrl+X</string>
+                </property>
+               </widget>
+              </widget>
+             </item>
+            </layout>
+           </item>
            <item>
             <widget class="QScrollArea" name="scrollArea">
              <property name="widgetResizable">

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -915,7 +915,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_7">
            <property name="bottomMargin">
-            <number>15</number>  <!-- Remove bottom margin -->
+            <number>22</number>
            </property>
            <item>
             <widget class="QTableView" name="peerWidget">
@@ -940,97 +940,106 @@
             </widget>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="banHeadingLayout">
-             <property name="spacing">
-              <number>8</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="banHeading">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>32</height>
-                </size>
-               </property>
-               <property name="font">
-                <font>
-                 <pointsize>12</pointsize>
-                </font>
-               </property>
-               <property name="cursor">
-                <cursorShape>IBeamCursor</cursorShape>
-               </property>
-               <property name="text">
-                <string>Banned peers</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-               <property name="textInteractionFlags">
-                <set>Qt::NoTextInteraction</set>
-               </property>
-              </widget>
-             </item>
-             <item alignment="Qt::AlignBottom">
-              <widget class="QPushButton" name="banToggleButton">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>60</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="text">
-                <string>Hide</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="banHeadingSpacer">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <widget class="QTableView" name="banlistWidget">
-             <property name="tabKeyNavigation">
-              <bool>false</bool>
-             </property>
-             <property name="alternatingRowColors">
-              <bool>true</bool>
-             </property>
-             <property name="sortingEnabled">
-              <bool>true</bool>
-             </property>
-             <attribute name="horizontalHeaderHighlightSections">
-              <bool>false</bool>
-             </attribute>
+            <widget class="QWidget" name="banSectionContainer" native="true">
+             <layout class="QVBoxLayout" name="banSectionLayout">
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <layout class="QHBoxLayout" name="banHeadingLayout">
+                <property name="spacing">
+                 <number>8</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="banHeading">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>32</height>
+                   </size>
+                  </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>12</pointsize>
+                   </font>
+                  </property>
+                  <property name="cursor">
+                   <cursorShape>IBeamCursor</cursorShape>
+                  </property>
+                  <property name="text">
+                   <string>Banned peers</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+                  </property>
+                  <property name="wordWrap">
+                   <bool>true</bool>
+                  </property>
+                  <property name="textInteractionFlags">
+                   <set>Qt::NoTextInteraction</set>
+                  </property>
+                 </widget>
+                </item>
+                <item alignment="Qt::AlignBottom">
+                 <widget class="QPushButton" name="banToggleButton">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>60</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="cursor">
+                   <cursorShape>PointingHandCursor</cursorShape>
+                  </property>
+                  <property name="text">
+                   <string>Hide</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="banHeadingSpacer">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <widget class="QTableView" name="banlistWidget">
+                <property name="tabKeyNavigation">
+                 <bool>false</bool>
+                </property>
+                <property name="alternatingRowColors">
+                 <bool>true</bool>
+                </property>
+                <property name="sortingEnabled">
+                 <bool>true</bool>
+                </property>
+                <attribute name="horizontalHeaderHighlightSections">
+                 <bool>false</bool>
+                </attribute>
+               </widget>
+              </item>
+             </layout>
             </widget>
            </item>
           </layout>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -524,6 +524,10 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
     m_peer_widget_header_state = settings.value("PeersTabPeerHeaderState_Knots23").toByteArray();
     m_banlist_widget_header_state = settings.value("PeersTabBanlistHeaderState").toByteArray();
     m_alternating_row_colors = settings.value("PeersTabAlternatingRowColors").toBool();
+    
+    // Set up ban list toggle button
+    m_banlist_visible = settings.value("PeersTabBanlistVisible", true).toBool();
+    connect(ui->banToggleButton, &QPushButton::clicked, this, &RPCConsole::toggleBanlistVisibility);
 
     {
         // Move everything down a row to make room
@@ -1514,8 +1518,27 @@ void RPCConsole::showOrHideBanTableIfRequired()
         return;
 
     bool visible = clientModel->getBanTableModel()->shouldShow();
-    ui->banlistWidget->setVisible(visible);
     ui->banHeading->setVisible(visible);
+    ui->banToggleButton->setVisible(visible);
+            
+    // Show table only if criteria says we should and user has selected to see it
+    ui->banlistWidget->setVisible(visible && m_banlist_visible);
+
+    // Update button text based on current state
+    if (visible) {
+        ui->banToggleButton->setText(m_banlist_visible ? tr("Hide") : tr("Show"));
+    }
+}
+
+void RPCConsole::toggleBanlistVisibility()
+{
+    m_banlist_visible = !m_banlist_visible;
+
+    // Save state to settings
+    QSettings settings;
+    settings.setValue("PeersTabBanlistVisible", m_banlist_visible);
+
+    showOrHideBanTableIfRequired();
 }
 
 std::vector<RPCConsole::TabTypes> RPCConsole::tabs() const

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1518,9 +1518,7 @@ void RPCConsole::showOrHideBanTableIfRequired()
         return;
 
     bool visible = clientModel->getBanTableModel()->shouldShow();
-    ui->banHeading->setVisible(visible);
-    ui->banToggleButton->setVisible(visible);
-            
+    ui->banSectionContainer->setVisible(visible);
     // Show table only if criteria says we should and user has selected to see it
     ui->banlistWidget->setVisible(visible && m_banlist_visible);
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -123,7 +123,8 @@ private Q_SLOTS:
     void resetDetailWidget();
     /** show detailed information on ui about selected node */
     void updateDetailWidget();
-
+    /** toggle visibility of ban list table */
+    void toggleBanlistVisibility();
 public Q_SLOTS:
     void clear(bool keep_prompt = false);
     void fontBigger();
@@ -201,6 +202,7 @@ private:
     QByteArray m_peer_widget_header_state;
     QByteArray m_banlist_widget_header_state;
     bool m_alternating_row_colors{false};
+    bool m_banlist_visible{true};
 
     // Theme Colors
     const ThemeColors *m_theme_colors;

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -125,6 +125,7 @@ private Q_SLOTS:
     void updateDetailWidget();
     /** toggle visibility of ban list table */
     void toggleBanlistVisibility();
+
 public Q_SLOTS:
     void clear(bool keep_prompt = false);
     void fontBigger();


### PR DESCRIPTION
Closes #185 
Adds a Hide / Show button on the banned peer list table which shows / hides banned table if visible. Default is to show. Also persists the state in `QSettings`. 

Also cleaned up some indentation and closing tags in the `debugwindow.ui`

There don't appear to be existing automated tests for individual Peers tab UI elements or visibility toggles. The existing Qt tests focus on RPC command parsing, wallet operations, and high-level integration testing rather than specific widget interactions.

Manually tested:
- Ban a peer -> verify section appears with Hide button
- Click Hide -> verify table collapses, button shows "Show"
- Click Show -> verify table reappears, button shows "Hide"
- Close and reopen Node window -> verify state persists
- Unban all peers → verify section (heading + button + table) disappears
- Button vertical alignment with "Banned peers" label
- No impact on other tabs (Info, Console, Graph)
- No extra spacing when table is hidden
- Waiting for expiry and created #273 which remains (banned peers remain in list after expiry).

Showing:
<img width="1824" height="1356" alt="image" src="https://github.com/user-attachments/assets/25b4d634-e99e-4f56-9d63-a500fdfdc638" />

Hidden:
<img width="1912" height="1368" alt="image" src="https://github.com/user-attachments/assets/95f29030-3fb1-4cbe-89c6-ec7d2ef4d12f" />