### PR TITLE
validation: runtime script verification calibration

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1597,12 +1597,12 @@ static RPCHelpMan scriptthreadsinfo()
                     {
                         {RPCResult::Type::BOOL, "enabled", "true if script verification threads are enabled (see setscriptthreadsenabled)."},
                         {RPCResult::Type::NUM, "num_script_check_threads", "The total number of script verification threads, when enabled."},
-                        {RPCResult::Type::OBJ, "calibration", "Script verification calibration data.",
+                        {RPCResult::Type::OBJ, "calibration", "Startup calibration from sampled ConnectBlock() verification intervals.",
                         {
                             {RPCResult::Type::BOOL, "complete", "Whether calibration has finished."},
                             {RPCResult::Type::NUM, "blocks", "Number of blocks sampled."},
                             {RPCResult::Type::NUM, "inputs", "Total inputs verified during calibration."},
-                            {RPCResult::Type::NUM, "us_per_input", "Average microseconds per input verification."},
+                            {RPCResult::Type::NUM, "us_per_input", "Approximate microseconds per input (includes UTXO and script verification)."},
                         }},
                     },
                 },

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1597,6 +1597,13 @@ static RPCHelpMan scriptthreadsinfo()
                     {
                         {RPCResult::Type::BOOL, "enabled", "true if script verification threads are enabled (see setscriptthreadsenabled)."},
                         {RPCResult::Type::NUM, "num_script_check_threads", "The total number of script verification threads, when enabled."},
+                        {RPCResult::Type::OBJ, "calibration", "Script verification calibration data.",
+                        {
+                            {RPCResult::Type::BOOL, "complete", "Whether calibration has finished."},
+                            {RPCResult::Type::NUM, "blocks", "Number of blocks sampled."},
+                            {RPCResult::Type::NUM, "inputs", "Total inputs verified during calibration."},
+                            {RPCResult::Type::NUM, "us_per_input", "Average microseconds per input verification."},
+                        }},
                     },
                 },
                 RPCExamples{
@@ -1610,6 +1617,18 @@ static RPCHelpMan scriptthreadsinfo()
     size_t thread_count{chainman.m_script_check_queue_enabled ? chainman.GetCheckQueue().ThreadCount() : 0};
     ret.pushKV("enabled", (bool)thread_count);
     ret.pushKV("num_script_check_threads", (int64_t)thread_count + 1);
+
+    UniValue calibration(UniValue::VOBJ);
+    bool cal_done = chainman.m_calibration_done.load(std::memory_order_acquire);
+    int cal_blocks = chainman.m_calibration_blocks.load(std::memory_order_relaxed);
+    int64_t cal_inputs = chainman.m_calibration_inputs.load(std::memory_order_relaxed);
+    int64_t cal_time_us = chainman.m_calibration_time_us.load(std::memory_order_relaxed);
+    calibration.pushKV("complete", cal_done);
+    calibration.pushKV("blocks", cal_blocks);
+    calibration.pushKV("inputs", cal_inputs);
+    calibration.pushKV("us_per_input", cal_inputs > 0 ? static_cast<double>(cal_time_us) / cal_inputs : 0.0);
+    ret.pushKV("calibration", calibration);
+
     return ret;
 },
     };

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3005,7 +3005,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
                 int64_t total_us = m_chainman.m_calibration_time_us.load(std::memory_order_relaxed);
                 double us_per_input = total_inputs > 0 ? static_cast<double>(total_us) / total_inputs : 0.0;
                 size_t thread_count = parallel_script_checks ? m_chainman.GetCheckQueue().ThreadCount() + 1 : 1;
-                LogInfo("Script verification calibration complete: %.1f us/input with %d threads (%d blocks, %d inputs)",
+                LogInfo("Verification calibration complete: ~%.1f us/input with %d threads (%d blocks, %d inputs)",
                         us_per_input, thread_count, blocks, total_inputs);
             }
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2993,6 +2993,24 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
              Ticks<SecondsDouble>(m_chainman.time_verify),
              Ticks<MillisecondsDouble>(m_chainman.time_verify) / m_chainman.num_blocks_total);
 
+    if (fScriptChecks && nInputs > 1 && !m_chainman.m_calibration_done.load(std::memory_order_relaxed)) {
+        int64_t verify_us = Ticks<std::chrono::microseconds>(time_4 - time_2);
+        m_chainman.m_calibration_inputs.fetch_add(nInputs - 1, std::memory_order_relaxed);
+        m_chainman.m_calibration_time_us.fetch_add(verify_us, std::memory_order_relaxed);
+        int blocks = m_chainman.m_calibration_blocks.fetch_add(1, std::memory_order_relaxed) + 1;
+        if (blocks >= ChainstateManager::CALIBRATION_SAMPLE_BLOCKS) {
+            bool expected = false;
+            if (m_chainman.m_calibration_done.compare_exchange_strong(expected, true, std::memory_order_release)) {
+                int64_t total_inputs = m_chainman.m_calibration_inputs.load(std::memory_order_relaxed);
+                int64_t total_us = m_chainman.m_calibration_time_us.load(std::memory_order_relaxed);
+                double us_per_input = total_inputs > 0 ? static_cast<double>(total_us) / total_inputs : 0.0;
+                size_t thread_count = parallel_script_checks ? m_chainman.GetCheckQueue().ThreadCount() + 1 : 1;
+                LogInfo("Script verification calibration complete: %.1f us/input with %d threads (%d blocks, %d inputs)",
+                        us_per_input, thread_count, blocks, total_inputs);
+            }
+        }
+    }
+
     if (fJustCheck) {
         return true;
     }

--- a/src/validation.h
+++ b/src/validation.h
@@ -990,6 +990,12 @@ private:
     SteadyClock::duration GUARDED_BY(::cs_main) time_post_connect{};
 
 public:
+    static constexpr int CALIBRATION_SAMPLE_BLOCKS{100};
+    std::atomic<int> m_calibration_blocks{0};
+    std::atomic<int64_t> m_calibration_inputs{0};
+    std::atomic<int64_t> m_calibration_time_us{0};
+    std::atomic<bool> m_calibration_done{false};
+
     using Options = kernel::ChainstateManagerOpts;
 
     explicit ChainstateManager(const util::SignalInterrupt& interrupt, Options options, node::BlockManager::Options blockman_options);


### PR DESCRIPTION
Calibrate script verification throughput at startup by sampling the first 100 blocks with script checks enabled, then expose the result via `scriptthreadsinfo` RPC.

Also raises `MAX_SCRIPTCHECK_THREADS` to 256 and clamps actual thread count to `nCores-1` to avoid context-switch overhead on high-core machines.

Closes #143