### PR TITLE
policy: Adapt vsize based on coinblocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           # Run tests on commits after the last merge commit and before the PR head commit
           # Use clang++, because it is a bit faster and uses less memory than g++
-          git rebase --exec "echo Running test-one-commit on \$( git log -1 ) && CC=clang CXX=clang++ cmake -B build -DWERROR=ON -DWITH_ZMQ=ON -DBUILD_GUI=ON -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON -DWITH_BDB=ON -DWITH_MINIUPNPC=ON -DWITH_USDT=ON -DCMAKE_CXX_FLAGS='-Wno-error=unused-member-function' && cmake --build build -j $(nproc) && ctest --output-on-failure --stop-on-failure --test-dir build -j $(nproc) && ./build/test/functional/test_runner.py -j $(( $(nproc) * 2 )) --combinedlogslen=99999999" ${{ env.TEST_BASE }}
+          git rebase --exec "echo Running test-one-commit on \$( git log -1 ) && CC=clang CXX=clang++ cmake -B build -DWERROR=ON -DWITH_ZMQ=ON -DBUILD_GUI=ON -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON -DWITH_BDB=ON -DWARN_INCOMPATIBLE_BDB=OFF -DWITH_MINIUPNPC=ON -DWITH_USDT=ON -DCMAKE_CXX_FLAGS='-Wno-error=unused-member-function' && cmake --build build -j $(nproc) && ctest --output-on-failure --stop-on-failure --test-dir build -j $(nproc) && ./build/test/functional/test_runner.py -j $(( $(nproc) * 2 )) --combinedlogslen=99999999" ${{ env.TEST_BASE }}
 
   macos-native-arm64:
     name: ${{ matrix.job-name }}
@@ -189,7 +189,7 @@ jobs:
         job-type: [standard, fuzz]
         include:
           - job-type: standard
-            generate-options: '-DBUILD_GUI=OFF -DWITH_BDB=ON -DWITH_MINIUPNPC=ON -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DWERROR=ON'
+            generate-options: '-DBUILD_GUI=OFF -DWITH_BDB=ON -DWARN_INCOMPATIBLE_BDB=OFF -DWITH_MINIUPNPC=ON -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DWERROR=ON'
             job-name: 'Win64 native, VS 2022'
           - job-type: fuzz
             generate-options: '-DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES="sqlite" -DBUILD_GUI=OFF -DBUILD_FOR_FUZZING=ON -DWERROR=ON'

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -714,7 +714,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-bytespersigopstrict", strprintf("Minimum bytes per sigop in transactions we relay and mine (default: %u)", DEFAULT_BYTES_PER_SIGOP_STRICT), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarrier", strprintf("Relay and mine data carrier transactions (default: %u)", DEFAULT_ACCEPT_DATACARRIER), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarriercost", strprintf("Treat extra data in transactions as at least N vbytes per actual byte (default: %s)", DEFAULT_WEIGHT_PER_DATA_BYTE / 4.0), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
-    argsman.AddArg("-priorityvsizediscount", strprintf("Discount vsize for transactions with coin-age priority (default: %u)", DEFAULT_PRIORITY_VSIZE_DISCOUNT), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-coinblocksvsizediscount", strprintf("Discount vsize for transactions with high coinblocks (default: %u)", DEFAULT_COINBLOCKS_VSIZE_DISCOUNT), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarrierfullcount", strprintf("Apply datacarriersize limit to all known datacarrier methods (default: %u)", DEFAULT_DATACARRIER_FULLCOUNT), ArgsManager::ALLOW_ANY | (DEFAULT_DATACARRIER_FULLCOUNT ? uint32_t{ArgsManager::DEBUG_ONLY} : 0), OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarriersize",
                    strprintf("Maximum size of data in data carrier transactions we relay and mine, in bytes (default: %u)",
@@ -867,7 +867,7 @@ void InitParameterInteraction(ArgsManager& args)
         args.SoftSetArg("-permitephemeral", "anchor,send,dust");
         args.SoftSetArg("-spkreuse", "allow");
         args.SoftSetArg("-blockprioritysize", "0");
-        args.SoftSetArg("-priorityvsizediscount", "0");
+        args.SoftSetArg("-coinblocksvsizediscount", "0");
         args.SoftSetArg("-blockmaxsize", "4000000");
         args.SoftSetArg("-blockmaxweight", "4000000");
     }
@@ -1200,7 +1200,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         g_weight_per_data_byte = ((*parsed * WITNESS_SCALE_FACTOR) + 99) / 100;
     }
 
-    g_priority_vsize_discount = args.GetBoolArg("-priorityvsizediscount", DEFAULT_PRIORITY_VSIZE_DISCOUNT);
+    g_coinblocks_vsize_discount = args.GetBoolArg("-coinblocksvsizediscount", DEFAULT_COINBLOCKS_VSIZE_DISCOUNT);
 
     g_script_size_policy_limit = args.GetIntArg("-maxscriptsize", g_script_size_policy_limit);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -714,6 +714,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-bytespersigopstrict", strprintf("Minimum bytes per sigop in transactions we relay and mine (default: %u)", DEFAULT_BYTES_PER_SIGOP_STRICT), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarrier", strprintf("Relay and mine data carrier transactions (default: %u)", DEFAULT_ACCEPT_DATACARRIER), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarriercost", strprintf("Treat extra data in transactions as at least N vbytes per actual byte (default: %s)", DEFAULT_WEIGHT_PER_DATA_BYTE / 4.0), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-priorityvsizediscount", strprintf("Discount vsize for transactions with coin-age priority (default: %u)", DEFAULT_PRIORITY_VSIZE_DISCOUNT), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarrierfullcount", strprintf("Apply datacarriersize limit to all known datacarrier methods (default: %u)", DEFAULT_DATACARRIER_FULLCOUNT), ArgsManager::ALLOW_ANY | (DEFAULT_DATACARRIER_FULLCOUNT ? uint32_t{ArgsManager::DEBUG_ONLY} : 0), OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarriersize",
                    strprintf("Maximum size of data in data carrier transactions we relay and mine, in bytes (default: %u)",
@@ -866,6 +867,7 @@ void InitParameterInteraction(ArgsManager& args)
         args.SoftSetArg("-permitephemeral", "anchor,send,dust");
         args.SoftSetArg("-spkreuse", "allow");
         args.SoftSetArg("-blockprioritysize", "0");
+        args.SoftSetArg("-priorityvsizediscount", "0");
         args.SoftSetArg("-blockmaxsize", "4000000");
         args.SoftSetArg("-blockmaxweight", "4000000");
     }
@@ -1197,6 +1199,8 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     if (auto parsed = args.GetFixedPointArg("-datacarriercost", 2)) {
         g_weight_per_data_byte = ((*parsed * WITNESS_SCALE_FACTOR) + 99) / 100;
     }
+
+    g_priority_vsize_discount = args.GetBoolArg("-priorityvsizediscount", DEFAULT_PRIORITY_VSIZE_DISCOUNT);
 
     g_script_size_policy_limit = args.GetIntArg("-maxscriptsize", g_script_size_policy_limit);
 

--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -15,6 +15,7 @@
 #include <util/epochguard.h>
 #include <util/overflow.h>
 
+#include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <functional>
@@ -193,7 +194,7 @@ public:
     const CAmount& GetFee() const { return nFee; }
     int32_t GetTxSize() const
     {
-        return GetVirtualTransactionSize(nTxWeight + m_base_extra_weight + m_coinblocks_weight_discount, sigOpCost, ::nBytesPerSigOp);
+        return std::max<int32_t>(GetVirtualTransactionSize(nTxWeight + m_base_extra_weight + m_coinblocks_weight_discount, sigOpCost, ::nBytesPerSigOp), 1);
     }
     int32_t GetTxWeight() const { return nTxWeight; }
     std::chrono::seconds GetTime() const { return std::chrono::seconds{nTime}; }

--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -96,12 +96,14 @@ private:
     const int64_t nTime;            //!< Local time when entering the mempool
     const uint64_t entry_sequence;  //!< Sequence number used to determine whether this transaction is too recent for relay
     const int64_t sigOpCost;        //!< Total sigop cost
-    const int32_t m_extra_weight;   //!< Policy-only additional transaction weight beyond nTxWeight
-    const size_t nModSize;          //!< Cached modified size for priority
+    const int32_t m_base_extra_weight;       //!< Policy-only extra weight (e.g. datacarrier), never changes
+    int32_t m_coinblocks_weight_discount;    //!< Coinblocks vsize discount (negative or zero), updated as coin age increases
+    size_t nModSize;                //!< Cached modified size for priority
     const double entryPriority;     //!< Priority when entering the mempool
     const unsigned int entryHeight; //!< Chain height when entering the mempool
     double cachedPriority;          //!< Last calculated priority
     unsigned int cachedHeight;      //!< Height at which priority was last calculated
+    double m_cached_coin_age;       //!< Cached sum coin-age of confirmed inputs (satoshi-blocks)
     CAmount inChainInputValue;      //!< Sum of all txin values that are already in blockchain
     const bool spendsCoinbase;      //!< keep track of transactions that spend a coinbase
     CAmount m_modified_fee;         //!< Used for determining the priority of the transaction for mining in a block
@@ -136,13 +138,17 @@ public:
           nTime{time},
           entry_sequence{entry_sequence},
           sigOpCost{sigops_cost},
-          m_extra_weight{extra_weight},
+          m_base_extra_weight{extra_weight},
+          m_coinblocks_weight_discount{::g_coinblocks_vsize_discount ?
+              CalculateCoinblocksWeightDiscount(coin_age_cache.inputs_coin_age, GetTransactionWeight(*tx),
+                  MIN_STANDARD_TX_NONWITNESS_SIZE * WITNESS_SCALE_FACTOR) : 0},
           nModSize{CalculateModifiedSize(*tx, GetTxSize())},
           entryPriority{ComputePriority2(coin_age_cache.inputs_coin_age, nModSize)},
           entryHeight{entry_height},
           cachedPriority{entryPriority},
           // Since entries arrive *after* the tip's height, their entry priority is for the height+1
           cachedHeight{entry_height + 1},
+          m_cached_coin_age{coin_age_cache.inputs_coin_age},
           inChainInputValue{coin_age_cache.in_chain_input_value},
           spendsCoinbase{spends_coinbase},
           m_modified_fee{nFee},
@@ -168,7 +174,7 @@ public:
     double GetStartingPriority() const {return entryPriority; }
     CoinAgeCache GetInternalCoinAgeCache() const {
         return {
-            .inputs_coin_age = ReversePriority2(cachedPriority, nModSize),
+            .inputs_coin_age = m_cached_coin_age,
             .in_chain_input_value = inChainInputValue,
         };
     }
@@ -180,18 +186,20 @@ public:
     /**
      * Recalculate the cached priority as of currentHeight and adjust inChainInputValue by
      * valueInCurrentBlock which represents input that was just added to or removed from the blockchain.
+     * Also recalculates the coinblocks weight discount based on updated coin age.
+     * @return The change in GetTxSize() caused by the discount update (0 if unchanged).
      */
-    void UpdateCachedPriority(unsigned int currentHeight, CAmount valueInCurrentBlock);
+    int32_t UpdateCachedPriority(unsigned int currentHeight, CAmount valueInCurrentBlock);
     const CAmount& GetFee() const { return nFee; }
     int32_t GetTxSize() const
     {
-        return GetVirtualTransactionSize(nTxWeight + m_extra_weight, sigOpCost, ::nBytesPerSigOp);
+        return GetVirtualTransactionSize(nTxWeight + m_base_extra_weight + m_coinblocks_weight_discount, sigOpCost, ::nBytesPerSigOp);
     }
     int32_t GetTxWeight() const { return nTxWeight; }
     std::chrono::seconds GetTime() const { return std::chrono::seconds{nTime}; }
     unsigned int GetHeight() const { return entryHeight; }
     uint64_t GetSequence() const { return entry_sequence; }
-    int32_t GetExtraWeight() const { return m_extra_weight; }
+    int32_t GetExtraWeight() const { return m_base_extra_weight + m_coinblocks_weight_discount; }
     int64_t GetSigOpCost() const { return sigOpCost; }
     CAmount GetModifiedFee() const { return m_modified_fee; }
     size_t DynamicMemoryUsage() const { return nUsageSize; }

--- a/src/policy/coin_age_priority.cpp
+++ b/src/policy/coin_age_priority.cpp
@@ -27,7 +27,7 @@ unsigned int CalculateModifiedSize(const CTransaction& tx, unsigned int nTxSize)
     // is enough to cover a compressed pubkey p2sh redemption) for priority.
     // Providing any more cleanup incentive than making additional inputs free would
     // risk encouraging people to create junk outputs to redeem later.
-    Assert(nTxSize > 0);
+    if (nTxSize == 0) return 0;
     for (std::vector<CTxIn>::const_iterator it(tx.vin.begin()); it != tx.vin.end(); ++it)
     {
         unsigned int offset = 41U + std::min(110U, (unsigned int)it->scriptSig.size());
@@ -97,7 +97,7 @@ int32_t CTxMemPoolEntry::UpdateCachedPriority(unsigned int currentHeight, CAmoun
 struct update_priority
 {
     update_priority(unsigned int _height, CAmount _value) :
-        height(_height), value(_value), size_delta(0)
+        height(_height), value(_value)
     {}
 
     void operator() (CTxMemPoolEntry &e)
@@ -105,7 +105,7 @@ struct update_priority
 
     unsigned int height;
     CAmount value;
-    int32_t size_delta;
+    int32_t size_delta{0};
 };
 
 void CTxMemPool::UpdateDependentPriorities(const CTransaction &tx, unsigned int nBlockHeight, bool addToChain)
@@ -117,7 +117,9 @@ void CTxMemPool::UpdateDependentPriorities(const CTransaction &tx, unsigned int 
             continue;
         uint256 hash = it->second->GetHash();
         txiter iter = mapTx.find(hash);
+        const int32_t old_size = iter->GetTxSize();
         mapTx.modify(iter, update_priority(nBlockHeight, addToChain ? tx.vout[i].nValue : -tx.vout[i].nValue));
+        totalTxSize += iter->GetTxSize() - old_size;
     }
 }
 

--- a/src/policy/coin_age_priority.cpp
+++ b/src/policy/coin_age_priority.cpp
@@ -4,6 +4,9 @@
 
 #include <policy/coin_age_priority.h>
 
+#include <algorithm>
+#include <cmath>
+
 #include <coins.h>
 #include <common/args.h>
 #include <consensus/validation.h>
@@ -114,6 +117,22 @@ CTxMemPoolEntry::GetPriority(unsigned int currentHeight) const
     if (dResult < 0) // This should only happen if it was called with an invalid height
         dResult = 0;
     return dResult;
+}
+
+int32_t CalculatePriorityWeightDiscount(double inputs_coin_age, int32_t tx_weight, int32_t min_weight)
+{
+    if (tx_weight <= min_weight || inputs_coin_age <= 0.0) return 0;
+
+    const double vsize = static_cast<double>(tx_weight) / WITNESS_SCALE_FACTOR;
+    const double priority = inputs_coin_age / vsize;
+    static constexpr double PRIORITY_DISCOUNT_LOG_DIVISOR{8.0};
+    const double discount_ratio = std::min(0.5, std::log2(1.0 + priority / MINIMUM_TX_PRIORITY) / PRIORITY_DISCOUNT_LOG_DIVISOR);
+
+    int32_t weight_discount = static_cast<int32_t>(-discount_ratio * tx_weight);
+    weight_discount = std::max(weight_discount, min_weight - tx_weight);
+
+    Assume(weight_discount <= 0);
+    return weight_discount;
 }
 
 #ifndef BUILDING_FOR_LIBBITCOINKERNEL

--- a/src/policy/coin_age_priority.cpp
+++ b/src/policy/coin_age_priority.cpp
@@ -119,14 +119,14 @@ CTxMemPoolEntry::GetPriority(unsigned int currentHeight) const
     return dResult;
 }
 
-int32_t CalculatePriorityWeightDiscount(double inputs_coin_age, int32_t tx_weight, int32_t min_weight)
+int32_t CalculateCoinblocksWeightDiscount(double inputs_coin_age, int32_t tx_weight, int32_t min_weight)
 {
     if (tx_weight <= min_weight || inputs_coin_age <= 0.0) return 0;
 
     const double vsize = static_cast<double>(tx_weight) / WITNESS_SCALE_FACTOR;
-    const double priority = inputs_coin_age / vsize;
-    static constexpr double PRIORITY_DISCOUNT_LOG_DIVISOR{8.0};
-    const double discount_ratio = std::min(0.5, std::log2(1.0 + priority / MINIMUM_TX_PRIORITY) / PRIORITY_DISCOUNT_LOG_DIVISOR);
+    const double coinblocks = inputs_coin_age / vsize;
+    static constexpr double COINBLOCKS_DISCOUNT_LOG_DIVISOR{8.0};
+    const double discount_ratio = std::min(0.5, std::log2(1.0 + coinblocks / MINIMUM_TX_PRIORITY) / COINBLOCKS_DISCOUNT_LOG_DIVISOR);
 
     int32_t weight_discount = static_cast<int32_t>(-discount_ratio * tx_weight);
     weight_discount = std::max(weight_discount, min_weight - tx_weight);

--- a/src/policy/coin_age_priority.cpp
+++ b/src/policy/coin_age_priority.cpp
@@ -12,6 +12,7 @@
 #include <consensus/validation.h>
 #include <node/miner.h>
 #include <policy/policy.h>
+#include <policy/settings.h>
 #include <primitives/transaction.h>
 #include <txmempool.h>
 #include <util/check.h>
@@ -68,28 +69,43 @@ CoinAgeCache GetCoinAge(const CTransaction &tx, const CCoinsViewCache& view, int
     return r;
 }
 
-void CTxMemPoolEntry::UpdateCachedPriority(unsigned int currentHeight, CAmount valueInCurrentBlock)
+int32_t CTxMemPoolEntry::UpdateCachedPriority(unsigned int currentHeight, CAmount valueInCurrentBlock)
 {
     int heightDiff = int(currentHeight) - int(cachedHeight);
     double deltaPriority = ((double)heightDiff*inChainInputValue)/nModSize;
     cachedPriority += deltaPriority;
     cachedHeight = currentHeight;
+
+    m_cached_coin_age += (double)heightDiff * inChainInputValue;
     inChainInputValue += valueInCurrentBlock;
     assert(MoneyRange(inChainInputValue));
+
+    if (!::g_coinblocks_vsize_discount) return 0;
+
+    const int32_t old_size = GetTxSize();
+    static constexpr int32_t min_weight = MIN_STANDARD_TX_NONWITNESS_SIZE * WITNESS_SCALE_FACTOR;
+    m_coinblocks_weight_discount = CalculateCoinblocksWeightDiscount(m_cached_coin_age, nTxWeight, min_weight);
+    const int32_t new_size = GetTxSize();
+
+    if (new_size != old_size) {
+        nModSize = CalculateModifiedSize(GetTx(), new_size);
+    }
+
+    return new_size - old_size;
 }
 
 struct update_priority
 {
     update_priority(unsigned int _height, CAmount _value) :
-        height(_height), value(_value)
+        height(_height), value(_value), size_delta(0)
     {}
 
     void operator() (CTxMemPoolEntry &e)
-    { e.UpdateCachedPriority(height, value); }
+    { size_delta = e.UpdateCachedPriority(height, value); }
 
-    private:
-        unsigned int height;
-        CAmount value;
+    unsigned int height;
+    CAmount value;
+    int32_t size_delta;
 };
 
 void CTxMemPool::UpdateDependentPriorities(const CTransaction &tx, unsigned int nBlockHeight, bool addToChain)

--- a/src/policy/coin_age_priority.h
+++ b/src/policy/coin_age_priority.h
@@ -37,6 +37,6 @@ double ReversePriority2(double coin_age_priority, unsigned int mod_vsize);
  */
 CoinAgeCache GetCoinAge(const CTransaction &tx, const CCoinsViewCache& view, int nHeight);
 
-int32_t CalculatePriorityWeightDiscount(double inputs_coin_age, int32_t tx_weight, int32_t min_weight);
+int32_t CalculateCoinblocksWeightDiscount(double inputs_coin_age, int32_t tx_weight, int32_t min_weight);
 
 #endif // BITCOIN_POLICY_COIN_AGE_PRIORITY_H

--- a/src/policy/coin_age_priority.h
+++ b/src/policy/coin_age_priority.h
@@ -37,6 +37,32 @@ double ReversePriority2(double coin_age_priority, unsigned int mod_vsize);
  */
 CoinAgeCache GetCoinAge(const CTransaction &tx, const CCoinsViewCache& view, int nHeight);
 
+/**
+ * Calculate a weight discount for transactions spending older coins.
+ *
+ * The discount reduces a transaction's effective vsize based on the coin age
+ * density (coinblocks per vbyte) of its inputs. The formula uses a logarithmic
+ * curve that rises quickly for young coins and flattens as they age:
+ *
+ *   discount_ratio = min(0.5, log2(1 + coinblocks_per_vbyte / MINIMUM_TX_PRIORITY) / 8)
+ *
+ * where coinblocks_per_vbyte = inputs_coin_age / vsize, and inputs_coin_age is
+ * the sum of (value_sat * confirmation_depth) across all confirmed inputs.
+ *
+ * The divisor of 8 controls saturation speed: the 50% cap is reached when
+ * coinblocks_per_vbyte >= 255 * MINIMUM_TX_PRIORITY (i.e. log2(256) / 8 = 1.0,
+ * clamped to 0.5). In practice this means a typical 1-input, 1 BTC transaction
+ * reaches the maximum discount after roughly 36 days of confirmations.
+ *
+ * The returned value is always <= 0 (a negative weight offset). The total
+ * effective weight (tx_weight + discount) is clamped so it never drops below
+ * min_weight, preventing transactions from having an unreasonably small vsize.
+ *
+ * @param[in] inputs_coin_age  Sum of (value_sat * height_depth) for confirmed inputs.
+ * @param[in] tx_weight        Consensus transaction weight.
+ * @param[in] min_weight       Floor for effective weight after discount.
+ * @return Negative weight discount, or 0 if no discount applies.
+ */
 int32_t CalculateCoinblocksWeightDiscount(double inputs_coin_age, int32_t tx_weight, int32_t min_weight);
 
 #endif // BITCOIN_POLICY_COIN_AGE_PRIORITY_H

--- a/src/policy/coin_age_priority.h
+++ b/src/policy/coin_age_priority.h
@@ -37,4 +37,6 @@ double ReversePriority2(double coin_age_priority, unsigned int mod_vsize);
  */
 CoinAgeCache GetCoinAge(const CTransaction &tx, const CCoinsViewCache& view, int nHeight);
 
+int32_t CalculatePriorityWeightDiscount(double inputs_coin_age, int32_t tx_weight, int32_t min_weight);
+
 #endif // BITCOIN_POLICY_COIN_AGE_PRIORITY_H

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -66,8 +66,8 @@ static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP_STRICT{20};
 static constexpr unsigned int DEFAULT_WEIGHT_PER_DATA_BYTE{4};
 /** Default for -rejecttokens */
 static constexpr bool DEFAULT_REJECT_TOKENS{false};
-/** Default for -priorityvsizediscount */
-static constexpr bool DEFAULT_PRIORITY_VSIZE_DISCOUNT{true};
+/** Default for -coinblocksvsizediscount */
+static constexpr bool DEFAULT_COINBLOCKS_VSIZE_DISCOUNT{true};
 
 // NOTE: Changes to these three require manually adjusting doc in init.cpp
 /** Default for -permitephemeral=send */

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -66,6 +66,8 @@ static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP_STRICT{20};
 static constexpr unsigned int DEFAULT_WEIGHT_PER_DATA_BYTE{4};
 /** Default for -rejecttokens */
 static constexpr bool DEFAULT_REJECT_TOKENS{false};
+/** Default for -priorityvsizediscount */
+static constexpr bool DEFAULT_PRIORITY_VSIZE_DISCOUNT{true};
 
 // NOTE: Changes to these three require manually adjusting doc in init.cpp
 /** Default for -permitephemeral=send */

--- a/src/policy/settings.cpp
+++ b/src/policy/settings.cpp
@@ -10,3 +10,4 @@
 unsigned int nBytesPerSigOp = DEFAULT_BYTES_PER_SIGOP;
 unsigned int nBytesPerSigOpStrict = DEFAULT_BYTES_PER_SIGOP_STRICT;
 unsigned int g_weight_per_data_byte = DEFAULT_WEIGHT_PER_DATA_BYTE;
+bool g_priority_vsize_discount = DEFAULT_PRIORITY_VSIZE_DISCOUNT;

--- a/src/policy/settings.cpp
+++ b/src/policy/settings.cpp
@@ -10,4 +10,4 @@
 unsigned int nBytesPerSigOp = DEFAULT_BYTES_PER_SIGOP;
 unsigned int nBytesPerSigOpStrict = DEFAULT_BYTES_PER_SIGOP_STRICT;
 unsigned int g_weight_per_data_byte = DEFAULT_WEIGHT_PER_DATA_BYTE;
-bool g_priority_vsize_discount = DEFAULT_PRIORITY_VSIZE_DISCOUNT;
+bool g_coinblocks_vsize_discount = DEFAULT_COINBLOCKS_VSIZE_DISCOUNT;

--- a/src/policy/settings.h
+++ b/src/policy/settings.h
@@ -10,6 +10,6 @@ extern unsigned int g_script_size_policy_limit;
 extern unsigned int nBytesPerSigOp;
 extern unsigned int nBytesPerSigOpStrict;
 extern unsigned int g_weight_per_data_byte;
-extern bool g_priority_vsize_discount;
+extern bool g_coinblocks_vsize_discount;
 
 #endif // BITCOIN_POLICY_SETTINGS_H

--- a/src/policy/settings.h
+++ b/src/policy/settings.h
@@ -10,5 +10,6 @@ extern unsigned int g_script_size_policy_limit;
 extern unsigned int nBytesPerSigOp;
 extern unsigned int nBytesPerSigOpStrict;
 extern unsigned int g_weight_per_data_byte;
+extern bool g_priority_vsize_discount;
 
 #endif // BITCOIN_POLICY_SETTINGS_H

--- a/src/test/fuzz/util/mempool.cpp
+++ b/src/test/fuzz/util/mempool.cpp
@@ -38,7 +38,7 @@ CTxMemPoolEntry ConsumeTxMemPoolEntry(FuzzedDataProvider& fuzzed_data_provider, 
     const double coin_age = fuzzed_data_provider.ConsumeFloatingPoint<double>();
     const unsigned int entry_height = fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, std::numeric_limits<unsigned int>::max() - 1);
     const bool spends_coinbase = fuzzed_data_provider.ConsumeBool();
-    const int32_t extra_weight = fuzzed_data_provider.ConsumeIntegralInRange<int32_t>(0, GetTransactionWeight(tx) * 3);
+    const int32_t extra_weight = fuzzed_data_provider.ConsumeIntegralInRange<int32_t>(-(GetTransactionWeight(tx) / 2), GetTransactionWeight(tx) * 3);
     const unsigned int sig_op_cost = fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, MAX_BLOCK_SIGOPS_COST);
     return CTxMemPoolEntry{MakeTransactionRef(tx), fee, time, entry_height, entry_sequence, {
         .inputs_coin_age = coin_age,

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -29,10 +29,10 @@ static const CAmount low_fee_amt{200};
 
 struct TxPackageTest : TestChain100Setup {
 TxPackageTest() {
-    g_priority_vsize_discount = false;
+    g_coinblocks_vsize_discount = false;
 }
 ~TxPackageTest() {
-    g_priority_vsize_discount = DEFAULT_PRIORITY_VSIZE_DISCOUNT;
+    g_coinblocks_vsize_discount = DEFAULT_COINBLOCKS_VSIZE_DISCOUNT;
 }
 // Create placeholder transactions that have no meaning.
 inline CTransactionRef create_placeholder_tx(size_t num_inputs, size_t num_outputs)

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -7,6 +7,7 @@
 #include <policy/packages.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
+#include <policy/settings.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <serialize.h>
@@ -27,6 +28,12 @@ using namespace util::hex_literals;
 static const CAmount low_fee_amt{200};
 
 struct TxPackageTest : TestChain100Setup {
+TxPackageTest() {
+    g_priority_vsize_discount = false;
+}
+~TxPackageTest() {
+    g_priority_vsize_discount = DEFAULT_PRIORITY_VSIZE_DISCOUNT;
+}
 // Create placeholder transactions that have no meaning.
 inline CTransactionRef create_placeholder_tx(size_t num_inputs, size_t num_outputs)
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1064,9 +1064,9 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // reorg to be marked earlier than any child txs that were already in the mempool.
     const uint64_t entry_sequence = args.m_ignore_rejects.count(rejectmsg_zero_mempool_entry_seq) ? 0 : m_pool.GetSequence();
     int32_t extra_weight = CalculateExtraTxWeight(*ptx, m_view, ::g_weight_per_data_byte);
-    if (::g_priority_vsize_discount) {
+    if (::g_coinblocks_vsize_discount) {
         static constexpr int32_t min_weight = MIN_STANDARD_TX_NONWITNESS_SIZE * WITNESS_SCALE_FACTOR;
-        extra_weight += CalculatePriorityWeightDiscount(coin_age.inputs_coin_age, GetTransactionWeight(tx), min_weight);
+        extra_weight += CalculateCoinblocksWeightDiscount(coin_age.inputs_coin_age, GetTransactionWeight(tx), min_weight);
     }
     if (!m_subpackage.m_changeset) {
         m_subpackage.m_changeset = m_pool.GetChangeSet();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1064,10 +1064,6 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // reorg to be marked earlier than any child txs that were already in the mempool.
     const uint64_t entry_sequence = args.m_ignore_rejects.count(rejectmsg_zero_mempool_entry_seq) ? 0 : m_pool.GetSequence();
     int32_t extra_weight = CalculateExtraTxWeight(*ptx, m_view, ::g_weight_per_data_byte);
-    if (::g_coinblocks_vsize_discount) {
-        static constexpr int32_t min_weight = MIN_STANDARD_TX_NONWITNESS_SIZE * WITNESS_SCALE_FACTOR;
-        extra_weight += CalculateCoinblocksWeightDiscount(coin_age.inputs_coin_age, GetTransactionWeight(tx), min_weight);
-    }
     if (!m_subpackage.m_changeset) {
         m_subpackage.m_changeset = m_pool.GetChangeSet();
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1064,6 +1064,10 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // reorg to be marked earlier than any child txs that were already in the mempool.
     const uint64_t entry_sequence = args.m_ignore_rejects.count(rejectmsg_zero_mempool_entry_seq) ? 0 : m_pool.GetSequence();
     int32_t extra_weight = CalculateExtraTxWeight(*ptx, m_view, ::g_weight_per_data_byte);
+    if (::g_priority_vsize_discount) {
+        static constexpr int32_t min_weight = MIN_STANDARD_TX_NONWITNESS_SIZE * WITNESS_SCALE_FACTOR;
+        extra_weight += CalculatePriorityWeightDiscount(coin_age.inputs_coin_age, GetTransactionWeight(tx), min_weight);
+    }
     if (!m_subpackage.m_changeset) {
         m_subpackage.m_changeset = m_pool.GetChangeSet();
     }

--- a/test/functional/mining_coin_age_priority.py
+++ b/test/functional/mining_coin_age_priority.py
@@ -192,11 +192,11 @@ class PriorityTest(BitcoinTestFramework):
         self.test_vsize_discount_disabled()
 
     def test_vsize_discount(self):
-        self.testmsg('vsize discount is applied for aged UTXOs (priorityvsizediscount=1)')
+        self.testmsg('vsize discount is applied for aged UTXOs (coinblocksvsizediscount=1)')
 
-        self.restart_node(0, extra_args=['-priorityvsizediscount=1'])
-        self.restart_node(1, extra_args=['-blockprioritysize=1000000', '-blockmaxsize=1000000', '-priorityvsizediscount=1'])
-        self.restart_node(2, extra_args=['-priorityvsizediscount=1'])
+        self.restart_node(0, extra_args=['-coinblocksvsizediscount=1'])
+        self.restart_node(1, extra_args=['-blockprioritysize=1000000', '-blockmaxsize=1000000', '-coinblocksvsizediscount=1'])
+        self.restart_node(2, extra_args=['-coinblocksvsizediscount=1'])
         self.connect_nodes(0, 1)
         self.connect_nodes(1, 2)
 
@@ -228,9 +228,9 @@ class PriorityTest(BitcoinTestFramework):
         WITNESS_SCALE_FACTOR = 4
         min_weight = MIN_STANDARD_TX_NONWITNESS_SIZE * WITNESS_SCALE_FACTOR
         inputs_coin_age = float(amt * BTC) * 144
-        priority = inputs_coin_age / raw_vsize
+        coinblocks = inputs_coin_age / raw_vsize
         MINIMUM_TX_PRIORITY = float(Decimal('100000000') * 144 / 250)
-        expected_ratio = min(0.5, math.log2(1.0 + priority / MINIMUM_TX_PRIORITY) / 8.0)
+        expected_ratio = min(0.5, math.log2(1.0 + coinblocks / MINIMUM_TX_PRIORITY) / 8.0)
         weight_discount = int(-(expected_ratio * raw_weight))
         effective_weight = max(raw_weight + weight_discount, min_weight)
         expected_vsize = (effective_weight + WITNESS_SCALE_FACTOR - 1) // WITNESS_SCALE_FACTOR
@@ -239,11 +239,11 @@ class PriorityTest(BitcoinTestFramework):
         assert abs(mempool_vsize - expected_vsize) <= 1
 
     def test_vsize_discount_disabled(self):
-        self.testmsg('vsize discount is NOT applied when priorityvsizediscount=0')
+        self.testmsg('vsize discount is NOT applied when coinblocksvsizediscount=0')
 
         self.stop_node(1)
         self.stop_node(2)
-        self.restart_node(0, extra_args=['-priorityvsizediscount=0'])
+        self.restart_node(0, extra_args=['-coinblocksvsizediscount=0'])
         node = self.nodes[0]
 
         self.generatetoaddress(node, 250, node.getnewaddress(), sync_fun=self.no_op)

--- a/test/functional/mining_coin_age_priority.py
+++ b/test/functional/mining_coin_age_priority.py
@@ -6,10 +6,11 @@
 
 from test_framework.blocktools import create_block
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import assert_equal, assert_greater_than
 
 from binascii import b2a_hex
 from decimal import Decimal
+import math
 
 def find_unspent(node, txid, amount):
     for utxo in node.listunspent(0):
@@ -186,6 +187,85 @@ class PriorityTest(BitcoinTestFramework):
 
         txid_e_reorg_prio = (amt_c2 * BTC * 6) / txmodsize_e
         self.assert_prio(txid_e, txid_e_starting_prio, txid_e_reorg_prio)
+
+        self.test_vsize_discount()
+        self.test_vsize_discount_disabled()
+
+    def test_vsize_discount(self):
+        self.testmsg('vsize discount is applied for aged UTXOs (priorityvsizediscount=1)')
+
+        self.restart_node(0, extra_args=['-priorityvsizediscount=1'])
+        self.restart_node(1, extra_args=['-blockprioritysize=1000000', '-blockmaxsize=1000000', '-priorityvsizediscount=1'])
+        self.restart_node(2, extra_args=['-priorityvsizediscount=1'])
+        self.connect_nodes(0, 1)
+        self.connect_nodes(1, 2)
+
+        node = self.nodes[0]
+
+        self.generate(node, 250)
+
+        amt = Decimal('1')
+        fee = Decimal('0.0001')
+        addr = node.getnewaddress()
+        txid_fund = node.sendtoaddress(addr, amt)
+        self.generate(node, 144)
+
+        utxo = find_unspent(node, txid_fund, amt)
+        txdata = node.createrawtransaction([utxo], {node.getnewaddress(): amt - fee})
+        txdata = node.signrawtransactionwithwallet(txdata)['hex']
+        decoded = node.decoderawtransaction(txdata)
+        raw_vsize = decoded['vsize']
+        txid = node.sendrawtransaction(txdata)
+
+        entry = node.getmempoolentry(txid)
+        mempool_vsize = entry['vsize']
+
+        self.log.info('  raw_vsize=%d mempool_vsize=%d' % (raw_vsize, mempool_vsize))
+        assert_greater_than(raw_vsize, mempool_vsize)
+
+        raw_weight = decoded['weight']
+        MIN_STANDARD_TX_NONWITNESS_SIZE = 65
+        WITNESS_SCALE_FACTOR = 4
+        min_weight = MIN_STANDARD_TX_NONWITNESS_SIZE * WITNESS_SCALE_FACTOR
+        inputs_coin_age = float(amt * BTC) * 144
+        priority = inputs_coin_age / raw_vsize
+        MINIMUM_TX_PRIORITY = float(Decimal('100000000') * 144 / 250)
+        expected_ratio = min(0.5, math.log2(1.0 + priority / MINIMUM_TX_PRIORITY) / 8.0)
+        weight_discount = int(-(expected_ratio * raw_weight))
+        effective_weight = max(raw_weight + weight_discount, min_weight)
+        expected_vsize = (effective_weight + WITNESS_SCALE_FACTOR - 1) // WITNESS_SCALE_FACTOR
+
+        self.log.info('  expected_vsize~=%d mempool_vsize=%d discount_ratio=%.3f' % (expected_vsize, mempool_vsize, expected_ratio))
+        assert abs(mempool_vsize - expected_vsize) <= 1
+
+    def test_vsize_discount_disabled(self):
+        self.testmsg('vsize discount is NOT applied when priorityvsizediscount=0')
+
+        self.stop_node(1)
+        self.stop_node(2)
+        self.restart_node(0, extra_args=['-priorityvsizediscount=0'])
+        node = self.nodes[0]
+
+        self.generatetoaddress(node, 250, node.getnewaddress(), sync_fun=self.no_op)
+
+        amt = Decimal('1')
+        fee = Decimal('0.0001')
+        addr = node.getnewaddress()
+        txid_fund = node.sendtoaddress(addr, amt)
+        self.generatetoaddress(node, 144, node.getnewaddress(), sync_fun=self.no_op)
+
+        utxo = find_unspent(node, txid_fund, amt)
+        txdata = node.createrawtransaction([utxo], {node.getnewaddress(): amt - fee})
+        txdata = node.signrawtransactionwithwallet(txdata)['hex']
+        decoded = node.decoderawtransaction(txdata)
+        raw_vsize = decoded['vsize']
+        txid = node.sendrawtransaction(txdata)
+
+        entry = node.getmempoolentry(txid)
+        mempool_vsize = entry['vsize']
+
+        self.log.info('  raw_vsize=%d mempool_vsize=%d' % (raw_vsize, mempool_vsize))
+        assert_equal(raw_vsize, mempool_vsize)
 
 if __name__ == '__main__':
     PriorityTest(__file__).main()


### PR DESCRIPTION
Depends on #342, which makes block assembly account for real consensus weight. Without it, this discount can build a block over `-blockmaxweight`.

Closes #147

Factor coinblocks into feerate calculation via vsize discount, making it cheaper to spend high-coinblock coins than quickly-respending dust. Optional via `-coinblocksvsizediscount`.
