### PR TITLE
qt: add Fusion-based system/light/dark theme selector

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -57,12 +57,15 @@
 #include <QLibraryInfo>
 #include <QLocale>
 #include <QMessageBox>
+#include <QPalette>
 #include <QSettings>
 #include <QString>
+#include <QStyle>
 #include <QThread>
 #include <QTimer>
 #include <QTranslator>
 #include <QWindow>
+#include <QStyleFactory>
 
 // Declare meta types used for QMetaObject::invokeMethod
 Q_DECLARE_METATYPE(bool*)
@@ -211,12 +214,93 @@ void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, cons
 static int qt_argc = 1;
 static const char* qt_argv = "bitcoin-qt";
 
+namespace {
+
+QStyle* CreateStyle(const QString& style_name)
+{
+    if (!style_name.isEmpty()) {
+        if (QStyle* style = QStyleFactory::create(style_name)) {
+            return style;
+        }
+    }
+    return QStyleFactory::create(QStringLiteral("Fusion"));
+}
+
+QPalette MakeLightPalette(const QPalette& base)
+{
+    QPalette palette{base};
+    const QColor window(245, 245, 245);
+    const QColor base_color(255, 255, 255);
+    const QColor alternate_base(235, 235, 235);
+    const QColor text(32, 32, 32);
+    const QColor disabled(140, 140, 140);
+    const QColor highlight(247, 147, 26);
+    const QColor link(210, 122, 15);
+
+    palette.setColor(QPalette::Window, window);
+    palette.setColor(QPalette::WindowText, text);
+    palette.setColor(QPalette::Base, base_color);
+    palette.setColor(QPalette::AlternateBase, alternate_base);
+    palette.setColor(QPalette::ToolTipBase, base_color);
+    palette.setColor(QPalette::ToolTipText, text);
+    palette.setColor(QPalette::Text, text);
+    palette.setColor(QPalette::Button, window);
+    palette.setColor(QPalette::ButtonText, text);
+    palette.setColor(QPalette::BrightText, Qt::white);
+    palette.setColor(QPalette::Link, link);
+    palette.setColor(QPalette::Highlight, highlight);
+    palette.setColor(QPalette::HighlightedText, text);
+    palette.setColor(QPalette::Disabled, QPalette::WindowText, disabled);
+    palette.setColor(QPalette::Disabled, QPalette::Text, disabled);
+    palette.setColor(QPalette::Disabled, QPalette::ButtonText, disabled);
+    palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(180, 180, 180));
+    palette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(245, 245, 245));
+    return palette;
+}
+
+QPalette MakeDarkPalette(const QPalette& base)
+{
+    QPalette palette{base};
+    const QColor window(53, 53, 53);
+    const QColor base_color(35, 35, 35);
+    const QColor alternate_base(64, 64, 64);
+    const QColor text(240, 240, 240);
+    const QColor disabled(127, 127, 127);
+    const QColor highlight(247, 147, 26);
+    const QColor link(247, 147, 26);
+    const QColor highlighted_text(24, 24, 24);
+
+    palette.setColor(QPalette::Window, window);
+    palette.setColor(QPalette::WindowText, text);
+    palette.setColor(QPalette::Base, base_color);
+    palette.setColor(QPalette::AlternateBase, alternate_base);
+    palette.setColor(QPalette::ToolTipBase, window);
+    palette.setColor(QPalette::ToolTipText, text);
+    palette.setColor(QPalette::Text, text);
+    palette.setColor(QPalette::Button, window);
+    palette.setColor(QPalette::ButtonText, text);
+    palette.setColor(QPalette::BrightText, QColor(255, 128, 128));
+    palette.setColor(QPalette::Link, link);
+    palette.setColor(QPalette::Highlight, highlight);
+    palette.setColor(QPalette::HighlightedText, highlighted_text);
+    palette.setColor(QPalette::Disabled, QPalette::WindowText, disabled);
+    palette.setColor(QPalette::Disabled, QPalette::Text, disabled);
+    palette.setColor(QPalette::Disabled, QPalette::ButtonText, disabled);
+    palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
+    palette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(180, 180, 180));
+    return palette;
+}
+
+} // namespace
+
 BitcoinApplication::BitcoinApplication()
     : QApplication(qt_argc, const_cast<char**>(&qt_argv))
 {
     // Qt runs setlocale(LC_ALL, "") on initialization.
     RegisterMetaTypes();
     setQuitOnLastWindowClosed(false);
+    m_system_style_name = style()->objectName();
+    m_system_palette = palette();
 }
 
 void BitcoinApplication::setupPlatformStyle()
@@ -268,7 +352,33 @@ bool BitcoinApplication::createOptionsModel(bool resetSettings)
         QMessageBox::critical(nullptr, CLIENT_NAME, QString::fromStdString(error.translated));
         return false;
     }
+    connect(optionsModel, &OptionsModel::themeChanged, this, &BitcoinApplication::setThemePreference);
+    setThemePreference(OptionsModel::ThemePreferenceToInt(optionsModel->getTheme()));
     return true;
+}
+
+void BitcoinApplication::setThemePreference(const int theme_preference)
+{
+    const auto preference = OptionsModel::ThemePreferenceFromInt(theme_preference);
+    if (QStyle* style = CreateStyle(QStringLiteral("Fusion"))) {
+        QApplication::setStyle(style);
+    }
+    QApplication::setStyleSheet(QString());
+    switch (preference) {
+    case OptionsModel::ThemePreference::System:
+        if (GUIUtil::isDarkMode(m_system_palette.color(QPalette::Window))) {
+            QApplication::setPalette(MakeDarkPalette(m_system_palette));
+        } else {
+            QApplication::setPalette(MakeLightPalette(m_system_palette));
+        }
+        break;
+    case OptionsModel::ThemePreference::Light:
+        QApplication::setPalette(MakeLightPalette(m_system_palette));
+        break;
+    case OptionsModel::ThemePreference::Dark:
+        QApplication::setPalette(MakeDarkPalette(m_system_palette));
+        break;
+    }
 }
 
 void BitcoinApplication::createWindow(const NetworkStyle *networkStyle)
@@ -587,6 +697,7 @@ int GuiMain(int argc, char* argv[])
         QSettings::setDefaultFormat(QSettings::IniFormat);
         QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, QString::fromStdString(qt_settings_path));
     }
+    app.setThemePreference(QSettings().value("ThemePreference", OptionsModel::ThemePreferenceToInt(OptionsModel::ThemePreference::System)).toInt());
 
     /// 4. Initialization of translations, so that intro dialog is in user's language
     // Now that QSettings are accessible, initialize translations

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -16,6 +16,8 @@
 #include <optional>
 
 #include <QApplication>
+#include <QPalette>
+#include <QString>
 
 class BitcoinGUI;
 class ClientModel;
@@ -66,6 +68,8 @@ public:
 
     /// Setup platform style
     void setupPlatformStyle();
+    /// Apply the UI theme preference.
+    void setThemePreference(int theme_preference);
 
     interfaces::Node& node() const { assert(m_node); return *m_node; }
 
@@ -104,6 +108,8 @@ private:
     std::unique_ptr<QWidget> shutdownWindow;
     SplashScreen* m_splash = nullptr;
     std::unique_ptr<interfaces::Node> m_node;
+    QString m_system_style_name;
+    QPalette m_system_palette;
 
     void startThread();
 };

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -205,7 +205,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     QString curStyle = QApplication::style()->metaObject()->className();
     if(curStyle == "QWindowsStyle" || curStyle == "QWindowsXPStyle")
     {
-        progressBar->setStyleSheet("QProgressBar { background-color: #e8e8e8; border: 1px solid grey; border-radius: 7px; padding: 1px; text-align: center; } QProgressBar::chunk { background: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #FF8000, stop: 1 orange); border-radius: 7px; margin: 0px; }");
+        progressBar->setStyleSheet("QProgressBar { background-color: palette(base); border: 1px solid palette(mid); border-radius: 7px; padding: 1px; text-align: center; color: palette(text); } QProgressBar::chunk { background: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #FF8000, stop: 1 orange); border-radius: 7px; margin: 0px; }");
     }
 
     statusBar()->addWidget(progressBarLabel);

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -19,9 +19,6 @@
      <property name="visible">
       <bool>false</bool>
      </property>
-     <property name="styleSheet">
-      <string notr="true">QLabel { background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #F0D0A0, stop:1 #F8D488); color:#000000; }</string>
-     </property>
      <property name="wordWrap">
       <bool>true</bool>
      </property>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -841,6 +841,30 @@
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_theme_Display">
+         <item>
+          <widget class="QLabel" name="themeLabel">
+           <property name="text">
+            <string>&amp;Theme:</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="buddy">
+            <cstring>theme</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QValueComboBox" name="theme">
+           <property name="toolTip">
+            <string>Choose whether the interface should follow the system theme or always use a light or dark appearance.</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2_Display">
          <item>
           <widget class="QLabel" name="unitLabel">

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -19,9 +19,6 @@
      <property name="visible">
       <bool>false</bool>
      </property>
-     <property name="styleSheet">
-      <string notr="true">QLabel { background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #F0D0A0, stop:1 #F8D488); color:#000000; }</string>
-     </property>
      <property name="wordWrap">
       <bool>true</bool>
      </property>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -132,9 +132,6 @@
               <bold>true</bold>
              </font>
             </property>
-            <property name="styleSheet">
-             <string notr="true">color:red;font-weight:bold;</string>
-            </property>
             <property name="text">
              <string>Insufficient funds!</string>
             </property>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1120,6 +1120,40 @@ bool isDarkMode(const QColor& color) {
     return ColourLuminosity(color) < .36;
 }
 
+static QColor ContrastingTextColor(const QColor& color)
+{
+    return isDarkMode(color) ? QColor("#FFFFFF") : QColor("#000000");
+}
+
+QColor getThemedErrorColor(const QPalette& palette)
+{
+    return isDarkMode(palette.color(QPalette::Window)) ? QColor("#FF8080") : QColor("#FF0000");
+}
+
+QColor getThemedSuccessColor(const QPalette& palette)
+{
+    return isDarkMode(palette.color(QPalette::Window)) ? QColor("#45DEB5") : QColor("#007D32");
+}
+
+QString getThemedWarningLabelStyle(const QPalette& palette)
+{
+    const bool dark_mode = isDarkMode(palette.color(QPalette::Window));
+    const QColor gradient_start = dark_mode ? QColor("#5C4215") : QColor("#F0D0A0");
+    const QColor gradient_end = dark_mode ? QColor("#8A6728") : QColor("#F8D488");
+    const QColor text_color = dark_mode ? QColor("#FFF3D6") : QColor("#000000");
+    return QStringLiteral(
+        "QLabel { background-color: qlineargradient("
+        "x1: 0, y1: 0, x2: 1, y2: 0, "
+        "stop:0 %1, stop:1 %2); color:%3; }")
+        .arg(gradient_start.name(), gradient_end.name(), text_color.name());
+}
+
+QString getStatusLabelStyle(const QColor& background_color)
+{
+    return QStringLiteral("QLabel { background-color: %1; color: %2; }")
+        .arg(background_color.name(), ContrastingTextColor(background_color).name());
+}
+
 qreal calculateIdealFontSize(int width, const QString& text, QFont font, qreal minPointSize, qreal font_size) {
     while(font_size >= minPointSize) {
         font.setPointSizeF(font_size);

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -20,6 +20,7 @@
 #include <QMessageBox>
 #include <QMetaObject>
 #include <QObject>
+#include <QPalette>
 #include <QProgressBar>
 #include <QString>
 #include <QTableView>
@@ -296,6 +297,10 @@ namespace GUIUtil
 
     /** Check if a background color indicates dark mode */
     bool isDarkMode(const QColor& color);
+    QColor getThemedErrorColor(const QPalette& palette);
+    QColor getThemedSuccessColor(const QPalette& palette);
+    QString getThemedWarningLabelStyle(const QPalette& palette);
+    QString getStatusLabelStyle(const QColor& background_color);
 
     qreal calculateIdealFontSize(int width, const QString& text, QFont font, qreal minPointSize = 4, qreal startPointSize = 14);
 

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -36,7 +36,6 @@ ModalOverlay::ModalOverlay(bool enable_wallet, const PlatformStyle& platform_sty
         raise();
     }
     ui->closeButton->installEventFilter(this);
-
     blockProcessTime.clear();
     setVisible(false);
     if (!enable_wallet) {

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -252,7 +252,7 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
     ui->threadsScriptVerif->setMinimum(-GetNumCores());
     ui->threadsScriptVerif->setMaximum(MAX_SCRIPTCHECK_THREADS);
     ui->pruneWarning->setVisible(false);
-    ui->pruneWarning->setStyleSheet("QLabel { color: red; }");
+    ui->pruneWarning->setStyleSheet(QStringLiteral("QLabel { color: %1; }").arg(GUIUtil::getThemedErrorColor(palette()).name()));
 
     ui->pruneSizeMiB->setEnabled(false);
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
@@ -721,6 +721,9 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
             ui->lang->addItem(locale.nativeLanguageName() + QString(" (") + langStr + QString(")"), QVariant(langStr));
         }
     }
+    ui->theme->addItem(tr("System default"), OptionsModel::ThemePreferenceToInt(OptionsModel::ThemePreference::System));
+    ui->theme->addItem(tr("Light"), OptionsModel::ThemePreferenceToInt(OptionsModel::ThemePreference::Light));
+    ui->theme->addItem(tr("Dark"), OptionsModel::ThemePreferenceToInt(OptionsModel::ThemePreference::Dark));
     ui->unit->setModel(new BitcoinUnits(this));
 
     /* Widget-to-option mapper */
@@ -999,6 +1002,7 @@ void OptionsDialog::setMapper()
     /* Display */
     mapper->addMapping(ui->peersTabAlternatingRowColors, OptionsModel::PeersTabAlternatingRowColors);
     mapper->addMapping(ui->lang, OptionsModel::Language);
+    mapper->addMapping(ui->theme, OptionsModel::Theme);
     mapper->addMapping(ui->unit, OptionsModel::DisplayUnit);
     mapper->addMapping(ui->displayAddresses, OptionsModel::DisplayAddresses);
     mapper->addMapping(ui->thirdPartyTxUrls, OptionsModel::ThirdPartyTxUrls);
@@ -1010,10 +1014,7 @@ void OptionsDialog::checkLineEdit()
     if (lineedit->hasAcceptableInput()) {
         lineedit->setStyleSheet("");
     } else {
-        // Check the line edit's actual background to choose appropriate warning color
-        const bool lineedit_dark = GUIUtil::isDarkMode(lineedit->palette().color(lineedit->backgroundRole()));
-        const QColor lineedit_warning = lineedit_dark ? QColor("#FF8080") : QColor("#FF0000");
-        lineedit->setStyleSheet(QStringLiteral("color: %1;").arg(lineedit_warning.name()));
+        lineedit->setStyleSheet(QStringLiteral("color: %1;").arg(GUIUtil::getThemedErrorColor(lineedit->palette()).name()));
     }
 }
 
@@ -1264,20 +1265,13 @@ void OptionsDialog::updateDefaultProxyNets()
 
 void OptionsDialog::updateThemeColors()
 {
-    // Detect dark mode for color palette selection
-    const bool dark_mode = GUIUtil::isDarkMode(palette().color(backgroundRole()));
-
-    // set message warning color based on dark mode
-    const QColor warning_color = dark_mode ? QColor("#FF8080") : QColor("#FF0000");
+    const QColor warning_color = GUIUtil::getThemedErrorColor(palette());
     ui->pruneWarning->setStyleSheet(QStringLiteral("QLabel { color: %1; }").arg(warning_color.name()));
     ui->statusLabel->setStyleSheet(QStringLiteral("QLabel { color: %1; }").arg(warning_color.name()));
 
     // Update networkPort line edit color if it has validation errors
     if (!ui->networkPort->hasAcceptableInput()) {
-        // Check networkPort's actual background for appropriate warning color
-        const bool networkport_dark = GUIUtil::isDarkMode(ui->networkPort->palette().color(ui->networkPort->backgroundRole()));
-        const QColor networkport_warning = networkport_dark ? QColor("#FF8080") : QColor("#FF0000");
-        ui->networkPort->setStyleSheet(QStringLiteral("color: %1;").arg(networkport_warning.name()));
+        ui->networkPort->setStyleSheet(QStringLiteral("color: %1;").arg(GUIUtil::getThemedErrorColor(ui->networkPort->palette()).name()));
     }
 }
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -283,6 +283,18 @@ static QString CanonicalPermitEphemeral(const OptionsModel& model)
         (opts.permitephemeral_dust ? "" : "-") + "dust";
 }
 
+OptionsModel::ThemePreference OptionsModel::ThemePreferenceFromInt(const int value)
+{
+    switch (value) {
+    case ThemePreferenceToInt(ThemePreference::Light):
+        return ThemePreference::Light;
+    case ThemePreferenceToInt(ThemePreference::Dark):
+        return ThemePreference::Dark;
+    default:
+        return ThemePreference::System;
+    }
+}
+
 OptionsModel::OptionsModel(interfaces::Node& node, QObject *parent) :
     QAbstractListModel(parent), m_node{node}
 {
@@ -446,6 +458,12 @@ bool OptionsModel::Init(bilingual_str& error)
     }
     m_peers_tab_alternating_row_colors = settings.value("PeersTabAlternatingRowColors").toBool();
     Q_EMIT peersTabAlternatingRowColorsChanged(m_peers_tab_alternating_row_colors);
+
+    if (!settings.contains("ThemePreference")) {
+        settings.setValue("ThemePreference", ThemePreferenceToInt(ThemePreference::System));
+    }
+    m_theme = ThemePreferenceFromInt(settings.value("ThemePreference").toInt());
+    Q_EMIT themeChanged(ThemePreferenceToInt(m_theme));
 
     m_mask_values = settings.value("mask_values", false).toBool();
 
@@ -679,6 +697,8 @@ QVariant OptionsModel::getOption(OptionID option, const std::string& suffix) con
         return QVariant::fromValue(m_font_qrcodes);
     case PeersTabAlternatingRowColors:
         return m_peers_tab_alternating_row_colors;
+    case Theme:
+        return ThemePreferenceToInt(m_theme);
 #ifdef ENABLE_WALLET
     case walletrbf:
         return gArgs.GetBoolArg("-walletrbf", wallet::DEFAULT_WALLET_RBF);
@@ -1012,6 +1032,15 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
         settings.setValue("PeersTabAlternatingRowColors", m_peers_tab_alternating_row_colors);
         Q_EMIT peersTabAlternatingRowColorsChanged(m_peers_tab_alternating_row_colors);
         break;
+    case Theme:
+    {
+        const ThemePreference new_theme = ThemePreferenceFromInt(value.toInt());
+        if (m_theme == new_theme) break;
+        m_theme = new_theme;
+        settings.setValue("ThemePreference", ThemePreferenceToInt(m_theme));
+        Q_EMIT themeChanged(ThemePreferenceToInt(m_theme));
+        break;
+    }
 #ifdef ENABLE_WALLET
     case walletrbf:
         if (changed()) {

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -43,6 +43,14 @@ class OptionsModel : public QAbstractListModel
 public:
     explicit OptionsModel(interfaces::Node& node, QObject *parent = nullptr);
 
+    enum class ThemePreference {
+        System = 0,
+        Light = 1,
+        Dark = 2,
+    };
+    static ThemePreference ThemePreferenceFromInt(int value);
+    static constexpr int ThemePreferenceToInt(ThemePreference value) { return static_cast<int>(value); }
+
     enum OptionID {
         StartAtStartup,         // bool
         ShowTrayIcon,           // bool
@@ -64,6 +72,7 @@ public:
         FontForMoney,           // FontChoice
         FontForQRCodes,         // FontChoice
         PeersTabAlternatingRowColors, // bool
+        Theme,
         walletrbf,              // bool
         CoinControlFeatures,    // bool
         SubFeeFromAmount,       // bool
@@ -152,6 +161,7 @@ public:
     QFont getFontForMoney(BitcoinUnit) const;
     FontChoice getFontChoiceForQRCodes() const { return m_font_qrcodes; }
     bool getPeersTabAlternatingRowColors() const { return m_peers_tab_alternating_row_colors; }
+    ThemePreference getTheme() const { return m_theme; }
     bool getCoinControlFeatures() const { return fCoinControlFeatures; }
     bool getSubFeeFromAmount() const { return m_sub_fee_from_amount; }
     bool getEnablePSBTControls() const { return m_enable_psbt_controls; }
@@ -183,6 +193,7 @@ private:
     bool m_font_money_supports_tonal;
     FontChoice m_font_qrcodes{FontChoiceAbstract::EmbeddedFont};
     bool m_peers_tab_alternating_row_colors;
+    ThemePreference m_theme{ThemePreference::System};
     bool fCoinControlFeatures;
     bool m_sub_fee_from_amount;
     bool m_enable_psbt_controls;
@@ -213,6 +224,7 @@ Q_SIGNALS:
     void fontForMoneyChanged(const QFont&);
     void fontForQRCodesChanged(const FontChoice&);
     void peersTabAlternatingRowColorsChanged(bool);
+    void themeChanged(int theme_preference);
 };
 
 Q_DECLARE_METATYPE(OptionsModel::FontChoice)

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -149,6 +149,7 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
     txdelegate(new TxViewDelegate(platformStyle, this))
 {
     ui->setupUi(this);
+    ui->labelAlerts->setStyleSheet(GUIUtil::getThemedWarningLabelStyle(palette()));
 
     // use a SingleColorIcon for the "out of sync warning" icon
     QIcon icon = m_platform_style->SingleColorIcon(QStringLiteral(":/icons/warning"));
@@ -303,6 +304,7 @@ void OverviewPage::changeEvent(QEvent* e)
         QIcon icon = m_platform_style->SingleColorIcon(QStringLiteral(":/icons/warning"));
         ui->labelTransactionsStatus->setIcon(icon);
         ui->labelWalletStatus->setIcon(icon);
+        ui->labelAlerts->setStyleSheet(GUIUtil::getThemedWarningLabelStyle(palette()));
     }
 
     QWidget::changeEvent(e);

--- a/src/qt/pairingpage.cpp
+++ b/src/qt/pairingpage.cpp
@@ -5,9 +5,11 @@
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #include <qt/clientmodel.h>
+#include <qt/guiutil.h>
 #include <qt/pairingpage.h>
 #include <qt/qrimagewidget.h>
 
+#include <QEvent>
 #include <QFormLayout>
 #include <QLabel>
 #include <QLayout>
@@ -18,13 +20,13 @@ PairingPage::PairingPage(QWidget *parent) :
 {
     QVBoxLayout *layout = new QVBoxLayout(this);
 
-    QLabel *label_experimental = new QLabel(this);
-    label_experimental->setStyleSheet("QLabel { background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #F0D0A0, stop:1 #F8D488); color:#000000; }");
-    label_experimental->setMargin(3);
-    label_experimental->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    label_experimental->setWordWrap(true);
-    label_experimental->setText(tr("Pairing is an experimental feature that currently only works when Tor is enabled. It is expected that the pairing address below will change with future updates, and you may need to re-pair after upgrading."));
-    layout->addWidget(label_experimental);
+    m_label_experimental = new QLabel(this);
+    m_label_experimental->setMargin(3);
+    m_label_experimental->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    m_label_experimental->setWordWrap(true);
+    m_label_experimental->setText(tr("Pairing is an experimental feature that currently only works when Tor is enabled. It is expected that the pairing address below will change with future updates, and you may need to re-pair after upgrading."));
+    layout->addWidget(m_label_experimental);
+    updateThemeStyles();
 
     QLabel *label_summary = new QLabel(this);
     label_summary->setText(tr("Below you will find information to pair other software or devices with this node:"));
@@ -45,6 +47,15 @@ PairingPage::PairingPage(QWidget *parent) :
     layout->addStretch();
 
     refresh();
+}
+
+void PairingPage::changeEvent(QEvent* e)
+{
+    if (e->type() == QEvent::PaletteChange) {
+        updateThemeStyles();
+    }
+
+    QWidget::changeEvent(e);
 }
 
 void PairingPage::setClientModel(ClientModel *client_model)
@@ -72,5 +83,12 @@ void PairingPage::refresh()
         m_onion_address->setText(tr("(not connected)"));
         m_onion_address->setEnabled(false);
         m_qrcode->setVisible(false);
+    }
+}
+
+void PairingPage::updateThemeStyles()
+{
+    if (m_label_experimental) {
+        m_label_experimental->setStyleSheet(GUIUtil::getThemedWarningLabelStyle(palette()));
     }
 }

--- a/src/qt/pairingpage.h
+++ b/src/qt/pairingpage.h
@@ -11,6 +11,8 @@ class ClientModel;
 class QRImageWidget;
 
 QT_BEGIN_NAMESPACE
+class QEvent;
+class QLabel;
 class QLineEdit;
 QT_END_NAMESPACE
 
@@ -26,8 +28,14 @@ public:
 public Q_SLOTS:
     void refresh();
 
+protected:
+    void changeEvent(QEvent* e) override;
+
 private:
+    void updateThemeStyles();
+
     ClientModel *m_client_model{nullptr};
+    QLabel* m_label_experimental{nullptr};
     QLineEdit *m_onion_address{nullptr};
     QRImageWidget *m_qrcode{nullptr};
 };

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -232,22 +232,32 @@ QString PSBTOperationsDialog::renderTransaction(const PartiallySignedTransaction
 }
 
 void PSBTOperationsDialog::showStatus(const QString &msg, StatusLevel level) {
+    m_status_level = level;
     m_ui->statusBar->setText(msg);
     switch (level) {
         case StatusLevel::INFO: {
-            m_ui->statusBar->setStyleSheet("QLabel { background-color : lightgreen }");
+            m_ui->statusBar->setStyleSheet(GUIUtil::getStatusLabelStyle(GUIUtil::getThemedSuccessColor(palette())));
             break;
         }
         case StatusLevel::WARN: {
-            m_ui->statusBar->setStyleSheet("QLabel { background-color : orange }");
+            m_ui->statusBar->setStyleSheet(GUIUtil::getStatusLabelStyle(QColor("#D98B00")));
             break;
         }
         case StatusLevel::ERR: {
-            m_ui->statusBar->setStyleSheet("QLabel { background-color : red }");
+            m_ui->statusBar->setStyleSheet(GUIUtil::getStatusLabelStyle(GUIUtil::getThemedErrorColor(palette())));
             break;
         }
     }
     m_ui->statusBar->show();
+}
+
+void PSBTOperationsDialog::changeEvent(QEvent* e)
+{
+    if (e->type() == QEvent::PaletteChange && m_ui->statusBar->isVisible()) {
+        showStatus(m_ui->statusBar->text(), m_status_level);
+    }
+
+    QDialog::changeEvent(e);
 }
 
 size_t PSBTOperationsDialog::couldSignInputs(const PartiallySignedTransaction &psbtx) {

--- a/src/qt/psbtoperationsdialog.h
+++ b/src/qt/psbtoperationsdialog.h
@@ -33,6 +33,9 @@ public Q_SLOTS:
     void copyToClipboard();
     void saveTransaction();
 
+protected:
+    void changeEvent(QEvent* e) override;
+
 private:
     Ui::PSBTOperationsDialog* m_ui;
     PartiallySignedTransaction m_transaction_data;
@@ -44,6 +47,7 @@ private:
         WARN,
         ERR
     };
+    StatusLevel m_status_level{StatusLevel::INFO};
 
     size_t couldSignInputs(const PartiallySignedTransaction &psbtx);
     void updateTransactionDisplay();

--- a/src/qt/qvalidatedlineedit.cpp
+++ b/src/qt/qvalidatedlineedit.cpp
@@ -56,8 +56,7 @@ void QValidatedLineEdit::setValid(bool _valid, bool with_warning, const std::vec
     {
         // Use theme-aware red color for invalid state
         const QColor bg_colour = palette().color(backgroundRole());
-        const bool dark_mode = GUIUtil::isDarkMode(bg_colour);
-        QColor error_colour = dark_mode ? QColor("#FF8080") : QColor("#FF0000");
+        QColor error_colour = GUIUtil::getThemedErrorColor(palette());
         setStyleSheet(QStringLiteral("QValidatedLineEdit { border: 3px solid %1; }").arg(error_colour.name()));
 
         if (!error_locations.empty()) {
@@ -66,9 +65,9 @@ void QValidatedLineEdit::setValid(bool _valid, bool with_warning, const std::vec
                 // red is dominant, avoid fg red
                 if (bg_colour.red() > bg_colour.blue() && bg_colour.green() > bg_colour.blue()) {
                     // bg is yellowish, fallback to blues
-                    error_colour = dark_mode ? Qt::cyan : Qt::blue;
+                    error_colour = GUIUtil::isDarkMode(bg_colour) ? Qt::cyan : Qt::blue;
                 } else {
-                    error_colour = dark_mode ? Qt::yellow : Qt::darkYellow;
+                    error_colour = GUIUtil::isDarkMode(bg_colour) ? Qt::yellow : Qt::darkYellow;
                 }
             }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1590,6 +1590,7 @@ void RPCConsole::updateThemeColors()
         ui->openDebugLogfileButton->setIcon(platformStyle->SingleColorIcon(":/icons/export"));
     }
     ui->hidePeersDetailButton->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/remove")));
+    ui->label_alerts->setStyleSheet(GUIUtil::getThemedWarningLabelStyle(palette()));
 
     // Update console stylesheet with new colors
     updateConsoleStyleSheet();

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -71,6 +71,7 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
     platformStyle(_platformStyle)
 {
     ui->setupUi(this);
+    updateThemeStyles();
 
     if (!_platformStyle->getImagesOnButtons()) {
         ui->addButton->setIcon(QIcon());
@@ -147,6 +148,15 @@ void SendCoinsDialog::setClientModel(ClientModel *_clientModel)
     if (_clientModel) {
         connect(_clientModel, &ClientModel::numBlocksChanged, this, &SendCoinsDialog::updateNumberOfBlocks);
     }
+}
+
+void SendCoinsDialog::changeEvent(QEvent* e)
+{
+    if (e->type() == QEvent::PaletteChange) {
+        updateThemeStyles();
+    }
+
+    QDialog::changeEvent(e);
 }
 
 void SendCoinsDialog::setModel(WalletModel *_model)
@@ -1085,7 +1095,7 @@ void SendCoinsDialog::coinControlChangeEdited(const QString& text)
     {
         // Default to no change address until verified
         m_coin_control->destChange = CNoDestination();
-        ui->labelCoinControlChangeLabel->setStyleSheet("QLabel{color:red;}");
+        ui->labelCoinControlChangeLabel->setStyleSheet(QStringLiteral("QLabel { color: %1; }").arg(GUIUtil::getThemedErrorColor(palette()).name()));
 
         const CTxDestination dest = DecodeDestination(text.toStdString());
 
@@ -1111,13 +1121,13 @@ void SendCoinsDialog::coinControlChangeEdited(const QString& text)
                 else
                 {
                     ui->lineEditCoinControlChange->setText("");
-                    ui->labelCoinControlChangeLabel->setStyleSheet("QLabel{color:black;}");
+                    ui->labelCoinControlChangeLabel->setStyleSheet(QStringLiteral("QLabel { color: %1; }").arg(palette().color(QPalette::WindowText).name()));
                     ui->labelCoinControlChangeLabel->setText("");
                 }
             }
             else // Known change address
             {
-                ui->labelCoinControlChangeLabel->setStyleSheet("QLabel{color:black;}");
+                ui->labelCoinControlChangeLabel->setStyleSheet(QStringLiteral("QLabel { color: %1; }").arg(palette().color(QPalette::WindowText).name()));
 
                 // Query label
                 QString associatedLabel = model->getAddressTableModel()->labelForAddress(text);
@@ -1130,6 +1140,19 @@ void SendCoinsDialog::coinControlChangeEdited(const QString& text)
             }
         }
     }
+}
+
+void SendCoinsDialog::updateThemeStyles()
+{
+    ui->labelCoinControlInsuffFunds->setStyleSheet(
+        QStringLiteral("color:%1;font-weight:bold;").arg(GUIUtil::getThemedErrorColor(palette()).name()));
+
+    const QColor change_label_color =
+        (!ui->labelCoinControlChangeLabel->text().isEmpty() && std::holds_alternative<CNoDestination>(m_coin_control->destChange))
+            ? GUIUtil::getThemedErrorColor(palette())
+            : palette().color(QPalette::WindowText);
+    ui->labelCoinControlChangeLabel->setStyleSheet(
+        QStringLiteral("QLabel { color: %1; }").arg(change_label_color.name()));
 }
 
 // Coin Control: update labels

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -26,6 +26,7 @@ namespace Ui {
 }
 
 QT_BEGIN_NAMESPACE
+class QEvent;
 class QUrl;
 QT_END_NAMESPACE
 
@@ -63,6 +64,9 @@ public Q_SLOTS:
 Q_SIGNALS:
     void coinsSent(const uint256& txid);
 
+protected:
+    void changeEvent(QEvent* e) override;
+
 private:
     Ui::SendCoinsDialog *ui;
     ClientModel* clientModel{nullptr};
@@ -80,6 +84,7 @@ private:
     // Additional parameter msgArg can be used via .arg(msgArg).
     void processSendCoinsReturn(const WalletModel::SendCoinsReturn &sendCoinsReturn, const QString &msgArg = QString());
     void minimizeFeeSection(bool fMinimize);
+    void updateThemeStyles();
     // Format confirmation message
     bool PrepareSendText(QString& question_string, QString& informative_text, QString& detailed_text);
     /* Sign PSBT using external signer.

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -11,12 +11,16 @@
 #include <qt/bitcoin.h>
 #include <qt/bitcoingui.h>
 #include <qt/networkstyle.h>
+#include <qt/optionsmodel.h>
 #include <qt/rpcconsole.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
 
 #include <QAction>
+#include <QCoreApplication>
+#include <QEvent>
 #include <QLineEdit>
+#include <QPalette>
 #include <QRegularExpression>
 #include <QScopedPointer>
 #include <QSignalSpy>
@@ -26,6 +30,7 @@
 #include <QtGlobal>
 #include <QtTest/QtTestWidgets>
 #include <QtTest/QtTestGui>
+#include <QWidget>
 
 namespace {
 //! Regex find a string group inside of the console output
@@ -49,6 +54,29 @@ void TestRpcCommand(RPCConsole* console)
     const QString output = messagesWidget->toPlainText();
     const QString pattern = QStringLiteral("\"chain\": \"(\\w+)\"");
     QCOMPARE(FindInConsole(output, pattern), QString("regtest"));
+}
+
+void ProcessEvents()
+{
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::ApplicationPaletteChange);
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::PaletteChange);
+    QCoreApplication::processEvents();
+}
+
+void CheckLightPalette(const QPalette& palette)
+{
+    QCOMPARE(palette.color(QPalette::Window), QColor(245, 245, 245));
+    QCOMPARE(palette.color(QPalette::Base), QColor(255, 255, 255));
+    QCOMPARE(palette.color(QPalette::Highlight), QColor(247, 147, 26));
+    QCOMPARE(palette.color(QPalette::HighlightedText), QColor(32, 32, 32));
+}
+
+void CheckDarkPalette(const QPalette& palette)
+{
+    QCOMPARE(palette.color(QPalette::Window), QColor(53, 53, 53));
+    QCOMPARE(palette.color(QPalette::Base), QColor(35, 35, 35));
+    QCOMPARE(palette.color(QPalette::Highlight), QColor(247, 147, 26));
+    QCOMPARE(palette.color(QPalette::HighlightedText), QColor(24, 24, 24));
 }
 } // namespace
 
@@ -97,6 +125,7 @@ void AppTests::appTests()
 void AppTests::guiTests(BitcoinGUI* window)
 {
     HandleCallback callback{"guiTests", *this};
+    themeTests(window);
     connect(window, &BitcoinGUI::consoleShown, this, &AppTests::consoleTests);
     expectCallback("consoleTests");
     QAction* action = window->findChild<QAction*>("openRPCConsoleAction");
@@ -108,6 +137,37 @@ void AppTests::consoleTests(RPCConsole* console)
 {
     HandleCallback callback{"consoleTests", *this};
     TestRpcCommand(console);
+}
+
+void AppTests::themeTests(QWidget* widget)
+{
+    const QPalette initial_palette = m_app.palette();
+    const bool system_is_dark = GUIUtil::isDarkMode(initial_palette.color(QPalette::Window));
+    if (system_is_dark) {
+        CheckDarkPalette(initial_palette);
+    } else {
+        CheckLightPalette(initial_palette);
+    }
+
+    m_app.setThemePreference(OptionsModel::ThemePreferenceToInt(OptionsModel::ThemePreference::Light));
+    ProcessEvents();
+    CheckLightPalette(m_app.palette());
+    QCOMPARE(widget->palette().color(QPalette::Window), QColor(245, 245, 245));
+
+    m_app.setThemePreference(OptionsModel::ThemePreferenceToInt(OptionsModel::ThemePreference::Dark));
+    ProcessEvents();
+    CheckDarkPalette(m_app.palette());
+    QCOMPARE(widget->palette().color(QPalette::Window), QColor(53, 53, 53));
+
+    m_app.setThemePreference(OptionsModel::ThemePreferenceToInt(OptionsModel::ThemePreference::System));
+    ProcessEvents();
+    if (system_is_dark) {
+        CheckDarkPalette(m_app.palette());
+        QCOMPARE(widget->palette().color(QPalette::Window), QColor(53, 53, 53));
+    } else {
+        CheckLightPalette(m_app.palette());
+        QCOMPARE(widget->palette().color(QPalette::Window), QColor(245, 245, 245));
+    }
 }
 
 //! Destructor to shut down after the last expected callback completes.

--- a/src/qt/test/apptests.h
+++ b/src/qt/test/apptests.h
@@ -13,6 +13,7 @@
 class BitcoinApplication;
 class BitcoinGUI;
 class RPCConsole;
+class QWidget;
 
 class AppTests : public QObject
 {
@@ -26,6 +27,8 @@ private Q_SLOTS:
     void consoleTests(RPCConsole* console);
 
 private:
+    void themeTests(QWidget* widget);
+
     //! Add expected callback name to list of pending callbacks.
     void expectCallback(std::string callback) { m_callbacks.emplace(std::move(callback)); }
 

--- a/src/qt/test/optiontests.cpp
+++ b/src/qt/test/optiontests.cpp
@@ -141,6 +141,33 @@ void OptionTests::parametersInteraction()
     gArgs.ClearPathCache();
 }
 
+void OptionTests::themePreference()
+{
+    QSettings settings;
+    settings.remove("ThemePreference");
+
+    {
+        OptionsModel options{m_node};
+        bilingual_str error;
+        QVERIFY(options.Init(error));
+        QCOMPARE(OptionsModel::ThemePreferenceToInt(options.getTheme()),
+                 OptionsModel::ThemePreferenceToInt(OptionsModel::ThemePreference::System));
+
+        QVERIFY(options.setOption(OptionsModel::Theme,
+                                  OptionsModel::ThemePreferenceToInt(OptionsModel::ThemePreference::Dark)));
+        QCOMPARE(settings.value("ThemePreference").toInt(),
+                 OptionsModel::ThemePreferenceToInt(OptionsModel::ThemePreference::Dark));
+    }
+
+    {
+        OptionsModel options{m_node};
+        bilingual_str error;
+        QVERIFY(options.Init(error));
+        QCOMPARE(OptionsModel::ThemePreferenceToInt(options.getTheme()),
+                 OptionsModel::ThemePreferenceToInt(OptionsModel::ThemePreference::Dark));
+    }
+}
+
 void OptionTests::extractFilter()
 {
     QString filter = QString("Partially Signed Transaction (Binary) (*.psbt)");

--- a/src/qt/test/optiontests.h
+++ b/src/qt/test/optiontests.h
@@ -22,6 +22,7 @@ private Q_SLOTS:
     void migrateSettings();
     void integerGetArgBug();
     void parametersInteraction();
+    void themePreference();
     void extractFilter();
 
 private:

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -48,7 +48,7 @@ WalletFrame::WalletFrame(const PlatformStyle* _platformStyle, QWidget* parent)
 
     m_label_alerts = new QLabel(this);
     m_label_alerts->setVisible(false);
-    m_label_alerts->setStyleSheet("QLabel { background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #F0D0A0, stop:1 #F8D488); color:#000000; }");
+    m_label_alerts->setStyleSheet(GUIUtil::getThemedWarningLabelStyle(palette()));
     m_label_alerts->setWordWrap(true);
     m_label_alerts->setMargin(3);
     m_label_alerts->setTextInteractionFlags(Qt::TextSelectableByMouse);
@@ -71,6 +71,15 @@ WalletFrame::WalletFrame(const PlatformStyle* _platformStyle, QWidget* parent)
 }
 
 WalletFrame::~WalletFrame() = default;
+
+void WalletFrame::changeEvent(QEvent* e)
+{
+    if (e->type() == QEvent::PaletteChange) {
+        updateAlertStyle();
+    }
+
+    QFrame::changeEvent(e);
+}
 
 void WalletFrame::setClientModel(ClientModel *_clientModel)
 {
@@ -317,6 +326,11 @@ void WalletFrame::updateAlerts(const QString &warnings)
 {
     m_label_alerts->setVisible(!warnings.isEmpty());
     m_label_alerts->setText(warnings);
+}
+
+void WalletFrame::updateAlertStyle()
+{
+    m_label_alerts->setStyleSheet(GUIUtil::getThemedWarningLabelStyle(palette()));
 }
 
 WalletModel* WalletFrame::currentWalletModel() const

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -16,6 +16,7 @@ class WalletModel;
 class WalletView;
 
 QT_BEGIN_NAMESPACE
+class QEvent;
 class QLabel;
 class QStackedWidget;
 QT_END_NAMESPACE
@@ -106,8 +107,14 @@ public Q_SLOTS:
     /** Show used receiving addresses */
     void usedReceivingAddresses();
 
+protected:
+    void changeEvent(QEvent* e) override;
+
 private Q_SLOTS:
     void updateAlerts(const QString &warnings);
+
+private:
+    void updateAlertStyle();
 };
 
 #endif // BITCOIN_QT_WALLETFRAME_H


### PR DESCRIPTION
## Summary
- add a Qt theme preference with System, Light, and Dark options stored in settings
- apply Fusion palettes at startup and runtime, using a Bitcoin orange accent and palette-aware widget colors


## Demo
#### Dark mode

<img width="1819" height="1326" alt="Screenshot 2026-03-07 at 9 20 53 AM" src="https://github.com/user-attachments/assets/c394b3ee-54b5-4ac6-a5ae-a5b6fb1061af" />
<img width="538" height="467" alt="Screenshot 2026-03-07 at 9 20 59 AM" src="https://github.com/user-attachments/assets/8317211b-be37-4210-a9bc-139830799e88" />
<img width="1819" height="1326" alt="Screenshot 2026-03-07 at 9 21 02 AM" src="https://github.com/user-attachments/assets/03eece49-56e0-4e8b-95a5-bcb06f8b3db1" />

#### Light mode
<img width="1819" height="1326" alt="Screenshot 2026-03-07 at 9 21 59 AM" src="https://github.com/user-attachments/assets/6b3c90b4-a70c-4c51-b37a-102a0175d06f" />
<img width="1819" height="1326" alt="Screenshot 2026-03-07 at 9 22 04 AM" src="https://github.com/user-attachments/assets/37fde4b2-175c-4886-afe5-f08e2d500ee7" />
<img width="538" height="467" alt="Screenshot 2026-03-07 at 9 22 10 AM" src="https://github.com/user-attachments/assets/6219d955-45e7-4493-84da-32d1256c5d07" />
<img width="1251" height="1007" alt="Screenshot 2026-03-07 at 9 22 23 AM" src="https://github.com/user-attachments/assets/1497d9cb-d4a4-4009-9baf-ac736dd8bab3" />

## Testing
- cmake -S . -B build_theme_check -DBUILD_GUI=ON -DBUILD_GUI_TESTS=ON -DBUILD_TESTS=ON -DENABLE_WALLET=ON -DWITH_BDB=OFF -DWITH_QRENCODE=ON
- cmake --build build_theme_check --target bitcoin-qt test_bitcoin-qt -j6
- ./build_theme_check/bin/test_bitcoin-qt
- QT_QPA_PLATFORM=cocoa ./build_theme_check/bin/test_bitcoin-qt
- manual verification of System, Light, and Dark modes in bitcoin-qt on macOS