### PR TITLE
gui: warn when a default-datadir config is ignored

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -151,7 +151,7 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
         // which can happen when a custom datadir moves the base path away from
         // the default location where the user's bitcoin.conf actually lives.
         if (!IsArgSet("-conf") && !stream.good()) {
-            LogWarning("Config file %s not found; settings from it will not be applied. "
+            LogWarning("Config file %s doesn't exist or cannot be read. "
                        "If your configuration is at the default data directory, consider "
                        "copying it or using the -conf option to specify its location.",
                        fs::PathToString(conf_path));

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -147,6 +147,15 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
             error = strprintf("specified config file \"%s\" could not be opened.", fs::PathToString(conf_path));
             return false;
         }
+        // Warn if the default config file doesn't exist at the resolved path,
+        // which can happen when a custom datadir moves the base path away from
+        // the default location where the user's bitcoin.conf actually lives.
+        if (!IsArgSet("-conf") && !stream.good()) {
+            LogWarning("Config file %s not found; settings from it will not be applied. "
+                       "If your configuration is at the default data directory, consider "
+                       "copying it or using the -conf option to specify its location.",
+                       fs::PathToString(conf_path));
+        }
     }
     // ok to not have a config file
     if (stream.good()) {


### PR DESCRIPTION
When a custom datadir leaves an existing `bitcoin.conf` at the default location, Knots now logs which config is being ignored and where it looked. Installations without any config file remain silent.

The warning requires an unreadable implicit config path, a different default-directory path, and a config that exists there. An explicit `-conf` retains its existing error handling; `-noconf` suppresses this warning. This incorporates [LionThunderFingers' correction](https://github.com/LionThunderFingers/bitcoin/commit/294d33c10cd2d15125ed1b39db7b99891afa0f82), preserving its authorship.

The new five-case regression in `feature_config_args.py` covers both datadir locations, present and absent configs, and `-noconf`. It fails on the original warning condition and passes with this fix. The complete configuration suite and the daemon/CLI build pass on Ubuntu 24.04; Windows GUI startup was not tested.

Fixes #282
