### PR TITLE
qt: warn when script threads exceed CPU cores

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -187,6 +187,16 @@
         </layout>
        </item>
        <item>
+        <widget class="QLabel" name="threadsWarning">
+         <property name="text">
+          <string>Using more threads than CPU cores may reduce performance due to context-switch overhead.</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="enableServer">
          <property name="toolTip">
           <string extracomment="Tooltip text for Options window setting that enables the RPC server.">This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</string>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -98,6 +98,8 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
     ui->databaseCache->setRange(MIN_DB_CACHE >> 20, std::numeric_limits<int>::max());
     ui->threadsScriptVerif->setMinimum(-GetNumCores());
     ui->threadsScriptVerif->setMaximum(MAX_SCRIPTCHECK_THREADS);
+    ui->threadsWarning->setVisible(false);
+    ui->threadsWarning->setStyleSheet("QLabel { color: red; }");
     ui->pruneWarning->setVisible(false);
     ui->pruneWarning->setStyleSheet("QLabel { color: red; }");
 
@@ -257,6 +259,10 @@ void OptionsDialog::setModel(OptionsModel *_model)
     connect(ui->databaseCache, qOverload<int>(&QSpinBox::valueChanged), this, &OptionsDialog::showRestartWarning);
     connect(ui->externalSignerPath, &QLineEdit::textChanged, [this]{ showRestartWarning(); });
     connect(ui->threadsScriptVerif, qOverload<int>(&QSpinBox::valueChanged), this, &OptionsDialog::showRestartWarning);
+    connect(ui->threadsScriptVerif, qOverload<int>(&QSpinBox::valueChanged), this, [this](int value) {
+        ui->threadsWarning->setVisible(value > GetNumCores());
+    });
+    ui->threadsWarning->setVisible(ui->threadsScriptVerif->value() > GetNumCores());
     /* Wallet */
     connect(ui->spendZeroConfChange, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
     /* Network */


### PR DESCRIPTION
## Summary
- Adds a GUI warning when the user sets script verification threads higher than available CPU cores
- Prevents users from unknowingly degrading performance through context-switch overhead

Split out from #278 (runtime calibration).

The MAX_SCRIPTCHECK_THREADS cap raise was dropped after benchmarking showed the mutex-based checkqueue saturates well before 15 threads (see bitcoin/bitcoin#32692).