### PR TITLE
qt: Expand sync progress bar in status bar

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -197,6 +197,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     progressBarLabel->setVisible(false);
     progressBar = new GUIUtil::ProgressBar();
     progressBar->setAlignment(Qt::AlignCenter);
+    progressBar->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     progressBar->setVisible(false);
 
     // Override style sheet for progress bar for styles that have a segmented progress bar,
@@ -209,7 +210,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     }
 
     statusBar()->addWidget(progressBarLabel);
-    statusBar()->addWidget(progressBar);
+    statusBar()->addWidget(progressBar, 1);
     statusBar()->addPermanentWidget(frameBlocks);
 
     // Install event filter to be able to catch status tip events (QEvent::StatusTip)


### PR DESCRIPTION
Fixes #177.

Keep the existing single-row status bar layout and make the sync progress bar expand across the available space, so it reads like a normal left-to-right progress bar.

Root cause:
- The sync progress bar was added to the status bar without stretch, so it remained near its minimum width.
- This made the fill appear visually truncated, as if progress only moved from the far left toward the middle.

Change:
- Keep the existing single-row status bar layout.
- Give the sync progress bar an expanding size policy.
- Add the progress bar to the status bar with stretch so it occupies the available space up to the permanent right-side widgets.

This keeps the patch tightly scoped and avoids the previously discussed two-row redesign.

Manual testing:
- Ran `bitcoin-qt` in syncing state with a fresh signet data dir.
- Verified the progress bar spans the available single-row sync area left-to-right.
- Verified the normal non-sync state still hides the progress bar cleanly.
- Verified resize behavior remains sane as the main window grows and shrinks.
- Verified status text/icons still display sensibly.
- Spot-checked Windows styling via `QT_STYLE_OVERRIDE=windows`.

Visuals:
- Before/after screenshot:
<img width="1210" height="674" alt="combined_vertical" src="https://github.com/user-attachments/assets/0287896e-b1d3-4f42-a9c4-853462ad775b" />

- Resize behavior demo:
https://github.com/user-attachments/assets/8781e2b5-068e-45b8-a8b8-ef345b31ed6e

