### PR TITLE
wallet: fix null deref in AvailableCoins when segwit_inputs_only is set

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -419,8 +419,14 @@ CoinsResult AvailableCoins(const CWallet& wallet,
 
             std::unique_ptr<SigningProvider> provider = wallet.GetSolvingProvider(output.scriptPubKey);
 
-            if (segwit_inputs_only && !IsSegWitOutput(*provider, wtx.tx->vout[i].scriptPubKey)) {
-                continue;
+            if (segwit_inputs_only) {
+                if (provider) {
+                    if (!IsSegWitOutput(*provider, output.scriptPubKey)) continue;
+                } else {
+                    int witness_ver;
+                    std::vector<unsigned char> witness_prog;
+                    if (!output.scriptPubKey.IsWitnessProgram(witness_ver, witness_prog)) continue;
+                }
             }
 
             int input_bytes = CalculateMaximumSignedInputSize(output, COutPoint(), provider.get(), can_grind_r, coinControl);


### PR DESCRIPTION
## Summary

- `GetSolvingProvider()` can return nullptr but `AvailableCoins` dereferences it unconditionally when `segwit_inputs_only=true`
- Use `IsWitnessProgram` directly for native segwit outputs (no provider needed), fall back to `IsSegWitOutput` with the provider for P2SH-wrapped segwit

## Test plan

- [x] Unit tests (`spend_tests`): pass
- [x] Functional test (`wallet_fundrawtransaction.py`, exercises `segwit_inputs_only`): pass