### PR TITLE
blockstorage: fix unsigned underflow in GetBlockFileInfo bounds check

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -784,7 +784,7 @@ void BlockManager::CleanupBlockRevFiles() const
 CBlockFileInfo* BlockManager::GetBlockFileInfo(size_t n)
 {
     LOCK(cs_LastBlockFile);
-    if (n > m_blockfile_info.size()-1) return nullptr;
+    if (n >= m_blockfile_info.size()) return nullptr;
     return &m_blockfile_info.at(n);
 }
 


### PR DESCRIPTION
## Summary

- `GetBlockFileInfo` checks `n > m_blockfile_info.size()-1` which wraps to SIZE_MAX when the vector is empty
- `.at(n)` then throws `out_of_range`, crashing the node
- Fix: use `n >= m_blockfile_info.size()` instead

## Test plan

- [x] Unit tests (`blockmanager_tests`): pass