### PR TITLE
init: clamp -lowmem to non-negative before assigning to size_t

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1461,7 +1461,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     LogPrintf("* Using %.1f MiB for in-memory UTXO set (plus up to %.1f MiB of unused mempool space)\n", cache_sizes.coins * (1.0 / 1024 / 1024), mempool_opts.max_size_bytes * (1.0 / 1024 / 1024));
 
     if (gArgs.IsArgSet("-lowmem")) {
-        g_low_memory_threshold = gArgs.GetIntArg("-lowmem", 0 /* not used */) * 1024 * 1024;
+        g_low_memory_threshold = std::max(int64_t{0}, gArgs.GetIntArg("-lowmem", 0 /* not used */)) * 1024 * 1024;
     }
     if (g_low_memory_threshold > 0) {
         LogPrintf("* Flushing caches if available system memory drops below %s MiB\n", g_low_memory_threshold / 1024 / 1024);


### PR DESCRIPTION
## Summary

- Negative `-lowmem` values (e.g. `-lowmem=-1`) wrap to near-SIZE_MAX when assigned to `size_t`, causing `SystemNeedsMemoryReleased()` to always return true
- Node enters perpetual cache flushing loop
- Clamp to non-negative with `std::max(int64_t{0}, ...)` before the multiplication

## Test plan

- [x] Unit tests (`validation_chainstate_tests`): pass