### PR TITLE
rpc: add segwit and taproot support to sweepprivkeys

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -615,7 +615,7 @@ static RPCHelpMan sweepprivkeys()
     // Parse options
     std::set<CScript> needles;
     wallet::CCoinControl coin_control;
-    FillableSigningProvider temp_keystore;
+    FlatSigningProvider temp_keystore;
     CMutableTransaction tx;
     std::string label;
     CAmount total_in = 0;
@@ -631,7 +631,8 @@ static RPCHelpMan sweepprivkeys()
                 CPubKey pubkey = key.GetPubKey();
                 CHECK_NONFATAL(key.VerifyPubKey(pubkey));
 
-                temp_keystore.AddKey(key);
+                temp_keystore.keys[pubkey.GetID()] = key;
+                temp_keystore.pubkeys[pubkey.GetID()] = pubkey;
                 CKeyID address = pubkey.GetID();
                 CScript script = GetScriptForDestination(PKHash(address));
                 if (!script.empty()) {
@@ -640,6 +641,25 @@ static RPCHelpMan sweepprivkeys()
                 script = GetScriptForRawPubKey(pubkey);
                 if (!script.empty()) {
                     needles.insert(script);
+                }
+                if (pubkey.IsCompressed()) {
+                    CScript p2wpkh_script = GetScriptForDestination(WitnessV0KeyHash(pubkey));
+                    if (!p2wpkh_script.empty()) {
+                        needles.insert(p2wpkh_script);
+                    }
+                    script = GetScriptForDestination(ScriptHash(p2wpkh_script));
+                    if (!script.empty()) {
+                        needles.insert(script);
+                        temp_keystore.scripts[CScriptID(p2wpkh_script)] = p2wpkh_script;
+                    }
+                    auto tap_tweak = XOnlyPubKey(pubkey).CreateTapTweak(nullptr);
+                    if (tap_tweak) {
+                        WitnessV1Taproot output_key{tap_tweak->first};
+                        needles.insert(GetScriptForDestination(output_key));
+                        TaprootBuilder builder;
+                        builder.Finalize(XOnlyPubKey(pubkey));
+                        temp_keystore.tr_trees[output_key] = builder;
+                    }
                 }
             }
         } else if (optname == "label") {
@@ -710,10 +730,12 @@ static RPCHelpMan sweepprivkeys()
         if (IsDust(tx.vout[0], pwallet->chain().relayDustFee())) {
             throw JSONRPCError(RPC_VERIFY_REJECTED, "Swept value would be dust");
         }
+        PrecomputedTransactionData txdata;
+        txdata.Init(tx, std::vector<CTxOut>(input_txos.begin(), input_txos.end()), true);
         for (size_t input_index = 0; input_index < tx.vin.size(); ++input_index) {
             const auto& utxo = input_txos[input_index];
             SignatureData sig_data;
-            MutableTransactionSignatureCreator creator(tx, input_index, utxo.nValue, SIGHASH_ALL);
+            MutableTransactionSignatureCreator creator(tx, input_index, utxo.nValue, &txdata, SIGHASH_ALL);
             if (!ProduceSignature(temp_keystore, creator, utxo.scriptPubKey, sig_data)) {
                 throw JSONRPCError(RPC_MISC_ERROR, "Failed to sign");
             }

--- a/test/functional/wallet_sweepprivkeys.py
+++ b/test/functional/wallet_sweepprivkeys.py
@@ -4,8 +4,11 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the sweepprivkeys RPC."""
 
+from test_framework.key import ECKey
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.descriptors import descsum_create
 from test_framework.util import assert_equal, assert_fee_amount
+from test_framework.wallet_util import bytes_to_wif
 
 class SweepPrivKeysTest(BitcoinTestFramework):
     def add_options(self, parser):
@@ -62,6 +65,26 @@ class SweepPrivKeysTest(BitcoinTestFramework):
         txid = node.sweepprivkeys({'privkeys': (keys[1][1],), 'label': 'test 2'})
         assert_equal(node.listtransactions()[-1]['label'], 'test 2')
         self.check_balance(5, txid)
+
+        # Test sweeping segwit address types (P2WPKH, P2SH-P2WPKH, P2TR)
+        self.log.info("Test sweeping P2WPKH, P2SH-P2WPKH, and P2TR outputs")
+        eckey = ECKey()
+        eckey.generate(compressed=True)
+        wif = bytes_to_wif(eckey.get_bytes(), compressed=True)
+        for desc_fmt, addr_type in (
+            ("wpkh(%s)", "P2WPKH"),
+            ("sh(wpkh(%s))", "P2SH-P2WPKH"),
+            ("tr(%s)", "P2TR"),
+        ):
+            desc = descsum_create(desc_fmt % wif)
+            addr = node.deriveaddresses(desc)[0]
+            txid = node.sendtoaddress(addr, 2)
+            self.check_balance(-2, txid)
+            self.sync_all()
+            self.generate(miner, 1)
+            txid = node.sweepprivkeys({'privkeys': (wif,), 'label': addr_type})
+            assert_equal(node.listtransactions()[-1]['label'], addr_type)
+            self.check_balance(2, txid)
 
 if __name__ == '__main__':
     SweepPrivKeysTest(__file__).main()


### PR DESCRIPTION
## Summary

- `sweepprivkeys` only scanned for P2PKH and bare pubkey outputs, silently missing funds at P2WPKH, P2SH-P2WPKH, and P2TR addresses
- Add all segwit/taproot output types to the UTXO needle set (compressed keys only, as segwit requires)
- Add P2WPKH redeem script and taproot builder data to the signing provider
- Pass `PrecomputedTransactionData` to the signature creator so BIP341 Schnorr signing works

## Test plan

- [x] Existing legacy sweep tests pass
- [x] New test: sweep P2WPKH output
- [x] New test: sweep P2SH-P2WPKH output
- [x] New test: sweep P2TR output