### PR TITLE
qt: Add sweep private key dialog

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -328,6 +328,8 @@ if(ENABLE_WALLET)
       sendcoinsentry.h
       signverifymessagedialog.cpp
       signverifymessagedialog.h
+      sweepprivkeydialog.cpp
+      sweepprivkeydialog.h
       transactiondesc.cpp
       transactiondesc.h
       transactiondescdialog.cpp

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -338,6 +338,8 @@ void BitcoinGUI::createActions()
     signMessageAction->setStatusTip(tr("Sign messages with your Bitcoin addresses to prove you own them"));
     verifyMessageAction = new QAction(tr("&Verify message…"), this);
     verifyMessageAction->setStatusTip(tr("Verify messages to ensure they were signed with specified Bitcoin addresses"));
+    sweepPrivKeyAction = new QAction(tr("&Sweep private key…"), this);
+    sweepPrivKeyAction->setStatusTip(tr("Sweep coins from a private key into this wallet"));
     m_load_psbt_action = new QAction(tr("&Load PSBT from file…"), this);
     m_load_psbt_action->setStatusTip(tr("Load Partially Signed Bitcoin Transaction"));
     m_load_psbt_clipboard_action = new QAction(tr("Load PSBT from &clipboard…"), this);
@@ -424,6 +426,8 @@ void BitcoinGUI::createActions()
         connect(m_load_psbt_clipboard_action, &QAction::triggered, [this]{ gotoLoadPSBT(true); });
         connect(verifyMessageAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
         connect(verifyMessageAction, &QAction::triggered, [this]{ gotoVerifyMessageTab(); });
+        connect(sweepPrivKeyAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
+        connect(sweepPrivKeyAction, &QAction::triggered, [this]{ gotoSweepPrivKeyDialog(); });
         connect(usedSendingAddressesAction, &QAction::triggered, walletFrame, &WalletFrame::usedSendingAddresses);
         connect(usedReceivingAddressesAction, &QAction::triggered, walletFrame, &WalletFrame::usedReceivingAddresses);
         connect(openAction, &QAction::triggered, this, &BitcoinGUI::openClicked);
@@ -547,6 +551,7 @@ void BitcoinGUI::createMenuBar()
         file->addAction(openAction);
         file->addAction(signMessageAction);
         file->addAction(verifyMessageAction);
+        file->addAction(sweepPrivKeyAction);
         file->addAction(m_load_psbt_action);
         file->addAction(m_load_psbt_clipboard_action);
         file->addSeparator();
@@ -878,6 +883,7 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     changePassphraseAction->setEnabled(enabled);
     signMessageAction->setEnabled(enabled);
     verifyMessageAction->setEnabled(enabled);
+    sweepPrivKeyAction->setEnabled(enabled);
     usedSendingAddressesAction->setEnabled(enabled);
     usedReceivingAddressesAction->setEnabled(enabled);
     openAction->setEnabled(enabled);
@@ -1085,6 +1091,12 @@ void BitcoinGUI::gotoVerifyMessageTab(QString addr)
 {
     if (walletFrame) walletFrame->gotoVerifyMessageTab(addr);
 }
+
+void BitcoinGUI::gotoSweepPrivKeyDialog()
+{
+    if (walletFrame) walletFrame->gotoSweepPrivKeyDialog();
+}
+
 void BitcoinGUI::gotoLoadPSBT(bool from_clipboard)
 {
     if (walletFrame) walletFrame->gotoLoadPSBT(from_clipboard);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -144,6 +144,7 @@ private:
     QAction* usedReceivingAddressesAction = nullptr;
     QAction* signMessageAction = nullptr;
     QAction* verifyMessageAction = nullptr;
+    QAction* sweepPrivKeyAction = nullptr;
     QAction* m_load_psbt_action = nullptr;
     QAction* m_load_psbt_clipboard_action = nullptr;
     QAction* aboutAction = nullptr;
@@ -303,6 +304,8 @@ public Q_SLOTS:
     void gotoVerifyMessageTab(QString addr = "");
     /** Load Partially Signed Bitcoin Transaction from file or clipboard */
     void gotoLoadPSBT(bool from_clipboard = false);
+
+    void gotoSweepPrivKeyDialog();
     /** Enable history action when privacy is changed */
     void enableHistoryAction(bool privacy);
 

--- a/src/qt/forms/sweepprivkeydialog.ui
+++ b/src/qt/forms/sweepprivkeydialog.ui
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SweepPrivKeyDialog</class>
+ <widget class="QDialog" name="SweepPrivKeyDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>500</width>
+    <height>300</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Sweep Private Key</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="descriptionLabel">
+     <property name="text">
+      <string>Enter WIF private key(s) to sweep all coins into the selected wallet. One key per line.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="walletLabel">
+       <property name="text">
+        <string>Sweep into wallet:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="walletSelector"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="privkeyLabel">
+       <property name="text">
+        <string>Private key(s):</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QPlainTextEdit" name="privkeyEdit">
+       <property name="placeholderText">
+        <string>Enter WIF private keys, one per line</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelLabel">
+       <property name="text">
+        <string>Label (optional):</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="labelEdit"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="statusLabel">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="sweepButton">
+       <property name="text">
+        <string>&amp;Sweep</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="clearButton">
+       <property name="text">
+        <string>Clear</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/sweepprivkeydialog.cpp
+++ b/src/qt/sweepprivkeydialog.cpp
@@ -1,0 +1,158 @@
+// Copyright (c) 2026-present The Bitcoin Knots developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/sweepprivkeydialog.h>
+#include <qt/forms/ui_sweepprivkeydialog.h>
+
+#include <qt/guiutil.h>
+#include <qt/walletmodel.h>
+
+#include <interfaces/node.h>
+#include <interfaces/wallet.h>
+#include <univalue.h>
+
+#include <QMessageBox>
+#include <QUrl>
+
+SweepPrivKeyDialog::SweepPrivKeyDialog(QWidget *parent) :
+    QDialog(parent, GUIUtil::dialog_flags),
+    ui(new Ui::SweepPrivKeyDialog)
+{
+    ui->setupUi(this);
+    ui->privkeyEdit->setUndoRedoEnabled(false);
+    connect(ui->closeButton, &QPushButton::clicked, this, &QDialog::close);
+    connect(this, &SweepPrivKeyDialog::sweepComplete, this, &SweepPrivKeyDialog::handleResult);
+}
+
+SweepPrivKeyDialog::~SweepPrivKeyDialog()
+{
+    if (m_sweep_thread.joinable()) {
+        m_sweep_thread.join();
+    }
+    ui->privkeyEdit->setPlainText(QString(ui->privkeyEdit->toPlainText().size(), '\0'));
+    delete ui;
+}
+
+void SweepPrivKeyDialog::setModel(WalletModel *_model)
+{
+    this->model = _model;
+    if (!_model) return;
+
+    ui->walletSelector->clear();
+    const std::string current_name = _model->getWalletName().toStdString();
+    for (auto& wallet : _model->node().walletLoader().getWallets()) {
+        const std::string name = wallet->getWalletName();
+        ui->walletSelector->addItem(name.empty() ? tr("[default wallet]") : QString::fromStdString(name),
+                                    QString::fromStdString(name));
+        if (name == current_name) {
+            ui->walletSelector->setCurrentIndex(ui->walletSelector->count() - 1);
+        }
+    }
+    const bool multi = ui->walletSelector->count() > 1;
+    ui->walletSelector->setVisible(multi);
+    ui->walletLabel->setVisible(multi);
+}
+
+void SweepPrivKeyDialog::reject()
+{
+    on_clearButton_clicked();
+    QDialog::reject();
+}
+
+void SweepPrivKeyDialog::on_sweepButton_clicked()
+{
+    if (!model) return;
+
+    QString keyText = ui->privkeyEdit->toPlainText().trimmed();
+    if (keyText.isEmpty()) {
+        ui->statusLabel->setText(tr("Please enter at least one private key."));
+        return;
+    }
+
+    QStringList keyLines = keyText.split('\n', Qt::SkipEmptyParts);
+    UniValue privkeys(UniValue::VARR);
+    for (const QString& line : keyLines) {
+        QString trimmed = line.trimmed();
+        if (!trimmed.isEmpty()) {
+            privkeys.push_back(trimmed.toStdString());
+            trimmed.fill('\0');
+        }
+    }
+    keyText.fill('\0');
+
+    if (privkeys.empty()) {
+        ui->statusLabel->setText(tr("Please enter at least one private key."));
+        return;
+    }
+
+    UniValue options(UniValue::VOBJ);
+    options.pushKV("privkeys", privkeys);
+
+    QString label = ui->labelEdit->text().trimmed();
+    if (!label.isEmpty()) {
+        options.pushKV("label", label.toStdString());
+    }
+
+    UniValue params(UniValue::VARR);
+    params.push_back(options);
+
+    const QString selectedName = ui->walletSelector->currentData().toString();
+    QByteArray encodedName = QUrl::toPercentEncoding(selectedName);
+    std::string uri = "/wallet/" + std::string(encodedName.constData(), encodedName.length());
+
+    ui->sweepButton->setEnabled(false);
+    ui->closeButton->setEnabled(false);
+    ui->statusLabel->setText(tr("Sweeping..."));
+
+    if (m_sweep_thread.joinable()) {
+        m_sweep_thread.join();
+    }
+
+    const QString sweep_failed = tr("Sweep failed");
+    WalletModel* m = model;
+    m_sweep_thread = std::thread([this, m, params, uri, sweep_failed]() {
+        try {
+            UniValue result = m->node().executeRpc("sweepprivkeys", params, uri);
+            QString txid = QString::fromStdString(result.get_str());
+            Q_EMIT sweepComplete(true, txid);
+        } catch (const UniValue& e) {
+            QString errorMsg;
+            if (e.isObject() && e.exists("message")) {
+                errorMsg = QString::fromStdString(e["message"].get_str());
+            } else {
+                errorMsg = sweep_failed;
+            }
+            Q_EMIT sweepComplete(false, errorMsg);
+        } catch (const std::exception&) {
+            Q_EMIT sweepComplete(false, sweep_failed);
+        }
+    });
+}
+
+void SweepPrivKeyDialog::handleResult(bool success, const QString& message)
+{
+    if (m_sweep_thread.joinable()) {
+        m_sweep_thread.join();
+    }
+
+    if (success) {
+        ui->statusLabel->setText(tr("Success! Transaction ID: %1").arg(message));
+        QMessageBox::information(this, tr("Sweep Successful"),
+            tr("Coins swept successfully.\n\nTransaction ID:\n%1").arg(message));
+        on_clearButton_clicked();
+    } else {
+        ui->statusLabel->setText(tr("Error: %1").arg(message));
+    }
+
+    ui->sweepButton->setEnabled(true);
+    ui->closeButton->setEnabled(true);
+}
+
+void SweepPrivKeyDialog::on_clearButton_clicked()
+{
+    ui->privkeyEdit->setPlainText(QString(ui->privkeyEdit->toPlainText().size(), '\0'));
+    ui->privkeyEdit->clear();
+    ui->labelEdit->clear();
+    ui->statusLabel->clear();
+}

--- a/src/qt/sweepprivkeydialog.h
+++ b/src/qt/sweepprivkeydialog.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2026-present The Bitcoin Knots developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_SWEEPPRIVKEYDIALOG_H
+#define BITCOIN_QT_SWEEPPRIVKEYDIALOG_H
+
+#include <QDialog>
+
+#include <thread>
+
+class WalletModel;
+
+namespace Ui {
+    class SweepPrivKeyDialog;
+}
+
+class SweepPrivKeyDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit SweepPrivKeyDialog(QWidget *parent = nullptr);
+    ~SweepPrivKeyDialog();
+
+    void setModel(WalletModel *model);
+    void reject() override;
+
+private Q_SLOTS:
+    void on_sweepButton_clicked();
+    void on_clearButton_clicked();
+    void handleResult(bool success, const QString& message);
+
+Q_SIGNALS:
+    void sweepComplete(bool success, const QString& message);
+
+private:
+    Ui::SweepPrivKeyDialog *ui;
+    WalletModel *model{nullptr};
+    std::thread m_sweep_thread;
+};
+
+#endif // BITCOIN_QT_SWEEPPRIVKEYDIALOG_H

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -221,6 +221,13 @@ void WalletFrame::gotoVerifyMessageTab(QString addr)
         walletView->gotoVerifyMessageTab(addr);
 }
 
+void WalletFrame::gotoSweepPrivKeyDialog()
+{
+    WalletView *walletView = currentWalletView();
+    if (walletView)
+        walletView->gotoSweepPrivKeyDialog();
+}
+
 void WalletFrame::gotoLoadPSBT(bool from_clipboard)
 {
     std::vector<unsigned char> data;

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -89,6 +89,8 @@ public Q_SLOTS:
     /** Show Sign/Verify Message dialog and switch to verify message tab */
     void gotoVerifyMessageTab(QString addr = "");
 
+    void gotoSweepPrivKeyDialog();
+
     /** Load Partially Signed Bitcoin Transaction */
     void gotoLoadPSBT(bool from_clipboard = false);
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -14,6 +14,7 @@
 #include <qt/receivecoinsdialog.h>
 #include <qt/sendcoinsdialog.h>
 #include <qt/signverifymessagedialog.h>
+#include <qt/sweepprivkeydialog.h>
 #include <qt/transactiontablemodel.h>
 #include <qt/transactionview.h>
 #include <qt/walletmodel.h>
@@ -188,6 +189,14 @@ void WalletView::gotoVerifyMessageTab(QString addr)
 
     if (!addr.isEmpty())
         signVerifyMessageDialog->setAddress_VM(addr);
+}
+
+void WalletView::gotoSweepPrivKeyDialog()
+{
+    SweepPrivKeyDialog *dialog = new SweepPrivKeyDialog(this);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->setModel(walletModel);
+    dialog->show();
 }
 
 bool WalletView::handlePaymentRequest(const SendCoinsRecipient& recipient)

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -85,6 +85,8 @@ public Q_SLOTS:
     /** Show Sign/Verify Message dialog and switch to verify message tab */
     void gotoVerifyMessageTab(QString addr = "");
 
+    void gotoSweepPrivKeyDialog();
+
     /** Show incoming transaction notification for new transactions.
 
         The new items are those between start and end inclusive, under the given parent item.


### PR DESCRIPTION
## Summary
- Adds a GUI dialog for sweeping coins from WIF private keys into the active wallet
- Accessible via File > "Sweep private key..." (same pattern as Sign/Verify Message)
- Wraps the existing `sweepprivkeys` RPC; supports multiple keys and optional label

Rework of bitcoin-core/gui#650 per review feedback: import private key is a footgun, only sweep should be exposed in the GUI.