### PR TITLE
GUI: Show warnings on all tabs

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -15,25 +15,6 @@
   </property>
   <layout class="QVBoxLayout" name="topLayout">
    <item>
-    <widget class="QLabel" name="labelAlerts">
-     <property name="visible">
-      <bool>false</bool>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">QLabel { background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #F0D0A0, stop:1 #F8D488); color:#000000; }</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-     <property name="margin">
-      <number>3</number>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::TextSelectableByMouse</set>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1">
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -251,10 +251,6 @@ void OverviewPage::setClientModel(ClientModel *model)
 {
     this->clientModel = model;
     if (model) {
-        // Show warning, for example if this is a prerelease version
-        connect(model, &ClientModel::alertsChanged, this, &OverviewPage::updateAlerts);
-        updateAlerts(model->getStatusBarWarnings());
-
         connect(model->getOptionsModel(), &OptionsModel::fontForMoneyChanged, this, &OverviewPage::setMonospacedFont);
         setMonospacedFont(QFont() /* ignored */);
     }
@@ -331,12 +327,6 @@ void OverviewPage::updateDisplayUnit()
 
         ui->listTransactions->update();
     }
-}
-
-void OverviewPage::updateAlerts(const QString &warnings)
-{
-    this->ui->labelAlerts->setVisible(!warnings.isEmpty());
-    this->ui->labelAlerts->setText(warnings);
 }
 
 void OverviewPage::showOutOfSyncWarning(bool fShow)

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -63,7 +63,6 @@ private Q_SLOTS:
     void LimitTransactionRows();
     void updateDisplayUnit();
     void handleTransactionClicked(const QModelIndex &index);
-    void updateAlerts(const QString &warnings);
     void updateWatchOnlyLabels(bool showWatchOnly);
     void setMonospacedFont(const QFont&);
 };

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -22,7 +22,6 @@
 #include <Qt>
 #include <QApplication>
 #include <QClipboard>
-#include <QHBoxLayout>
 #include <QLabel>
 #include <QPushButton>
 #include <QVBoxLayout>
@@ -33,18 +32,13 @@ WalletFrame::WalletFrame(const PlatformStyle* _platformStyle, QWidget* parent)
       platformStyle(_platformStyle),
       m_size_hint(OverviewPage{platformStyle, nullptr}.sizeHint())
 {
-    // Leave HBox hook for adding a list view later
-    QHBoxLayout *walletFrameLayout = new QHBoxLayout(this);
+    QVBoxLayout *walletFrameLayout = new QVBoxLayout(this);
     setContentsMargins(0,0,0,0);
     walletStack = new QStackedWidget(this);
     m_global_stack = new QStackedWidget(this);
     m_global_stack->addWidget(walletStack);
     walletFrameLayout->setContentsMargins(0,0,0,0);
-    walletFrameLayout->addWidget(m_global_stack);
-
-    // hbox for no wallet
-    QWidget* no_wallet_group = new QWidget(walletStack);
-    QVBoxLayout* no_wallet_layout = new QVBoxLayout(no_wallet_group);
+    walletFrameLayout->setSpacing(0);
 
     m_label_alerts = new QLabel(this);
     m_label_alerts->setVisible(false);
@@ -52,7 +46,12 @@ WalletFrame::WalletFrame(const PlatformStyle* _platformStyle, QWidget* parent)
     m_label_alerts->setWordWrap(true);
     m_label_alerts->setMargin(3);
     m_label_alerts->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    no_wallet_layout->addWidget(m_label_alerts, 0, Qt::AlignTop);
+    walletFrameLayout->addWidget(m_label_alerts);
+    walletFrameLayout->addWidget(m_global_stack);
+
+    // hbox for no wallet
+    QWidget* no_wallet_group = new QWidget(walletStack);
+    QVBoxLayout* no_wallet_layout = new QVBoxLayout(no_wallet_group);
 
     QLabel *noWallet = new QLabel(tr("No wallet has been loaded.\nGo to File > Open Wallet to load a wallet.\n- OR -"));
     noWallet->setAlignment(Qt::AlignCenter);

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -42,7 +42,7 @@ WalletFrame::WalletFrame(const PlatformStyle* _platformStyle, QWidget* parent)
 
     m_label_alerts = new QLabel(this);
     m_label_alerts->setVisible(false);
-    m_label_alerts->setStyleSheet("QLabel { background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #F0D0A0, stop:1 #F8D488); color:#000000; }");
+    m_label_alerts->setStyleSheet("QLabel { background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #F0D0A0, stop:1 #F8D488); color:#000000; padding:1ex; }");
     m_label_alerts->setWordWrap(true);
     m_label_alerts->setMargin(3);
     m_label_alerts->setTextInteractionFlags(Qt::TextSelectableByMouse);


### PR DESCRIPTION
Fixes #300.

The status-bar warning from `ClientModel::getStatusBarWarnings()` (e.g. unknown soft-fork activation, "large-work invalid chain", clock-skew warnings, pre-release build notices) was only ever rendered on the Overview tab. Its alert label lived inside `OverviewPage`, so every other tab showed nothing. Because the Send/Receive/Transactions/Pairing pages each live in their own widget in the stack, switching to any of them hid the warning.

This moves the warning label out of `OverviewPage` and up into `WalletFrame`, as a sibling of `m_global_stack` rather than a child of any single page. The `WalletFrame` layout changes from an `QHBoxLayout` to a `QVBoxLayout` so the label sits above the stack and stays visible on every tab. `OverviewPage::labelAlerts` and its `updateAlerts` slot are removed so there is a single source for the warning instead of a per-page duplicate.

Result: the warning shows on all five tabs when a wallet is loaded (Overview/Send/Receive/Transactions/Pairing) and on both no-wallet tabs (Overview/Pairing). The `RPCConsole` path used under `-disablewallet` is untouched.

## How to reproduce

`getStatusBarWarnings()` only returns a non-empty string when the node actually raises a warning (unknown version-bit activation, invalid-chain detection, system-clock skew, etc.), which is awkward to trigger on demand. The simplest way to see the bug is to inject a fixed warning, build, and click through the tabs.

1. Hardcode a warning in `src/qt/clientmodel.cpp`:
   ```cpp
   QString ClientModel::getStatusBarWarnings() const
   {
       return "TEST WARNING";
       // return QString::fromStdString(m_node.getWarnings().translated);
   }
   ```
2. Build the GUI and start on regtest with no wallet:
   ```
   ./src/qt/bitcoin-qt -regtest -noconnect
   ```
3. Click through the tabs.

**Before this PR:** the yellow warning bar appears only on the Overview tab. Switching to Pairing (or, with a wallet loaded, to Send/Receive/Transactions) hides it.

**With this PR:** the warning bar stays visible on every accessible tab. With no wallet that is Overview and Pairing (Send/Receive/Transactions are greyed out); with a wallet loaded it is all five tabs.

Remember to revert the hardcoded warning before testing anything else.
