### PR TITLE
Bugfix: Build fails to enable ARM CPU crypto extensions

### DIFF
--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -277,9 +277,9 @@ if(NOT MSVC)
     #include <arm_neon.h>
 
     #if defined(__clang__)
-    #pragma clang attribute push(__attribute__((__target__("armv8-a+crypto"))), apply_to = function)
+    #pragma clang attribute push(__attribute__((__target__("+crypto"))), apply_to = function)
     #elif defined(__GNUC__)
-    #pragma GCC target ("armv8-a+crypto")
+    #pragma GCC target ("+crypto")
     #endif
 
     int main()

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -279,7 +279,7 @@ if(NOT MSVC)
     #if defined(__clang__)
     #pragma clang attribute push(__attribute__((__target__("armv8-a+crypto"))), apply_to = function)
     #elif defined(__GNUC__)
-    #pragma GCC target ("armv8-a+crypto")
+    #pragma GCC target ("+crypto")
     #endif
 
     int main()

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -277,7 +277,7 @@ if(NOT MSVC)
     #include <arm_neon.h>
 
     #if defined(__clang__)
-    #pragma clang attribute push(__attribute__((__target__("armv8-a+crypto"))), apply_to = function)
+    #pragma clang attribute push(__attribute__((__target__("+crypto"))), apply_to = function)
     #elif defined(__GNUC__)
     #pragma GCC target ("+crypto")
     #endif


### PR DESCRIPTION
When building on an ARM64 CPU with the crypto extensions, the build process fails to enable the custom assembler version.  It instead uses the software version.

This patch relates to this issue:
[https://github.com/bitcoinknots/bitcoin/issues/308](https://github.com/bitcoinknots/bitcoin/issues/308)

Example build command:
cmake -B build \
  -DENABLE_WALLET=OFF \
  -DWITH_ZMQ=ON \
  -DENABLE_TOR_SUBPROCESS=OFF \
  -D RDTS_CONSENT=IMPLICIT \
  -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g0 -march=native"

When you run bitcoind, this appears near the top of the log:
2026-05-31T23:36:14.290939Z Using the 'standard' SHA256 implementation

After *MANY* hours, I have finally tracked this down.  In this file: ./cmake/introspection.cmake
Line 282 has:
#pragma GCC target ("armv8-a+crypto")
The GCC target has to be a *feature*, not an architecture.  For example, this is valid:
#pragma GCC target ("+crypto")
You can match an architecture using this syntax:
#pragma GCC target ("arch=armv8-a+crypto")

I think matching on the feature is better, because there may be other ARM CPUs with the crypto feature set (in the future) that are not this exact architecture.

Also note that if you apply this fix, it still works even without -marchive=native.

With the fix applied, you now get this in the log:
2026-06-02T09:42:45Z Using the 'arm_shani(1way;2way)' SHA256 implementation

**edit**: Corrected the clang pragma to correctly detect crypto CPU extension on ARM.