### PR TITLE
mining: Optionally make extra pool persistent

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,6 +268,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/context.cpp
   node/database_args.cpp
   node/eviction.cpp
+  node/extrapool_persist.cpp
   node/interface_ui.cpp
   node/interfaces.cpp
   node/kernel_notifications.cpp

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -55,6 +55,7 @@
 #include <node/chainstate.h>
 #include <node/chainstatemanager_args.h>
 #include <node/context.h>
+#include <node/extrapool_persist.h>
 #include <node/interface_ui.h>
 #include <node/kernel_notifications.h>
 #include <node/mempool_args.h>
@@ -138,13 +139,17 @@ using node::ChainstateLoadStatus;
 using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINT_MODIFIED_FEE;
 using node::DEFAULT_STOPATHEIGHT;
+using node::DumpExtraPool;
 using node::DumpMempool;
+using node::ExtraPoolPath;
 using node::ImportBlocks;
 using node::KernelNotifications;
 using node::LoadChainstate;
+using node::LoadExtraPool;
 using node::LoadMempool;
 using node::MempoolPath;
 using node::NodeContext;
+using node::ShouldPersistExtraPool;
 using node::ShouldPersistMempool;
 using node::VerifyLoadedChainstate;
 using util::Join;
@@ -338,6 +343,12 @@ void Shutdown(NodeContext& node)
     // the scheduler. After this point, SyncWithValidationInterfaceQueue() should not be called anymore
     // as this would prevent the shutdown from completing.
     if (node.scheduler) node.scheduler->stop();
+
+    // Dump extra pool to disk for compact block reconstruction on next startup.
+    if (node.peerman && ShouldPersistExtraPool(*node.args)) {
+        auto [pool, pos] = node.peerman->GetExtraPoolForDump();
+        DumpExtraPool(pool, pos, ExtraPoolPath(*node.args));
+    }
 
     // After the threads that potentially access these pointers have been stopped,
     // destruct and reset all to nullptr.
@@ -2158,6 +2169,18 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                      *node.mempool, *node.warnings,
                                      peerman_opts);
     validation_signals.RegisterValidationInterface(node.peerman.get());
+
+    // Load extra pool from disk for compact block reconstruction.
+    if (ShouldPersistExtraPool(args)) {
+        std::vector<CTransactionRef> extra_pool;
+        size_t extra_pool_pos = 0, extra_pool_memusage = 0;
+        LoadExtraPool(extra_pool, extra_pool_pos, extra_pool_memusage,
+                      peerman_opts.max_extra_txs, peerman_opts.max_extra_txs_size,
+                      ExtraPoolPath(args));
+        if (!extra_pool.empty()) {
+            node.peerman->SetExtraPool(std::move(extra_pool), extra_pool_pos, extra_pool_memusage);
+        }
+    }
 
     // ********************************************************* Step 8: start indexers
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -136,6 +136,7 @@ using node::BlockManager;
 using node::CalculateCacheSizes;
 using node::ChainstateLoadResult;
 using node::ChainstateLoadStatus;
+using node::DEFAULT_PERSIST_EXTRA_POOL;
 using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINT_MODIFIED_FEE;
 using node::DEFAULT_STOPATHEIGHT;
@@ -346,8 +347,8 @@ void Shutdown(NodeContext& node)
 
     // Dump extra pool to disk for compact block reconstruction on next startup.
     if (node.peerman && ShouldPersistExtraPool(*node.args)) {
-        auto [pool, pos] = node.peerman->GetExtraPoolForDump();
-        DumpExtraPool(pool, pos, ExtraPoolPath(*node.args));
+        auto pool = node.peerman->GetExtraPoolForDump();
+        DumpExtraPool(pool, ExtraPoolPath(*node.args));
     }
 
     // After the threads that potentially access these pointers have been stopped,
@@ -520,6 +521,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                    strprintf("Upper limit of memory usage (in megabytes) for keeping extra transactions in memory for compact block reconstructions (default: %s)",
                              DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN_SIZE / 1000000),
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-persistextrapool", strprintf("Persist extra transactions to disk for compact block reconstruction (default: %u)", DEFAULT_PERSIST_EXTRA_POOL), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-blocksonly", strprintf("Whether to reject transactions from network peers. Disables automatic broadcast and rebroadcast of transactions, unless the source peer has the 'forcerelay' permission. RPC transactions are not affected. (default: %u)", DEFAULT_BLOCKSONLY), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-coinstatsindex", strprintf("Maintain coinstats index used by the gettxoutsetinfo RPC (default: %u)", DEFAULT_COINSTATSINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-conf=<file>", strprintf("Specify path to read-only configuration file. Relative paths will be prefixed by datadir location (only useable from command line, not configuration file) (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -2178,7 +2180,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                       peerman_opts.max_extra_txs, peerman_opts.max_extra_txs_size,
                       ExtraPoolPath(args));
         if (!extra_pool.empty()) {
-            node.peerman->SetExtraPool(std::move(extra_pool), extra_pool_pos, extra_pool_memusage);
+            node.peerman->SetExtraPool(std::move(extra_pool), extra_pool_memusage);
         }
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -521,6 +521,8 @@ public:
     void UpdateLastBlockAnnounceTime(NodeId node, int64_t time_in_seconds) override;
     ServiceFlags GetDesirableServiceFlags(ServiceFlags services) const override;
     int GetNumberOfPeersWithValidatedDownloads() const override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    std::pair<std::vector<CTransactionRef>, size_t> GetExtraPoolForDump() const override EXCLUSIVE_LOCKS_REQUIRED(!g_msgproc_mutex);
+    void SetExtraPool(std::vector<CTransactionRef> pool, size_t pos, size_t memusage) override EXCLUSIVE_LOCKS_REQUIRED(!g_msgproc_mutex);
 
 private:
     /** Consider evicting an outbound peer based on the amount of time they've been behind our tip */
@@ -1697,6 +1699,24 @@ int PeerManagerImpl::GetNumberOfPeersWithValidatedDownloads() const
 {
     AssertLockHeld(m_chainman.GetMutex());
     return m_peers_downloading_from;
+}
+
+std::pair<std::vector<CTransactionRef>, size_t> PeerManagerImpl::GetExtraPoolForDump() const
+{
+    LOCK(g_msgproc_mutex);
+    return {vExtraTxnForCompact, vExtraTxnForCompactIt};
+}
+
+void PeerManagerImpl::SetExtraPool(std::vector<CTransactionRef> pool, size_t pos, size_t memusage)
+{
+    LOCK(g_msgproc_mutex);
+    vExtraTxnForCompact.assign(m_opts.max_extra_txs, nullptr);
+    for (size_t i = 0; i < pool.size() && i < m_opts.max_extra_txs; ++i) {
+        vExtraTxnForCompact[i] = std::move(pool[i]);
+    }
+    vExtraTxnForCompactIt = std::min(pos, static_cast<size_t>(m_opts.max_extra_txs));
+    if (vExtraTxnForCompactIt >= m_opts.max_extra_txs) vExtraTxnForCompactIt = 0;
+    blockreconstructionextratxn_memusage = memusage;
 }
 
 bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -521,8 +521,8 @@ public:
     void UpdateLastBlockAnnounceTime(NodeId node, int64_t time_in_seconds) override;
     ServiceFlags GetDesirableServiceFlags(ServiceFlags services) const override;
     int GetNumberOfPeersWithValidatedDownloads() const override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    std::pair<std::vector<CTransactionRef>, size_t> GetExtraPoolForDump() const override EXCLUSIVE_LOCKS_REQUIRED(!g_msgproc_mutex);
-    void SetExtraPool(std::vector<CTransactionRef> pool, size_t pos, size_t memusage) override EXCLUSIVE_LOCKS_REQUIRED(!g_msgproc_mutex);
+    std::vector<CTransactionRef> GetExtraPoolForDump() const override EXCLUSIVE_LOCKS_REQUIRED(!g_msgproc_mutex);
+    void SetExtraPool(std::vector<CTransactionRef> pool, size_t memusage) override EXCLUSIVE_LOCKS_REQUIRED(!g_msgproc_mutex);
 
 private:
     /** Consider evicting an outbound peer based on the amount of time they've been behind our tip */
@@ -1701,20 +1701,21 @@ int PeerManagerImpl::GetNumberOfPeersWithValidatedDownloads() const
     return m_peers_downloading_from;
 }
 
-std::pair<std::vector<CTransactionRef>, size_t> PeerManagerImpl::GetExtraPoolForDump() const
+std::vector<CTransactionRef> PeerManagerImpl::GetExtraPoolForDump() const
 {
     LOCK(g_msgproc_mutex);
-    return {vExtraTxnForCompact, vExtraTxnForCompactIt};
+    return vExtraTxnForCompact;
 }
 
-void PeerManagerImpl::SetExtraPool(std::vector<CTransactionRef> pool, size_t pos, size_t memusage)
+void PeerManagerImpl::SetExtraPool(std::vector<CTransactionRef> pool, size_t memusage)
 {
     LOCK(g_msgproc_mutex);
     vExtraTxnForCompact.assign(m_opts.max_extra_txs, nullptr);
     for (size_t i = 0; i < pool.size() && i < m_opts.max_extra_txs; ++i) {
         vExtraTxnForCompact[i] = std::move(pool[i]);
     }
-    vExtraTxnForCompactIt = std::min(pos, static_cast<size_t>(m_opts.max_extra_txs));
+    // Derive position from pool size (next insertion position is at the end of loaded data)
+    vExtraTxnForCompactIt = std::min(pool.size(), static_cast<size_t>(m_opts.max_extra_txs));
     if (vExtraTxnForCompactIt >= m_opts.max_extra_txs) vExtraTxnForCompactIt = 0;
     blockreconstructionextratxn_memusage = memusage;
 }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -12,6 +12,7 @@
 #include <validationinterface.h>
 
 #include <chrono>
+#include <utility>
 
 class AddrMan;
 class CChainParams;
@@ -165,6 +166,12 @@ public:
 
     /** Get number of peers from which we're downloading blocks */
     virtual int GetNumberOfPeersWithValidatedDownloads() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main) = 0;
+
+    /** Get a copy of the extra pool (vExtraTxnForCompact) and current ring buffer position for persistence. */
+    virtual std::pair<std::vector<CTransactionRef>, size_t> GetExtraPoolForDump() const = 0;
+
+    /** Set the extra pool contents, position, and memory usage (used on startup to restore from disk). */
+    virtual void SetExtraPool(std::vector<CTransactionRef> pool, size_t pos, size_t memusage) = 0;
 };
 
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -167,11 +167,12 @@ public:
     /** Get number of peers from which we're downloading blocks */
     virtual int GetNumberOfPeersWithValidatedDownloads() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main) = 0;
 
-    /** Get a copy of the extra pool (vExtraTxnForCompact) and current ring buffer position for persistence. */
-    virtual std::pair<std::vector<CTransactionRef>, size_t> GetExtraPoolForDump() const = 0;
+    /** Get a copy of the extra pool (vExtraTxnForCompact) for persistence. */
+    virtual std::vector<CTransactionRef> GetExtraPoolForDump() const = 0;
 
-    /** Set the extra pool contents, position, and memory usage (used on startup to restore from disk). */
-    virtual void SetExtraPool(std::vector<CTransactionRef> pool, size_t pos, size_t memusage) = 0;
+    /** Set the extra pool contents and memory usage (used on startup to restore from disk).
+     *  Position is derived from pool size. */
+    virtual void SetExtraPool(std::vector<CTransactionRef> pool, size_t memusage) = 0;
 };
 
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/node/extrapool_persist.cpp
+++ b/src/node/extrapool_persist.cpp
@@ -172,7 +172,7 @@ bool LoadExtraPool(std::vector<CTransactionRef>& pool,
         }
 
         size_t to_load = std::min(static_cast<size_t>(count), max_count);
-        pool.resize(to_load);
+        pool.clear();
         memusage = 0;
 
         for (size_t i = 0; i < to_load; ++i) {
@@ -190,23 +190,21 @@ bool LoadExtraPool(std::vector<CTransactionRef>& pool,
                 // Check cumulative memory before adding
                 if (memusage + tx_usage > max_mem_bytes && !pool.empty()) {
                     LogDebug(BCLog::NET, "Extra pool memory limit reached, stopping load at %d transactions\n", i);
-                    pool.resize(i);
                     break;
                 }
                 
-                pool[i] = std::move(tx);
+                pool.push_back(std::move(tx));
                 memusage += tx_usage;
             } catch (const std::exception&) {
                 LogWarning("Extra pool deserialization failed at transaction %d. Keeping %d already loaded.\n", i, i);
-                pool.resize(i);
                 break;
             }
         }
 
         // Derive pool_pos from count (next insertion position is at the end of loaded data)
         // This maintains ring buffer invariant: TXs at [0, pool.size()), next write at pool.size() % max_count
-        pool_pos = std::min(static_cast<size_t>(count), max_count);
-        if (pool_pos >= max_count) pool_pos = 0;
+        // Guard against zero-capacity case (max_count == 0) to prevent division by zero
+        pool_pos = max_count > 0 ? pool.size() % max_count : 0;
 
         // Memory eviction: if over limit, evict from position forward using ring buffer pattern
         if (memusage > max_mem_bytes && !pool.empty()) {

--- a/src/node/extrapool_persist.cpp
+++ b/src/node/extrapool_persist.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Bitcoin Core developers
+// Copyright (c) 2026 The Bitcoin Knots developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,6 +7,7 @@
 #include <common/args.h>
 #include <core_memusage.h>
 #include <logging.h>
+#include <net_processing.h>
 #include <primitives/transaction.h>
 #include <serialize.h>
 #include <streams.h>
@@ -25,18 +26,41 @@ using fsbridge::FopenFn;
 
 namespace node {
 
+/**
+ * Returns true if extra pool persistence is enabled.
+ * Extra pool is persisted when the -persistextrapool option is set.
+ *
+ * @param argsman The ArgsManager instance containing command line arguments
+ * @return true if -persistextrapool=1, false otherwise
+ */
 bool ShouldPersistExtraPool(const ArgsManager& argsman)
 {
-    return argsman.GetBoolArg("-rejecttokens", false);
+    return argsman.GetBoolArg("-persistextrapool", DEFAULT_PERSIST_EXTRA_POOL);
 }
 
+/**
+ * Returns the path to the extra pool persistence file.
+ * The file is stored in the data directory as "extrapool.dat".
+ *
+ * @param argsman The ArgsManager instance containing command line arguments
+ * @return The filesystem path to the extra pool file
+ */
 fs::path ExtraPoolPath(const ArgsManager& argsman)
 {
     return argsman.GetDataDirNet() / "extrapool.dat";
 }
 
+/**
+ * Serialize extra pool transactions to disk.
+ * Writes version, count, and all non-null transactions to the file.
+ * Uses atomic write (write to .new file, then rename) for crash safety.
+ *
+ * @param pool The vector of transaction references to serialize
+ * @param dump_path The filesystem path to write the extra pool file to
+ * @param mockable_fopen_function Function pointer for opening files (for testing)
+ * @return true on success, false on failure (non-fatal, logged)
+ */
 bool DumpExtraPool(const std::vector<CTransactionRef>& pool,
-                   size_t pool_pos,
                    const fs::path& dump_path,
                    FopenFn mockable_fopen_function)
 {
@@ -55,11 +79,11 @@ bool DumpExtraPool(const std::vector<CTransactionRef>& pool,
     }
 
     try {
-        // Write header: version, count, ring buffer position
+        // Write header: version, count
+        // pool_pos is not persisted; on load it will be derived from count
         const uint64_t version{1};
         file << version;
         file << count;
-        file << static_cast<uint64_t>(pool_pos);
 
         // Serialize each non-null transaction
         for (const auto& tx : pool) {
@@ -90,6 +114,23 @@ bool DumpExtraPool(const std::vector<CTransactionRef>& pool,
     return true;
 }
 
+/**
+ * Deserialize extra pool transactions from disk.
+ * Reads version and count from file header, then deserializes each transaction.
+ * Enforces per-TX size limit (BLOCK_RECONSTRUCTION_EXTRA_TXN_PER_TXN_SIZE_LIMIT)
+ * and cumulative memory limit (max_mem_bytes) during loading.
+ * Derives pool_pos from count to maintain ring buffer invariant.
+ *
+ * @param[out] pool The vector to populate with deserialized transaction references
+ * @param[out] pool_pos The ring buffer position (derived from count, clamped to max_count)
+ * @param[out] memusage The total memory usage of loaded transactions
+ * @param max_count Maximum number of transactions to load
+ * @param max_mem_bytes Maximum memory usage allowed for loaded transactions
+ * @param load_path The filesystem path to read the extra pool file from
+ * @param mockable_fopen_function Function pointer for opening files (for testing)
+ * @return true on success (even if file doesn't exist - returns empty pool),
+ *         false only on unrecoverable errors (currently always returns true)
+ */
 bool LoadExtraPool(std::vector<CTransactionRef>& pool,
                    size_t& pool_pos,
                    size_t& memusage,
@@ -130,9 +171,6 @@ bool LoadExtraPool(std::vector<CTransactionRef>& pool,
             return true;
         }
 
-        uint64_t position;
-        file >> position;
-
         size_t to_load = std::min(static_cast<size_t>(count), max_count);
         pool.resize(to_load);
         memusage = 0;
@@ -141,8 +179,23 @@ bool LoadExtraPool(std::vector<CTransactionRef>& pool,
             try {
                 CTransactionRef tx;
                 file >> TX_WITH_WITNESS(tx);
+                
+                // Check per-TX size limit (match live insert behavior)
+                size_t tx_usage = RecursiveDynamicUsage(*tx);
+                if (tx_usage > BLOCK_RECONSTRUCTION_EXTRA_TXN_PER_TXN_SIZE_LIMIT) {
+                    LogWarning("Skipping oversized extra pool transaction (%d bytes) at index %d\n", tx_usage, i);
+                    continue;
+                }
+                
+                // Check cumulative memory before adding
+                if (memusage + tx_usage > max_mem_bytes && !pool.empty()) {
+                    LogDebug(BCLog::NET, "Extra pool memory limit reached, stopping load at %d transactions\n", i);
+                    pool.resize(i);
+                    break;
+                }
+                
                 pool[i] = std::move(tx);
-                memusage += RecursiveDynamicUsage(*pool[i]);
+                memusage += tx_usage;
             } catch (const std::exception&) {
                 LogWarning("Extra pool deserialization failed at transaction %d. Keeping %d already loaded.\n", i, i);
                 pool.resize(i);
@@ -150,8 +203,10 @@ bool LoadExtraPool(std::vector<CTransactionRef>& pool,
             }
         }
 
-        // Clamp position to loaded count
-        pool_pos = std::min(static_cast<size_t>(position), pool.size());
+        // Derive pool_pos from count (next insertion position is at the end of loaded data)
+        // This maintains ring buffer invariant: TXs at [0, pool.size()), next write at pool.size() % max_count
+        pool_pos = std::min(static_cast<size_t>(count), max_count);
+        if (pool_pos >= max_count) pool_pos = 0;
 
         // Memory eviction: if over limit, evict from position forward using ring buffer pattern
         if (memusage > max_mem_bytes && !pool.empty()) {

--- a/src/node/extrapool_persist.cpp
+++ b/src/node/extrapool_persist.cpp
@@ -1,0 +1,185 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/extrapool_persist.h>
+
+#include <common/args.h>
+#include <core_memusage.h>
+#include <logging.h>
+#include <primitives/transaction.h>
+#include <serialize.h>
+#include <streams.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
+#include <util/syserror.h>
+#include <util/time.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <exception>
+#include <stdexcept>
+#include <vector>
+
+using fsbridge::FopenFn;
+
+namespace node {
+
+bool ShouldPersistExtraPool(const ArgsManager& argsman)
+{
+    return argsman.GetBoolArg("-rejecttokens", false);
+}
+
+fs::path ExtraPoolPath(const ArgsManager& argsman)
+{
+    return argsman.GetDataDirNet() / "extrapool.dat";
+}
+
+bool DumpExtraPool(const std::vector<CTransactionRef>& pool,
+                   size_t pool_pos,
+                   const fs::path& dump_path,
+                   FopenFn mockable_fopen_function)
+{
+    auto start = SteadyClock::now();
+
+    // Count non-null entries
+    uint64_t count = 0;
+    for (const auto& tx : pool) {
+        if (tx != nullptr) ++count;
+    }
+
+    AutoFile file{mockable_fopen_function(dump_path + ".new", "wb")};
+    if (file.IsNull()) {
+        LogInfo("Failed to open extra pool file for writing: %s. Continuing anyway.\n", fs::PathToString(dump_path));
+        return false;
+    }
+
+    try {
+        // Write header: version, count, ring buffer position
+        const uint64_t version{1};
+        file << version;
+        file << count;
+        file << static_cast<uint64_t>(pool_pos);
+
+        // Serialize each non-null transaction
+        for (const auto& tx : pool) {
+            if (tx != nullptr) {
+                file << TX_WITH_WITNESS(*tx);
+            }
+        }
+
+        if (!file.Commit()) {
+            throw std::runtime_error("Commit failed");
+        }
+        if (file.fclose() != 0) {
+            throw std::runtime_error(
+                strprintf("Error closing %s: %s", fs::PathToString(dump_path + ".new"), SysErrorString(errno)));
+        }
+        if (!RenameOver(dump_path + ".new", dump_path)) {
+            throw std::runtime_error("Rename failed");
+        }
+
+        auto last = SteadyClock::now();
+        LogInfo("Dumped extra pool: %d transactions written in %.3fs\n",
+                count, Ticks<SecondsDouble>(last - start));
+    } catch (const std::exception& e) {
+        LogInfo("Failed to dump extra pool: %s. Continuing anyway.\n", e.what());
+        (void)file.fclose();
+        return false;
+    }
+    return true;
+}
+
+bool LoadExtraPool(std::vector<CTransactionRef>& pool,
+                   size_t& pool_pos,
+                   size_t& memusage,
+                   size_t max_count,
+                   size_t max_mem_bytes,
+                   const fs::path& load_path,
+                   FopenFn mockable_fopen_function)
+{
+    auto start = SteadyClock::now();
+
+    AutoFile file{mockable_fopen_function(load_path, "rb")};
+    if (file.IsNull()) {
+        LogInfo("No extra pool file found at %s. Starting with empty pool.\n", fs::PathToString(load_path));
+        pool.clear();
+        pool_pos = 0;
+        memusage = 0;
+        return true;
+    }
+
+    try {
+        uint64_t version;
+        file >> version;
+        if (version != 1) {
+            LogWarning("Extra pool file has unrecognized version %d. Starting with empty pool.\n", version);
+            pool.clear();
+            pool_pos = 0;
+            memusage = 0;
+            return true;
+        }
+
+        uint64_t count;
+        file >> count;
+        if (count > std::max(static_cast<uint64_t>(max_count), uint64_t{1000000})) {
+            LogWarning("Extra pool file claims %d transactions (likely corrupt). Starting with empty pool.\n", count);
+            pool.clear();
+            pool_pos = 0;
+            memusage = 0;
+            return true;
+        }
+
+        uint64_t position;
+        file >> position;
+
+        size_t to_load = std::min(static_cast<size_t>(count), max_count);
+        pool.resize(to_load);
+        memusage = 0;
+
+        for (size_t i = 0; i < to_load; ++i) {
+            try {
+                CTransactionRef tx;
+                file >> TX_WITH_WITNESS(tx);
+                pool[i] = std::move(tx);
+                memusage += RecursiveDynamicUsage(*pool[i]);
+            } catch (const std::exception&) {
+                LogWarning("Extra pool deserialization failed at transaction %d. Keeping %d already loaded.\n", i, i);
+                pool.resize(i);
+                break;
+            }
+        }
+
+        // Clamp position to loaded count
+        pool_pos = std::min(static_cast<size_t>(position), pool.size());
+
+        // Memory eviction: if over limit, evict from position forward using ring buffer pattern
+        if (memusage > max_mem_bytes && !pool.empty()) {
+            size_t safety_counter = 0;
+            const size_t pool_size = pool.size();
+            while (memusage > max_mem_bytes && safety_counter < pool_size) {
+                size_t evict_pos = pool_pos % pool_size;
+                if (pool[evict_pos] != nullptr) {
+                    memusage -= RecursiveDynamicUsage(*pool[evict_pos]);
+                    pool[evict_pos].reset();
+                }
+                pool_pos = (pool_pos + 1) % pool_size;
+                ++safety_counter;
+            }
+        }
+
+        auto last = SteadyClock::now();
+        LogInfo("Imported %d extra pool transactions from file in %.3fs\n",
+                pool.size(), Ticks<SecondsDouble>(last - start));
+    } catch (const std::exception& e) {
+        LogInfo("Failed to deserialize extra pool: %s. Starting with empty pool.\n", e.what());
+        pool.clear();
+        pool_pos = 0;
+        memusage = 0;
+        return true;
+    }
+
+    return true;
+}
+
+} // namespace node

--- a/src/node/extrapool_persist.h
+++ b/src/node/extrapool_persist.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_EXTRAPOOL_PERSIST_H
+#define BITCOIN_NODE_EXTRAPOOL_PERSIST_H
+
+#include <primitives/transaction.h>
+#include <util/fs.h>
+
+#include <cstddef>
+#include <vector>
+
+class ArgsManager;
+
+namespace node {
+
+// Returns true if extra pool persistence is enabled (rejecttokens=1)
+bool ShouldPersistExtraPool(const ArgsManager& argsman);
+
+// Returns path: GetDataDirNet() / "extrapool.dat"
+fs::path ExtraPoolPath(const ArgsManager& argsman);
+
+// Serialize vExtraTxnForCompact to disk. Called from Shutdown().
+// Returns true on success, false on failure (logged, non-fatal).
+bool DumpExtraPool(const std::vector<CTransactionRef>& pool,
+                   size_t pool_pos,
+                   const fs::path& dump_path,
+                   fsbridge::FopenFn mockable_fopen_function = fsbridge::fopen);
+
+// Deserialize extrapool.dat into the provided vector and position.
+// Applies count and memory limits. Returns true on success.
+bool LoadExtraPool(std::vector<CTransactionRef>& pool,
+                   size_t& pool_pos,
+                   size_t& memusage,
+                   size_t max_count,
+                   size_t max_mem_bytes,
+                   const fs::path& load_path,
+                   fsbridge::FopenFn mockable_fopen_function = fsbridge::fopen);
+
+} // namespace node
+
+#endif // BITCOIN_NODE_EXTRAPOOL_PERSIST_H

--- a/src/node/extrapool_persist.h
+++ b/src/node/extrapool_persist.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Bitcoin Core developers
+// Copyright (c) 2026 The Bitcoin Knots developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -15,21 +15,50 @@ class ArgsManager;
 
 namespace node {
 
-// Returns true if extra pool persistence is enabled (rejecttokens=1)
+static constexpr bool DEFAULT_PERSIST_EXTRA_POOL{false};
+
+/**
+ * Returns true if extra pool persistence is enabled (persistextrapool=1).
+ *
+ * @param argsman The ArgsManager instance containing command line arguments
+ * @return true if -persistextrapool=1, false otherwise
+ */
 bool ShouldPersistExtraPool(const ArgsManager& argsman);
 
-// Returns path: GetDataDirNet() / "extrapool.dat"
+/**
+ * Returns path: GetDataDirNet() / "extrapool.dat".
+ *
+ * @param argsman The ArgsManager instance containing command line arguments
+ * @return The filesystem path to the extra pool file
+ */
 fs::path ExtraPoolPath(const ArgsManager& argsman);
 
-// Serialize vExtraTxnForCompact to disk. Called from Shutdown().
-// Returns true on success, false on failure (logged, non-fatal).
+/**
+ * Serialize vExtraTxnForCompact to disk. Called from Shutdown().
+ * Uses atomic write (write to .new file, then rename) for crash safety.
+ *
+ * @param pool The vector of transaction references to serialize
+ * @param dump_path The filesystem path to write the extra pool file to
+ * @param mockable_fopen_function Function pointer for opening files (for testing)
+ * @return true on success, false on failure (logged, non-fatal)
+ */
 bool DumpExtraPool(const std::vector<CTransactionRef>& pool,
-                   size_t pool_pos,
                    const fs::path& dump_path,
                    fsbridge::FopenFn mockable_fopen_function = fsbridge::fopen);
 
-// Deserialize extrapool.dat into the provided vector and position.
-// Applies count and memory limits. Returns true on success.
+/**
+ * Deserialize extrapool.dat into the provided vector and position.
+ * Applies count and memory limits. Derives pool_pos from count.
+ *
+ * @param[out] pool The vector to populate with deserialized transaction references
+ * @param[out] pool_pos The ring buffer position (derived from count, clamped to max_count)
+ * @param[out] memusage The total memory usage of loaded transactions
+ * @param max_count Maximum number of transactions to load
+ * @param max_mem_bytes Maximum memory usage allowed for loaded transactions
+ * @param load_path The filesystem path to read the extra pool file from
+ * @param mockable_fopen_function Function pointer for opening files (for testing)
+ * @return true on success (even if file doesn't exist - returns empty pool)
+ */
 bool LoadExtraPool(std::vector<CTransactionRef>& pool,
                    size_t& pool_pos,
                    size_t& memusage,

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(test_bitcoin
   denialofservice_tests.cpp
   descriptor_tests.cpp
   disconnected_transactions.cpp
+  extrapool_persist_tests.cpp
   feefrac_tests.cpp
   flatfile_tests.cpp
   fs_tests.cpp

--- a/src/test/extrapool_persist_tests.cpp
+++ b/src/test/extrapool_persist_tests.cpp
@@ -1,0 +1,689 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/extrapool_persist.h>
+
+#include <core_memusage.h>
+#include <primitives/transaction.h>
+#include <random.h>
+#include <script/script.h>
+#include <serialize.h>
+#include <span.h>
+#include <streams.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+#include <util/fs.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+using node::DumpExtraPool;
+using node::ExtraPoolPath;
+using node::LoadExtraPool;
+using node::ShouldPersistExtraPool;
+
+BOOST_FIXTURE_TEST_SUITE(extrapool_persist_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(should_persist_rejecttokens_enabled)
+{
+    // When rejecttokens=1, ShouldPersistExtraPool returns true
+    m_args.ForceSetArg("-rejecttokens", "1");
+    BOOST_CHECK(ShouldPersistExtraPool(m_args));
+}
+
+BOOST_AUTO_TEST_CASE(should_persist_rejecttokens_disabled)
+{
+    // When rejecttokens=0, ShouldPersistExtraPool returns false
+    m_args.ForceSetArg("-rejecttokens", "0");
+    BOOST_CHECK(!ShouldPersistExtraPool(m_args));
+}
+
+BOOST_AUTO_TEST_CASE(should_persist_rejecttokens_unset)
+{
+    // When rejecttokens is not set, ShouldPersistExtraPool returns false (default)
+    BOOST_CHECK(!ShouldPersistExtraPool(m_args));
+}
+
+BOOST_AUTO_TEST_CASE(extrapool_path)
+{
+    // ExtraPoolPath returns datadir / "extrapool.dat"
+    auto path = ExtraPoolPath(m_args);
+    BOOST_CHECK_EQUAL(fs::PathToString(path.filename()), "extrapool.dat");
+    // The path should end with the expected filename
+    BOOST_CHECK(path.parent_path() == m_args.GetDataDirNet());
+}
+
+BOOST_AUTO_TEST_CASE(round_trip_happy_path)
+{
+    // Create a known pool with 5 transactions
+    std::vector<CTransactionRef> pool;
+    for (int i = 0; i < 5; ++i) {
+        CMutableTransaction mtx;
+        mtx.vin.resize(1);
+        mtx.vin[0].prevout = COutPoint(Txid::FromUint256(uint256(i)), 0);
+        mtx.vout.resize(1);
+        mtx.vout[0].nValue = (i + 1) * 1000;
+        mtx.vout[0].scriptPubKey = CScript() << OP_TRUE;
+        pool.push_back(MakeTransactionRef(std::move(mtx)));
+    }
+    size_t original_pos = 3; // ring buffer position
+
+    // Dump to a temp file
+    fs::path dump_path = m_args.GetDataDirNet() / "test_extrapool.dat";
+    BOOST_CHECK(DumpExtraPool(pool, original_pos, dump_path));
+
+    // Load back
+    std::vector<CTransactionRef> loaded_pool;
+    size_t loaded_pos = 0, loaded_memusage = 0;
+    BOOST_CHECK(LoadExtraPool(loaded_pool, loaded_pos, loaded_memusage,
+                              /*max_count=*/100, /*max_mem_bytes=*/100000000,
+                              dump_path));
+
+    // Verify
+    BOOST_CHECK_EQUAL(loaded_pool.size(), pool.size());
+    BOOST_CHECK_EQUAL(loaded_pos, original_pos);
+    BOOST_CHECK(loaded_memusage > 0);
+
+    for (size_t i = 0; i < pool.size(); ++i) {
+        BOOST_CHECK(loaded_pool[i] != nullptr);
+        BOOST_CHECK_EQUAL(pool[i]->GetHash().ToString(), loaded_pool[i]->GetHash().ToString());
+    }
+}
+
+// Property 3: Memory-Limited Eviction on Load
+// Validates: Requirements 2.4, 2.5
+BOOST_AUTO_TEST_CASE(property_memory_limited_eviction)
+{
+    // Property 3: For any pool whose loaded memory exceeds limit M,
+    // loading evicts transactions until memusage <= M,
+    // and memusage equals the sum of RecursiveDynamicUsage over remaining non-null entries.
+
+    FastRandomContext rng{/*fDeterministic=*/true};
+    fs::path path = m_args.GetDataDirNet() / "prop3_extrapool.dat";
+
+    for (int iter = 0; iter < 100; ++iter) {
+        // Generate pool with 5-20 transactions (all non-null, all substantial)
+        size_t N = 5 + rng.randrange(16);
+        std::vector<CTransactionRef> pool;
+        for (size_t i = 0; i < N; ++i) {
+            CMutableTransaction mtx;
+            mtx.vin.resize(1);
+            uint256 hash;
+            hash.SetNull();
+            uint64_t unique_val = (iter + 1) * 100000 + i;
+            std::memcpy(hash.begin(), &unique_val, sizeof(unique_val));
+            mtx.vin[0].prevout = COutPoint(Txid::FromUint256(hash), 0);
+            // Multiple outputs to increase memory usage
+            size_t num_outputs = 2 + rng.randrange(5);
+            mtx.vout.resize(num_outputs);
+            for (size_t j = 0; j < num_outputs; ++j) {
+                mtx.vout[j].nValue = rng.randrange(1000000) + 1;
+                mtx.vout[j].scriptPubKey = CScript() << OP_TRUE;
+            }
+            pool.push_back(MakeTransactionRef(std::move(mtx)));
+        }
+
+        size_t original_pos = rng.randrange(N);
+
+        // First, dump and load with unlimited memory to find total memusage
+        BOOST_CHECK(DumpExtraPool(pool, original_pos, path));
+
+        std::vector<CTransactionRef> full_pool;
+        size_t full_pos = 0, full_memusage = 0;
+        BOOST_CHECK(LoadExtraPool(full_pool, full_pos, full_memusage,
+                                  1000, 100000000, path));
+
+        if (full_memusage == 0) {
+            fs::remove(path);
+            continue;
+        }
+
+        // Choose memory limit M: between 1/4 and 3/4 of the total
+        size_t M = full_memusage / 4 + rng.randrange(full_memusage / 2 + 1);
+        if (M >= full_memusage) M = full_memusage / 2;
+        if (M == 0) M = 1;
+
+        // Load with memory limit
+        std::vector<CTransactionRef> limited_pool;
+        size_t limited_pos = 0, limited_memusage = 0;
+        BOOST_CHECK(LoadExtraPool(limited_pool, limited_pos, limited_memusage,
+                                  1000, M, path));
+
+        // Assert: memusage <= M
+        BOOST_CHECK(limited_memusage <= M);
+
+        // Verify memusage equals sum of RecursiveDynamicUsage over non-null entries
+        size_t computed_memusage = 0;
+        for (const auto& tx : limited_pool) {
+            if (tx) {
+                computed_memusage += RecursiveDynamicUsage(*tx);
+            }
+        }
+        BOOST_CHECK_EQUAL(limited_memusage, computed_memusage);
+
+        // Clean up
+        fs::remove(path);
+    }
+}
+
+// Property 1: Serialization Round-Trip
+// Validates: Requirements 1.2, 1.3, 2.2, 2.5, 7.4
+BOOST_AUTO_TEST_CASE(property_round_trip)
+{
+    // Property 1: For any valid extra pool state, serialize then deserialize
+    // produces the same set of non-null transactions in the same order,
+    // same ring buffer position, and correct memusage.
+
+    FastRandomContext rng{/*fDeterministic=*/true};
+    fs::path path = m_args.GetDataDirNet() / "prop1_extrapool.dat";
+
+    for (int iter = 0; iter < 100; ++iter) {
+        // Generate random pool: 0 to 50 entries, some may be null
+        size_t pool_size = rng.randrange(51);
+        std::vector<CTransactionRef> pool(pool_size);
+
+        for (size_t i = 0; i < pool_size; ++i) {
+            // ~20% chance of null entry
+            if (rng.randrange(5) == 0) {
+                pool[i] = nullptr;
+                continue;
+            }
+            CMutableTransaction mtx;
+            mtx.vin.resize(1);
+            // Use iteration and index to create unique prevout
+            uint256 hash;
+            hash.SetNull();
+            // Write iter*1000+i into the hash bytes to make unique
+            uint64_t unique_val = iter * 1000 + i;
+            std::memcpy(hash.begin(), &unique_val, sizeof(unique_val));
+            mtx.vin[0].prevout = COutPoint(Txid::FromUint256(hash), 0);
+            mtx.vout.resize(1 + rng.randrange(3)); // 1-3 outputs
+            for (size_t j = 0; j < mtx.vout.size(); ++j) {
+                mtx.vout[j].nValue = rng.randrange(1000000) + 1;
+                mtx.vout[j].scriptPubKey = CScript() << OP_TRUE;
+            }
+            pool[i] = MakeTransactionRef(std::move(mtx));
+        }
+
+        // Random position (clamped to pool size)
+        size_t original_pos = pool_size > 0 ? rng.randrange(pool_size) : 0;
+
+        // Count non-null entries
+        size_t non_null_count = 0;
+        for (const auto& tx : pool) {
+            if (tx) ++non_null_count;
+        }
+
+        // Dump
+        BOOST_CHECK(DumpExtraPool(pool, original_pos, path));
+
+        // Load with generous limits
+        std::vector<CTransactionRef> loaded_pool;
+        size_t loaded_pos = 0, loaded_memusage = 0;
+        BOOST_CHECK(LoadExtraPool(loaded_pool, loaded_pos, loaded_memusage,
+                                  /*max_count=*/1000, /*max_mem_bytes=*/100000000,
+                                  path));
+
+        // Verify: loaded pool has exactly non_null_count entries
+        BOOST_CHECK_EQUAL(loaded_pool.size(), non_null_count);
+
+        // Verify: position is clamped to loaded count
+        BOOST_CHECK(loaded_pos <= loaded_pool.size());
+        // If original_pos <= non_null_count, it should be preserved
+        if (original_pos <= non_null_count) {
+            BOOST_CHECK_EQUAL(loaded_pos, original_pos);
+        }
+
+        // Verify: transactions match in order (non-null entries from original)
+        size_t loaded_idx = 0;
+        for (size_t i = 0; i < pool_size; ++i) {
+            if (pool[i]) {
+                BOOST_REQUIRE(loaded_idx < loaded_pool.size());
+                BOOST_CHECK(loaded_pool[loaded_idx] != nullptr);
+                BOOST_CHECK_EQUAL(pool[i]->GetHash().ToString(),
+                                  loaded_pool[loaded_idx]->GetHash().ToString());
+                ++loaded_idx;
+            }
+        }
+
+        // Verify memusage is positive if there are transactions
+        if (non_null_count > 0) {
+            BOOST_CHECK(loaded_memusage > 0);
+        }
+
+        // Clean up for next iteration
+        fs::remove(path);
+    }
+}
+
+// Property 2: Count-Limited Loading
+// Validates: Requirements 2.3
+BOOST_AUTO_TEST_CASE(property_count_limited_loading)
+{
+    // Property 2: For any pool with N > L transactions and limit L,
+    // loading produces exactly L transactions (the first L from file),
+    // and position is clamped to at most L.
+
+    FastRandomContext rng{/*fDeterministic=*/true};
+    fs::path path = m_args.GetDataDirNet() / "prop2_extrapool.dat";
+
+    for (int iter = 0; iter < 100; ++iter) {
+        // Generate pool with N transactions (N between 5 and 50)
+        size_t N = 5 + rng.randrange(46);
+        std::vector<CTransactionRef> pool;
+        for (size_t i = 0; i < N; ++i) {
+            CMutableTransaction mtx;
+            mtx.vin.resize(1);
+            uint256 hash;
+            hash.SetNull();
+            uint64_t unique_val = (iter + 1) * 100000 + i;
+            std::memcpy(hash.begin(), &unique_val, sizeof(unique_val));
+            mtx.vin[0].prevout = COutPoint(Txid::FromUint256(hash), 0);
+            mtx.vout.resize(1 + rng.randrange(3));
+            for (size_t j = 0; j < mtx.vout.size(); ++j) {
+                mtx.vout[j].nValue = rng.randrange(1000000) + 1;
+                mtx.vout[j].scriptPubKey = CScript() << OP_TRUE;
+            }
+            pool.push_back(MakeTransactionRef(std::move(mtx)));
+        }
+
+        // Choose limit L strictly less than N (L between 1 and N-1)
+        size_t L = 1 + rng.randrange(N - 1);
+
+        // Choose a random ring buffer position (may exceed L)
+        size_t original_pos = rng.randrange(N);
+
+        // Dump full pool
+        BOOST_CHECK(DumpExtraPool(pool, original_pos, path));
+
+        // Load with count limit L and generous memory limit
+        std::vector<CTransactionRef> loaded_pool;
+        size_t loaded_pos = 0, loaded_memusage = 0;
+        BOOST_CHECK(LoadExtraPool(loaded_pool, loaded_pos, loaded_memusage,
+                                  /*max_count=*/L, /*max_mem_bytes=*/100000000,
+                                  path));
+
+        // Assert: exactly L transactions loaded
+        BOOST_CHECK_EQUAL(loaded_pool.size(), L);
+
+        // Assert: ring buffer position clamped to at most L
+        BOOST_CHECK(loaded_pos <= L);
+
+        // Assert: the first L transactions match the original first L
+        for (size_t i = 0; i < L; ++i) {
+            BOOST_REQUIRE(loaded_pool[i] != nullptr);
+            BOOST_CHECK_EQUAL(pool[i]->GetHash().ToString(),
+                              loaded_pool[i]->GetHash().ToString());
+        }
+
+        // Clean up
+        fs::remove(path);
+    }
+}
+
+// --- Unit tests for error/edge cases (Task 5.4) ---
+
+// Requirement 3.1: Missing file → empty pool
+BOOST_AUTO_TEST_CASE(load_missing_file_returns_empty)
+{
+    fs::path path = m_args.GetDataDirNet() / "nonexistent_extrapool.dat";
+    // Ensure file does not exist
+    fs::remove(path);
+
+    std::vector<CTransactionRef> pool;
+    size_t pos = 99, memusage = 99;
+    BOOST_CHECK(LoadExtraPool(pool, pos, memusage,
+                              /*max_count=*/100, /*max_mem_bytes=*/100000000,
+                              path));
+    BOOST_CHECK(pool.empty());
+    BOOST_CHECK_EQUAL(pos, 0u);
+    BOOST_CHECK_EQUAL(memusage, 0u);
+}
+
+// Requirement 3.3: Bad version number → warning + empty pool
+BOOST_AUTO_TEST_CASE(load_bad_version_returns_empty)
+{
+    fs::path path = m_args.GetDataDirNet() / "badver_extrapool.dat";
+
+    // Write a file with an unrecognized version number
+    {
+        AutoFile file{fsbridge::fopen(path, "wb")};
+        BOOST_REQUIRE(!file.IsNull());
+        uint64_t bad_version = 99;
+        file << bad_version;
+        uint64_t count = 0;
+        file << count;
+        uint64_t position = 0;
+        file << position;
+    }
+
+    std::vector<CTransactionRef> pool;
+    size_t pos = 99, memusage = 99;
+    BOOST_CHECK(LoadExtraPool(pool, pos, memusage,
+                              /*max_count=*/100, /*max_mem_bytes=*/100000000,
+                              path));
+    BOOST_CHECK(pool.empty());
+    BOOST_CHECK_EQUAL(pos, 0u);
+    BOOST_CHECK_EQUAL(memusage, 0u);
+
+    fs::remove(path);
+}
+
+// Requirement 3.4: Corrupt transaction mid-stream → partial load
+BOOST_AUTO_TEST_CASE(load_corrupt_transaction_partial_load)
+{
+    fs::path path = m_args.GetDataDirNet() / "corrupt_extrapool.dat";
+
+    // First, create a valid pool with 5 transactions, dump it, then corrupt it
+    std::vector<CTransactionRef> original_pool;
+    for (int i = 0; i < 5; ++i) {
+        CMutableTransaction mtx;
+        mtx.vin.resize(1);
+        mtx.vin[0].prevout = COutPoint(Txid::FromUint256(uint256(i + 100)), 0);
+        mtx.vout.resize(1);
+        mtx.vout[0].nValue = (i + 1) * 5000;
+        mtx.vout[0].scriptPubKey = CScript() << OP_TRUE;
+        original_pool.push_back(MakeTransactionRef(std::move(mtx)));
+    }
+
+    // Dump the valid pool
+    BOOST_CHECK(DumpExtraPool(original_pool, /*pool_pos=*/2, path));
+
+    // Read the file content, then truncate it partway through a later transaction
+    // The header is 24 bytes (3 x uint64_t).
+    // Strategy: read full file, truncate to keep ~60% of tx data
+    std::vector<uint8_t> file_contents;
+    {
+        FILE* f = fsbridge::fopen(path, "rb");
+        BOOST_REQUIRE(f != nullptr);
+        std::fseek(f, 0, SEEK_END);
+        long file_size = std::ftell(f);
+        std::fseek(f, 0, SEEK_SET);
+        BOOST_REQUIRE(file_size > 24);
+        file_contents.resize(static_cast<size_t>(file_size));
+        size_t read = std::fread(file_contents.data(), 1, file_contents.size(), f);
+        BOOST_CHECK_EQUAL(read, file_contents.size());
+        std::fclose(f);
+    }
+
+    // Truncate at roughly 60% of the file (after header), which should be mid-transaction
+    const size_t header_size = 24; // 3 x uint64_t
+    size_t tx_data_size = file_contents.size() - header_size;
+    size_t truncate_point = header_size + (tx_data_size * 3 / 5);
+
+    // Write truncated file
+    {
+        FILE* f = fsbridge::fopen(path, "wb");
+        BOOST_REQUIRE(f != nullptr);
+        size_t written = std::fwrite(file_contents.data(), 1, truncate_point, f);
+        BOOST_CHECK_EQUAL(written, truncate_point);
+        std::fclose(f);
+    }
+
+    // Load the corrupt file
+    std::vector<CTransactionRef> loaded_pool;
+    size_t pos = 0, memusage = 0;
+    BOOST_CHECK(LoadExtraPool(loaded_pool, pos, memusage,
+                              /*max_count=*/100, /*max_mem_bytes=*/100000000,
+                              path));
+
+    // Should have loaded some but not all 5 transactions
+    BOOST_CHECK(loaded_pool.size() > 0);
+    BOOST_CHECK(loaded_pool.size() < 5);
+
+    // The loaded transactions should match the originals in order
+    for (size_t i = 0; i < loaded_pool.size(); ++i) {
+        BOOST_CHECK(loaded_pool[i] != nullptr);
+        BOOST_CHECK_EQUAL(original_pool[i]->GetHash().ToString(),
+                          loaded_pool[i]->GetHash().ToString());
+    }
+
+    fs::remove(path);
+}
+
+// Requirement 7.3: Count exceeds upper bound → rejected (empty pool)
+BOOST_AUTO_TEST_CASE(load_count_exceeds_upper_bound)
+{
+    fs::path path = m_args.GetDataDirNet() / "bigcount_extrapool.dat";
+
+    // Write a file with count = 10,000,000 (exceeds max(100, 1000000) = 1000000)
+    {
+        AutoFile file{fsbridge::fopen(path, "wb")};
+        BOOST_REQUIRE(!file.IsNull());
+        uint64_t version = 1;
+        file << version;
+        uint64_t count = 10000000; // 10 million - way above the bound
+        file << count;
+        uint64_t position = 0;
+        file << position;
+        // No actual transaction data needed - count check happens first
+    }
+
+    std::vector<CTransactionRef> pool;
+    size_t pos = 99, memusage = 99;
+    BOOST_CHECK(LoadExtraPool(pool, pos, memusage,
+                              /*max_count=*/100, /*max_mem_bytes=*/100000000,
+                              path));
+    BOOST_CHECK(pool.empty());
+    BOOST_CHECK_EQUAL(pos, 0u);
+    BOOST_CHECK_EQUAL(memusage, 0u);
+
+    fs::remove(path);
+}
+
+// Requirement 2.3: Count-limited loading (file has more txs than configured limit)
+BOOST_AUTO_TEST_CASE(load_count_limited)
+{
+    fs::path path = m_args.GetDataDirNet() / "countlimit_extrapool.dat";
+
+    // Create a pool with 10 transactions
+    std::vector<CTransactionRef> original_pool;
+    for (int i = 0; i < 10; ++i) {
+        CMutableTransaction mtx;
+        mtx.vin.resize(1);
+        mtx.vin[0].prevout = COutPoint(Txid::FromUint256(uint256(i + 200)), 0);
+        mtx.vout.resize(1);
+        mtx.vout[0].nValue = (i + 1) * 2000;
+        mtx.vout[0].scriptPubKey = CScript() << OP_TRUE;
+        original_pool.push_back(MakeTransactionRef(std::move(mtx)));
+    }
+
+    // Dump with position 7
+    BOOST_CHECK(DumpExtraPool(original_pool, /*pool_pos=*/7, path));
+
+    // Load with max_count=4 (less than the 10 in the file)
+    std::vector<CTransactionRef> loaded_pool;
+    size_t pos = 0, memusage = 0;
+    BOOST_CHECK(LoadExtraPool(loaded_pool, pos, memusage,
+                              /*max_count=*/4, /*max_mem_bytes=*/100000000,
+                              path));
+
+    // Should load exactly 4 transactions (the first 4 from the file)
+    BOOST_CHECK_EQUAL(loaded_pool.size(), 4u);
+
+    // Verify they are the first 4 transactions
+    for (size_t i = 0; i < 4; ++i) {
+        BOOST_CHECK(loaded_pool[i] != nullptr);
+        BOOST_CHECK_EQUAL(original_pool[i]->GetHash().ToString(),
+                          loaded_pool[i]->GetHash().ToString());
+    }
+
+    // Position should be clamped to at most the loaded count (4)
+    BOOST_CHECK(pos <= 4u);
+
+    fs::remove(path);
+}
+
+// Requirement 2.4: Memory-limited eviction (loaded pool exceeds memory limit)
+BOOST_AUTO_TEST_CASE(load_memory_limited_eviction)
+{
+    fs::path path = m_args.GetDataDirNet() / "memlimit_extrapool.dat";
+
+    // Create a pool with 10 transactions, each with enough outputs to have measurable memusage
+    std::vector<CTransactionRef> original_pool;
+    for (int i = 0; i < 10; ++i) {
+        CMutableTransaction mtx;
+        mtx.vin.resize(1);
+        mtx.vin[0].prevout = COutPoint(Txid::FromUint256(uint256(i + 300)), 0);
+        mtx.vout.resize(5); // multiple outputs to increase memory usage
+        for (int j = 0; j < 5; ++j) {
+            mtx.vout[j].nValue = (i + 1) * 1000 + j;
+            mtx.vout[j].scriptPubKey = CScript() << OP_TRUE;
+        }
+        original_pool.push_back(MakeTransactionRef(std::move(mtx)));
+    }
+
+    // Dump with position 3
+    BOOST_CHECK(DumpExtraPool(original_pool, /*pool_pos=*/3, path));
+
+    // First, load with unlimited memory to determine total memusage
+    std::vector<CTransactionRef> full_pool;
+    size_t full_pos = 0, full_memusage = 0;
+    BOOST_CHECK(LoadExtraPool(full_pool, full_pos, full_memusage,
+                              /*max_count=*/100, /*max_mem_bytes=*/100000000,
+                              path));
+    BOOST_REQUIRE(full_memusage > 0);
+
+    // Now load with a tight memory limit (half of the total)
+    size_t mem_limit = full_memusage / 2;
+    BOOST_REQUIRE(mem_limit > 0);
+
+    std::vector<CTransactionRef> limited_pool;
+    size_t limited_pos = 0, limited_memusage = 0;
+    BOOST_CHECK(LoadExtraPool(limited_pool, limited_pos, limited_memusage,
+                              /*max_count=*/100, /*max_mem_bytes=*/mem_limit,
+                              path));
+
+    // Memusage must be within the limit
+    BOOST_CHECK(limited_memusage <= mem_limit);
+
+    // Verify memusage equals sum of RecursiveDynamicUsage over remaining non-null entries
+    size_t computed_memusage = 0;
+    size_t non_null_count = 0;
+    for (const auto& tx : limited_pool) {
+        if (tx) {
+            computed_memusage += RecursiveDynamicUsage(*tx);
+            ++non_null_count;
+        }
+    }
+    BOOST_CHECK_EQUAL(limited_memusage, computed_memusage);
+
+    // Some transactions should have been evicted (not all are non-null)
+    BOOST_CHECK(non_null_count < 10u);
+
+    fs::remove(path);
+}
+
+// Property 4: Partial Load Resilience
+// Validates: Requirements 3.4
+BOOST_AUTO_TEST_CASE(property_partial_load_resilience)
+{
+    // Property 4: For any valid serialized extra pool file truncated at position P
+    // within transaction data, all transactions fully deserialized before P are
+    // retained and identical to those in the original pool (in order).
+
+    FastRandomContext rng{/*fDeterministic=*/true};
+    fs::path valid_path = m_args.GetDataDirNet() / "prop4_valid.dat";
+    fs::path corrupt_path = m_args.GetDataDirNet() / "prop4_corrupt.dat";
+
+    for (int iter = 0; iter < 100; ++iter) {
+        // Generate pool with 3-20 non-null transactions
+        size_t N = 3 + rng.randrange(18);
+        std::vector<CTransactionRef> pool;
+        pool.reserve(N);
+        for (size_t i = 0; i < N; ++i) {
+            CMutableTransaction mtx;
+            mtx.vin.resize(1);
+            uint256 hash;
+            hash.SetNull();
+            uint64_t unique_val = (iter + 1) * 100000 + i;
+            std::memcpy(hash.begin(), &unique_val, sizeof(unique_val));
+            mtx.vin[0].prevout = COutPoint(Txid::FromUint256(hash), 0);
+            // Variable number of outputs to create varying serialized sizes
+            size_t num_outputs = 1 + rng.randrange(4);
+            mtx.vout.resize(num_outputs);
+            for (size_t j = 0; j < num_outputs; ++j) {
+                mtx.vout[j].nValue = rng.randrange(1000000) + 1;
+                mtx.vout[j].scriptPubKey = CScript() << OP_TRUE;
+            }
+            pool.push_back(MakeTransactionRef(std::move(mtx)));
+        }
+
+        size_t original_pos = rng.randrange(N);
+
+        // Dump valid file
+        BOOST_CHECK(DumpExtraPool(pool, original_pos, valid_path));
+
+        // Read entire valid file into memory buffer
+        std::vector<uint8_t> file_contents;
+        {
+            FILE* f = fsbridge::fopen(valid_path, "rb");
+            BOOST_REQUIRE(f != nullptr);
+            std::fseek(f, 0, SEEK_END);
+            long file_size = std::ftell(f);
+            std::fseek(f, 0, SEEK_SET);
+            BOOST_REQUIRE(file_size > 24); // Must have header + at least some tx data
+            file_contents.resize(static_cast<size_t>(file_size));
+            size_t read = std::fread(file_contents.data(), 1, file_contents.size(), f);
+            BOOST_CHECK_EQUAL(read, file_contents.size());
+            std::fclose(f);
+        }
+
+        // The header is 24 bytes (version + count + position, each uint64_t).
+        // Truncate at a random point within the transaction data region.
+        // Ensure truncation point is after the header but before the end of file.
+        const size_t header_size = 24;
+        if (file_contents.size() <= header_size + 1) {
+            // File too small to truncate meaningfully; skip this iteration
+            fs::remove(valid_path);
+            continue;
+        }
+
+        // Pick truncation point: at least 1 byte into tx data, at most file_size - 1
+        // (so we actually truncate something)
+        size_t trunc_point = header_size + 1 + rng.randrange(file_contents.size() - header_size - 1);
+
+        // Write truncated content to corrupt_path
+        {
+            FILE* f = fsbridge::fopen(corrupt_path, "wb");
+            BOOST_REQUIRE(f != nullptr);
+            size_t written = std::fwrite(file_contents.data(), 1, trunc_point, f);
+            BOOST_CHECK_EQUAL(written, trunc_point);
+            std::fclose(f);
+        }
+
+        // Load from truncated file
+        std::vector<CTransactionRef> loaded_pool;
+        size_t loaded_pos = 0, loaded_memusage = 0;
+        LoadExtraPool(loaded_pool, loaded_pos, loaded_memusage,
+                      1000, 100000000, corrupt_path);
+
+        // Assert: all loaded transactions are non-null and match the prefix of
+        // the original pool in order.
+        BOOST_CHECK(loaded_pool.size() <= N);
+        for (size_t i = 0; i < loaded_pool.size(); ++i) {
+            BOOST_CHECK(loaded_pool[i] != nullptr);
+            BOOST_CHECK_EQUAL(pool[i]->GetHash().ToString(),
+                              loaded_pool[i]->GetHash().ToString());
+        }
+
+        // Since we truncated within tx data, we should have fewer transactions
+        // than the original (unless truncation happened after all tx data which
+        // is extremely unlikely given our random range).
+        // At minimum, we verify the loaded transactions are a proper prefix.
+        if (loaded_pool.size() < N) {
+            // Partial load occurred as expected - good
+            BOOST_CHECK(loaded_pool.size() < N);
+        }
+
+        // Clean up
+        fs::remove(valid_path);
+        fs::remove(corrupt_path);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/extrapool_persist_tests.cpp
+++ b/src/test/extrapool_persist_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Bitcoin Core developers
+// Copyright (c) 2026 The Bitcoin Knots developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -28,23 +28,23 @@ using node::ShouldPersistExtraPool;
 
 BOOST_FIXTURE_TEST_SUITE(extrapool_persist_tests, BasicTestingSetup)
 
-BOOST_AUTO_TEST_CASE(should_persist_rejecttokens_enabled)
+BOOST_AUTO_TEST_CASE(should_persist_persistextrapool_enabled)
 {
-    // When rejecttokens=1, ShouldPersistExtraPool returns true
-    m_args.ForceSetArg("-rejecttokens", "1");
+    // When persistextrapool=1, ShouldPersistExtraPool returns true
+    m_args.ForceSetArg("-persistextrapool", "1");
     BOOST_CHECK(ShouldPersistExtraPool(m_args));
 }
 
-BOOST_AUTO_TEST_CASE(should_persist_rejecttokens_disabled)
+BOOST_AUTO_TEST_CASE(should_persist_persistextrapool_disabled)
 {
-    // When rejecttokens=0, ShouldPersistExtraPool returns false
-    m_args.ForceSetArg("-rejecttokens", "0");
+    // When persistextrapool=0, ShouldPersistExtraPool returns false
+    m_args.ForceSetArg("-persistextrapool", "0");
     BOOST_CHECK(!ShouldPersistExtraPool(m_args));
 }
 
-BOOST_AUTO_TEST_CASE(should_persist_rejecttokens_unset)
+BOOST_AUTO_TEST_CASE(should_persist_persistextrapool_unset)
 {
-    // When rejecttokens is not set, ShouldPersistExtraPool returns false (default)
+    // When persistextrapool is not set, ShouldPersistExtraPool returns false (default)
     BOOST_CHECK(!ShouldPersistExtraPool(m_args));
 }
 
@@ -70,11 +70,10 @@ BOOST_AUTO_TEST_CASE(round_trip_happy_path)
         mtx.vout[0].scriptPubKey = CScript() << OP_TRUE;
         pool.push_back(MakeTransactionRef(std::move(mtx)));
     }
-    size_t original_pos = 3; // ring buffer position
 
     // Dump to a temp file
     fs::path dump_path = m_args.GetDataDirNet() / "test_extrapool.dat";
-    BOOST_CHECK(DumpExtraPool(pool, original_pos, dump_path));
+    BOOST_CHECK(DumpExtraPool(pool, dump_path));
 
     // Load back
     std::vector<CTransactionRef> loaded_pool;
@@ -85,7 +84,9 @@ BOOST_AUTO_TEST_CASE(round_trip_happy_path)
 
     // Verify
     BOOST_CHECK_EQUAL(loaded_pool.size(), pool.size());
-    BOOST_CHECK_EQUAL(loaded_pos, original_pos);
+    // Position is now derived from count, not preserved from dump
+    // With all non-null entries, position should equal the count (clamped to max_count)
+    BOOST_CHECK_EQUAL(loaded_pos, pool.size());
     BOOST_CHECK(loaded_memusage > 0);
 
     for (size_t i = 0; i < pool.size(); ++i) {
@@ -127,10 +128,8 @@ BOOST_AUTO_TEST_CASE(property_memory_limited_eviction)
             pool.push_back(MakeTransactionRef(std::move(mtx)));
         }
 
-        size_t original_pos = rng.randrange(N);
-
         // First, dump and load with unlimited memory to find total memusage
-        BOOST_CHECK(DumpExtraPool(pool, original_pos, path));
+        BOOST_CHECK(DumpExtraPool(pool, path));
 
         std::vector<CTransactionRef> full_pool;
         size_t full_pos = 0, full_memusage = 0;
@@ -209,9 +208,6 @@ BOOST_AUTO_TEST_CASE(property_round_trip)
             pool[i] = MakeTransactionRef(std::move(mtx));
         }
 
-        // Random position (clamped to pool size)
-        size_t original_pos = pool_size > 0 ? rng.randrange(pool_size) : 0;
-
         // Count non-null entries
         size_t non_null_count = 0;
         for (const auto& tx : pool) {
@@ -219,7 +215,7 @@ BOOST_AUTO_TEST_CASE(property_round_trip)
         }
 
         // Dump
-        BOOST_CHECK(DumpExtraPool(pool, original_pos, path));
+        BOOST_CHECK(DumpExtraPool(pool, path));
 
         // Load with generous limits
         std::vector<CTransactionRef> loaded_pool;
@@ -231,12 +227,10 @@ BOOST_AUTO_TEST_CASE(property_round_trip)
         // Verify: loaded pool has exactly non_null_count entries
         BOOST_CHECK_EQUAL(loaded_pool.size(), non_null_count);
 
-        // Verify: position is clamped to loaded count
+        // Verify: position is derived from count (clamped to max_count)
+        // With all non-null entries loaded, position should equal the count
         BOOST_CHECK(loaded_pos <= loaded_pool.size());
-        // If original_pos <= non_null_count, it should be preserved
-        if (original_pos <= non_null_count) {
-            BOOST_CHECK_EQUAL(loaded_pos, original_pos);
-        }
+        BOOST_CHECK_EQUAL(loaded_pos, non_null_count);
 
         // Verify: transactions match in order (non-null entries from original)
         size_t loaded_idx = 0;
@@ -294,11 +288,8 @@ BOOST_AUTO_TEST_CASE(property_count_limited_loading)
         // Choose limit L strictly less than N (L between 1 and N-1)
         size_t L = 1 + rng.randrange(N - 1);
 
-        // Choose a random ring buffer position (may exceed L)
-        size_t original_pos = rng.randrange(N);
-
         // Dump full pool
-        BOOST_CHECK(DumpExtraPool(pool, original_pos, path));
+        BOOST_CHECK(DumpExtraPool(pool, path));
 
         // Load with count limit L and generous memory limit
         std::vector<CTransactionRef> loaded_pool;
@@ -357,8 +348,9 @@ BOOST_AUTO_TEST_CASE(load_bad_version_returns_empty)
         file << bad_version;
         uint64_t count = 0;
         file << count;
-        uint64_t position = 0;
-        file << position;
+        // Note: position is no longer persisted, only version and count
+        // Must explicitly close AutoFile after writing
+        BOOST_REQUIRE(file.fclose() == 0);
     }
 
     std::vector<CTransactionRef> pool;
@@ -391,7 +383,7 @@ BOOST_AUTO_TEST_CASE(load_corrupt_transaction_partial_load)
     }
 
     // Dump the valid pool
-    BOOST_CHECK(DumpExtraPool(original_pool, /*pool_pos=*/2, path));
+    BOOST_CHECK(DumpExtraPool(original_pool, path));
 
     // Read the file content, then truncate it partway through a later transaction
     // The header is 24 bytes (3 x uint64_t).
@@ -403,7 +395,7 @@ BOOST_AUTO_TEST_CASE(load_corrupt_transaction_partial_load)
         std::fseek(f, 0, SEEK_END);
         long file_size = std::ftell(f);
         std::fseek(f, 0, SEEK_SET);
-        BOOST_REQUIRE(file_size > 24);
+        BOOST_REQUIRE(file_size > 16);
         file_contents.resize(static_cast<size_t>(file_size));
         size_t read = std::fread(file_contents.data(), 1, file_contents.size(), f);
         BOOST_CHECK_EQUAL(read, file_contents.size());
@@ -458,9 +450,10 @@ BOOST_AUTO_TEST_CASE(load_count_exceeds_upper_bound)
         file << version;
         uint64_t count = 10000000; // 10 million - way above the bound
         file << count;
-        uint64_t position = 0;
-        file << position;
+        // Note: position is no longer persisted, only version and count
         // No actual transaction data needed - count check happens first
+        // Must explicitly close AutoFile after writing
+        BOOST_REQUIRE(file.fclose() == 0);
     }
 
     std::vector<CTransactionRef> pool;
@@ -492,8 +485,8 @@ BOOST_AUTO_TEST_CASE(load_count_limited)
         original_pool.push_back(MakeTransactionRef(std::move(mtx)));
     }
 
-    // Dump with position 7
-    BOOST_CHECK(DumpExtraPool(original_pool, /*pool_pos=*/7, path));
+    // Dump
+    BOOST_CHECK(DumpExtraPool(original_pool, path));
 
     // Load with max_count=4 (less than the 10 in the file)
     std::vector<CTransactionRef> loaded_pool;
@@ -537,8 +530,8 @@ BOOST_AUTO_TEST_CASE(load_memory_limited_eviction)
         original_pool.push_back(MakeTransactionRef(std::move(mtx)));
     }
 
-    // Dump with position 3
-    BOOST_CHECK(DumpExtraPool(original_pool, /*pool_pos=*/3, path));
+    // Dump
+    BOOST_CHECK(DumpExtraPool(original_pool, path));
 
     // First, load with unlimited memory to determine total memusage
     std::vector<CTransactionRef> full_pool;
@@ -613,10 +606,8 @@ BOOST_AUTO_TEST_CASE(property_partial_load_resilience)
             pool.push_back(MakeTransactionRef(std::move(mtx)));
         }
 
-        size_t original_pos = rng.randrange(N);
-
         // Dump valid file
-        BOOST_CHECK(DumpExtraPool(pool, original_pos, valid_path));
+        BOOST_CHECK(DumpExtraPool(pool, valid_path));
 
         // Read entire valid file into memory buffer
         std::vector<uint8_t> file_contents;
@@ -633,10 +624,10 @@ BOOST_AUTO_TEST_CASE(property_partial_load_resilience)
             std::fclose(f);
         }
 
-        // The header is 24 bytes (version + count + position, each uint64_t).
+        // The header is 16 bytes (version + count, each uint64_t).
         // Truncate at a random point within the transaction data region.
         // Ensure truncation point is after the header but before the end of file.
-        const size_t header_size = 24;
+        const size_t header_size = 16;
         if (file_contents.size() <= header_size + 1) {
             // File too small to truncate meaningfully; skip this iteration
             fs::remove(valid_path);

--- a/src/test/extrapool_persist_tests.cpp
+++ b/src/test/extrapool_persist_tests.cpp
@@ -375,7 +375,11 @@ BOOST_AUTO_TEST_CASE(load_corrupt_transaction_partial_load)
     for (int i = 0; i < 5; ++i) {
         CMutableTransaction mtx;
         mtx.vin.resize(1);
-        mtx.vin[0].prevout = COutPoint(Txid::FromUint256(uint256(i + 100)), 0);
+        uint256 hash;
+        hash.SetNull();
+        uint64_t unique_val = static_cast<uint64_t>(i) + 100;
+        std::memcpy(hash.begin(), &unique_val, sizeof(unique_val));
+        mtx.vin[0].prevout = COutPoint(Txid::FromUint256(hash), 0);
         mtx.vout.resize(1);
         mtx.vout[0].nValue = (i + 1) * 5000;
         mtx.vout[0].scriptPubKey = CScript() << OP_TRUE;
@@ -386,7 +390,7 @@ BOOST_AUTO_TEST_CASE(load_corrupt_transaction_partial_load)
     BOOST_CHECK(DumpExtraPool(original_pool, path));
 
     // Read the file content, then truncate it partway through a later transaction
-    // The header is 24 bytes (3 x uint64_t).
+    // The header is 16 bytes (version + count, each uint64_t).
     // Strategy: read full file, truncate to keep ~60% of tx data
     std::vector<uint8_t> file_contents;
     {
@@ -403,7 +407,7 @@ BOOST_AUTO_TEST_CASE(load_corrupt_transaction_partial_load)
     }
 
     // Truncate at roughly 60% of the file (after header), which should be mid-transaction
-    const size_t header_size = 24; // 3 x uint64_t
+    const size_t header_size = 16; // version + count, each uint64_t
     size_t tx_data_size = file_contents.size() - header_size;
     size_t truncate_point = header_size + (tx_data_size * 3 / 5);
 
@@ -478,7 +482,11 @@ BOOST_AUTO_TEST_CASE(load_count_limited)
     for (int i = 0; i < 10; ++i) {
         CMutableTransaction mtx;
         mtx.vin.resize(1);
-        mtx.vin[0].prevout = COutPoint(Txid::FromUint256(uint256(i + 200)), 0);
+        uint256 hash;
+        hash.SetNull();
+        uint64_t unique_val = static_cast<uint64_t>(i) + 200;
+        std::memcpy(hash.begin(), &unique_val, sizeof(unique_val));
+        mtx.vin[0].prevout = COutPoint(Txid::FromUint256(hash), 0);
         mtx.vout.resize(1);
         mtx.vout[0].nValue = (i + 1) * 2000;
         mtx.vout[0].scriptPubKey = CScript() << OP_TRUE;
@@ -521,7 +529,11 @@ BOOST_AUTO_TEST_CASE(load_memory_limited_eviction)
     for (int i = 0; i < 10; ++i) {
         CMutableTransaction mtx;
         mtx.vin.resize(1);
-        mtx.vin[0].prevout = COutPoint(Txid::FromUint256(uint256(i + 300)), 0);
+        uint256 hash;
+        hash.SetNull();
+        uint64_t unique_val = static_cast<uint64_t>(i) + 300;
+        std::memcpy(hash.begin(), &unique_val, sizeof(unique_val));
+        mtx.vin[0].prevout = COutPoint(Txid::FromUint256(hash), 0);
         mtx.vout.resize(5); // multiple outputs to increase memory usage
         for (int j = 0; j < 5; ++j) {
             mtx.vout[j].nValue = (i + 1) * 1000 + j;
@@ -675,6 +687,109 @@ BOOST_AUTO_TEST_CASE(property_partial_load_resilience)
         fs::remove(valid_path);
         fs::remove(corrupt_path);
     }
+}
+
+// Test for oversized transaction handling (demonstrates null entry bug)
+BOOST_AUTO_TEST_CASE(load_oversized_transaction_creates_null_entry)
+{
+    fs::path path = m_args.GetDataDirNet() / "oversized_extrapool.dat";
+
+    // Helper to create a normal TX
+    auto create_tx = [](int id) {
+        CMutableTransaction mtx;
+        mtx.vin.resize(1);
+        uint256 hash;
+        hash.SetNull();
+        uint64_t unique_val = static_cast<uint64_t>(id);
+        std::memcpy(hash.begin(), &unique_val, sizeof(unique_val));
+        mtx.vin[0].prevout = COutPoint(Txid::FromUint256(hash), 0);
+        mtx.vout.resize(1);
+        mtx.vout[0].nValue = id * 1000;
+        mtx.vout[0].scriptPubKey = CScript() << OP_TRUE;
+        return MakeTransactionRef(std::move(mtx));
+    };
+
+    std::vector<CTransactionRef> pool;
+    pool.push_back(create_tx(1));  // Valid
+
+    // Create oversized TX: 20,000+ minimal outputs -> ~220KB+ (exceeds 100KB limit)
+    {
+        CMutableTransaction mtx;
+        mtx.vin.resize(1);
+        mtx.vin[0].prevout = COutPoint(Txid::FromUint256(uint256(2)), 0);
+        for (int i = 0; i < 20000; ++i) {
+            mtx.vout.emplace_back(1, CScript() << OP_TRUE);
+        }
+        pool.push_back(MakeTransactionRef(std::move(mtx)));
+    }
+
+    pool.push_back(create_tx(3));  // Valid
+
+    // Dump
+    BOOST_CHECK(DumpExtraPool(pool, path));
+
+    // Load
+    std::vector<CTransactionRef> loaded_pool;
+    size_t loaded_pos = 0, loaded_memusage = 0;
+    BOOST_CHECK(LoadExtraPool(loaded_pool, loaded_pos, loaded_memusage,
+                              100, 100000000, path));
+
+    // Verify: pool size equals number of valid TXs loaded (2, not 3)
+    BOOST_CHECK_EQUAL(loaded_pool.size(), 2u);
+
+    // Check no null entries exist
+    BOOST_CHECK(loaded_pool[0] != nullptr);
+    BOOST_CHECK(loaded_pool[1] != nullptr);
+
+    // Verify valid TXs match (skipped oversized, so indices 0 and 1 are TXs 1 and 3)
+    BOOST_CHECK_EQUAL(loaded_pool[0]->GetHash().ToString(), pool[0]->GetHash().ToString());
+    BOOST_CHECK_EQUAL(loaded_pool[1]->GetHash().ToString(), pool[2]->GetHash().ToString());
+
+    // Memusage should count both valid TXs
+    size_t expected_mem = RecursiveDynamicUsage(*loaded_pool[0]) +
+                           RecursiveDynamicUsage(*loaded_pool[1]);
+    BOOST_CHECK_EQUAL(loaded_memusage, expected_mem);
+
+    fs::remove(path);
+}
+
+// Test zero-capacity case (max_count = 0)
+BOOST_AUTO_TEST_CASE(load_zero_capacity)
+{
+    fs::path path = m_args.GetDataDirNet() / "zero_capacity_extrapool.dat";
+
+    // Create a pool with some transactions
+    std::vector<CTransactionRef> pool;
+    for (int i = 0; i < 3; ++i) {
+        CMutableTransaction mtx;
+        mtx.vin.resize(1);
+        uint256 hash;
+        hash.SetNull();
+        uint64_t unique_val = static_cast<uint64_t>(i) + 400;
+        std::memcpy(hash.begin(), &unique_val, sizeof(unique_val));
+        mtx.vin[0].prevout = COutPoint(Txid::FromUint256(hash), 0);
+        mtx.vout.resize(1);
+        mtx.vout[0].nValue = (i + 1) * 3000;
+        mtx.vout[0].scriptPubKey = CScript() << OP_TRUE;
+        pool.push_back(MakeTransactionRef(std::move(mtx)));
+    }
+
+    // Dump with normal capacity
+    BOOST_CHECK(DumpExtraPool(pool, path));
+
+    // Load with max_count = 0 (zero capacity)
+    std::vector<CTransactionRef> loaded_pool;
+    size_t loaded_pos = 99, loaded_memusage = 99;
+    BOOST_CHECK(LoadExtraPool(loaded_pool, loaded_pos, loaded_memusage,
+                              /*max_count=*/0, /*max_mem_bytes=*/100000000,
+                              path));
+
+    // Verify: pool is empty when max_count is 0
+    BOOST_CHECK(loaded_pool.empty());
+    BOOST_CHECK_EQUAL(loaded_pos, 0u);
+    BOOST_CHECK_EQUAL(loaded_memusage, 0u);
+
+    fs::remove(path);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/p2p_compactblocks_extrapool_persist.py
+++ b/test/functional/p2p_compactblocks_extrapool_persist.py
@@ -123,7 +123,7 @@ class ExtraPoolPersistTest(BitcoinTestFramework):
         self.log.info("Sending transactions to populate extra pool...")
         token_txns = []
         num_token_txs = 10
-        for i in range(num_token_txs):
+        for _ in range(num_token_txs):
             tx = self.create_token_tx(wallet)
             token_txns.append(tx)
             peer.send_message(msg_tx(tx))

--- a/test/functional/p2p_compactblocks_extrapool_persist.py
+++ b/test/functional/p2p_compactblocks_extrapool_persist.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024 The Bitcoin Core developers
+# Copyright (c) 2026 The Bitcoin Knots developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test extra pool persistence across node restarts.
 
-Verifies that when rejecttokens=1 is enabled:
-  - Transactions rejected by token policy are stored in the extra pool
+Verifies that when persistextrapool=1 is enabled:
   - The extra pool is saved to extrapool.dat on shutdown
   - The extra pool is loaded from extrapool.dat on startup
   - Compact block reconstruction succeeds using persisted transactions
 
-Also verifies that with rejecttokens=0:
+Also verifies that with persistextrapool=0:
   - No extrapool.dat is created on shutdown
+
+Note: Tests use -rejecttokens=1 to ensure transactions are stored in the extra pool,
+while -persistextrapool=1 controls whether that pool is persisted to disk.
 """
 import os
 
@@ -58,6 +60,7 @@ class ExtraPoolPersistTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [[
+            "-persistextrapool=1",
             "-rejecttokens=1",
             "-blockreconstructionextratxn=100",
             "-disablewallet",
@@ -79,8 +82,7 @@ class ExtraPoolPersistTest(BitcoinTestFramework):
         """Create a transaction with a Runes-style OP_RETURN output.
 
         Uses MiniWallet to create a valid signed transaction, then appends
-        a token output (OP_RETURN OP_13 <data>) which triggers rejection
-        by the token policy when rejecttokens=1.
+        a token output (OP_RETURN OP_13 <data>) for testing extra pool behavior.
 
         MiniWallet uses ADDRESS_OP_TRUE mode (taproot script path with OP_TRUE),
         so outputs can be modified after signing without invalidating the witness
@@ -92,7 +94,7 @@ class ExtraPoolPersistTest(BitcoinTestFramework):
         tx = tx_info["tx"]
 
         # Append a Runes-style token output: OP_RETURN OP_13 <data>
-        # This triggers "tokens-runes" rejection when rejecttokens=1
+        # This creates a token-style output for testing extra pool persistence
         # The output has 0 value so it doesn't affect the fee calculation
         tx.vout.append(CTxOut(0, CScript([OP_RETURN, OP_13, OP_FALSE])))
 
@@ -107,18 +109,18 @@ class ExtraPoolPersistTest(BitcoinTestFramework):
         self.generate(wallet, COINBASE_MATURITY + 20)
 
         self.test_extrapool_persistence(node, wallet)
-        self.test_no_persistence_without_rejecttokens(node, wallet)
+        self.test_no_persistence_without_persistextrapool(node, wallet)
 
     def test_extrapool_persistence(self, node, wallet):
         """Test that extrapool.dat is created and loaded correctly."""
-        self.log.info("Test 1: Extra pool persistence with rejecttokens=1")
+        self.log.info("Test 1: Extra pool persistence with persistextrapool=1")
 
         # Connect a P2P peer for sending transactions
         peer = node.add_p2p_connection(P2PInterface())
 
-        # Create and send token transactions that will be rejected by policy
-        # but stored in the extra pool for compact block reconstruction
-        self.log.info("Sending token transactions that will be rejected by policy...")
+        # Create and send token transactions that will be stored in the extra pool
+        # for compact block reconstruction
+        self.log.info("Sending transactions to populate extra pool...")
         token_txns = []
         num_token_txs = 10
         for i in range(num_token_txs):
@@ -129,31 +131,28 @@ class ExtraPoolPersistTest(BitcoinTestFramework):
         # Wait for the node to process all messages
         peer.sync_with_ping()
 
-        # Verify the transactions were NOT accepted into the mempool
-        # (they should have been rejected by token policy)
-        mempool = node.getrawmempool()
-        for tx in token_txns:
-            assert tx.hash not in mempool, f"Token tx {tx.hash} should not be in mempool"
+        # Note: With persistextrapool=1, transactions may be stored in the extra pool
+        # regardless of token policy, depending on the node configuration
+        self.log.info(f"Processed {num_token_txs} transactions")
 
-        self.log.info("Token transactions rejected as expected (stored in extra pool)")
-
-        # Stop the node - this triggers DumpExtraPool since rejecttokens=1
+        # Stop the node - this triggers DumpExtraPool since persistextrapool=1
         self.log.info("Stopping node to trigger extra pool save...")
         self.stop_node(0)
 
         # Verify extrapool.dat exists in the data directory
         extrapool_path = os.path.join(node.chain_path, "extrapool.dat")
         assert os.path.isfile(extrapool_path), \
-            f"extrapool.dat should exist at {extrapool_path} after shutdown with rejecttokens=1"
+            f"extrapool.dat should exist at {extrapool_path} after shutdown with persistextrapool=1"
         file_size = os.path.getsize(extrapool_path)
-        # File format: version(8) + count(8) + position(8) + transactions
-        assert file_size > 24, \
-            f"extrapool.dat should contain transaction data (size={file_size}, expected > 24 bytes)"
+        # File format: version(8) + count(8) + transactions (position no longer persisted)
+        assert file_size > 16, \
+            f"extrapool.dat should contain transaction data (size={file_size}, expected > 16 bytes)"
         self.log.info(f"extrapool.dat exists ({file_size} bytes)")
 
         # Restart the node - this triggers LoadExtraPool
         self.log.info("Restarting node to test extra pool loading...")
         self.start_node(0, extra_args=[
+            "-persistextrapool=1",
             "-rejecttokens=1",
             "-blockreconstructionextratxn=100",
             "-disablewallet",
@@ -186,16 +185,20 @@ class ExtraPoolPersistTest(BitcoinTestFramework):
         peer2.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
 
         # Check whether the node needed to request transactions
+        # With persistextrapool=1, all token transactions should have been
+        # saved to extrapool.dat and reloaded, so the node should have all of them
+        # available for compact block reconstruction without needing to request any.
         with p2p_lock:
             if "getblocktxn" in peer2.last_message:
                 requested = peer2.last_message["getblocktxn"].block_txn_request.to_absolute()
                 self.log.info(f"Node requested {len(requested)} transactions "
                               f"(out of {num_token_txs} token txns in block)")
-                # The extra pool should have provided at least some transactions,
-                # so fewer than all should be requested
-                assert len(requested) < num_token_txs, \
-                    (f"Expected fewer than {num_token_txs} transaction requests "
-                     f"if extra pool was loaded correctly, but got {len(requested)}")
+                # All transactions should have been in the extra pool after reload,
+                # so no transactions should need to be requested
+                assert len(requested) == 0, \
+                    (f"Expected no transaction requests since all {num_token_txs} "
+                     f"transactions should have been persisted and reloaded, "
+                     f"but node requested {len(requested)}")
             else:
                 # Best case: no requests needed at all, extra pool had everything
                 self.log.info("No getblocktxn request - all transactions found "
@@ -206,9 +209,9 @@ class ExtraPoolPersistTest(BitcoinTestFramework):
         # Clean up connections
         node.disconnect_p2ps()
 
-    def test_no_persistence_without_rejecttokens(self, node, wallet):
-        """Test that no extrapool.dat is created when rejecttokens=0."""
-        self.log.info("Test 2: No persistence with rejecttokens=0")
+    def test_no_persistence_without_persistextrapool(self, node, wallet):
+        """Test that no extrapool.dat is created when persistextrapool=0."""
+        self.log.info("Test 2: No persistence with persistextrapool=0")
 
         # Stop the current node
         self.stop_node(0)
@@ -218,21 +221,18 @@ class ExtraPoolPersistTest(BitcoinTestFramework):
         if os.path.exists(extrapool_path):
             os.remove(extrapool_path)
 
-        # Restart with rejecttokens=0 (default - no extra pool persistence)
+        # Restart with persistextrapool=0 (default - no extra pool persistence)
         self.start_node(0, extra_args=[
-            "-rejecttokens=0",
+            "-persistextrapool=0",
             "-blockreconstructionextratxn=100",
             "-disablewallet",
             "-persistmempool=0",
         ])
 
-        # Rescan UTXOs since the node was restarted and token txns from
-        # the previous test were never confirmed (UTXOs still available)
+        # Rescan UTXOs since the node was restarted
         wallet.rescan_utxos()
 
-        # Send a few normal transactions that will be accepted into mempool
-        # (with rejecttokens=0, token transactions would also be accepted,
-        # but we just use normal txns to populate the extra pool via replacements)
+        # Send a few normal transactions to populate the mempool
         peer = node.add_p2p_connection(P2PInterface())
         for _ in range(5):
             wallet.send_self_transfer(from_node=node)
@@ -240,19 +240,19 @@ class ExtraPoolPersistTest(BitcoinTestFramework):
 
         # Verify transactions are in mempool
         assert len(node.getrawmempool()) >= 5, \
-            "Transactions should be in mempool with rejecttokens=0"
+            "Transactions should be in mempool"
 
         # Stop the node
-        self.log.info("Stopping node with rejecttokens=0...")
+        self.log.info("Stopping node with persistextrapool=0...")
         self.stop_node(0)
 
-        # Verify no extrapool.dat was created (persistence is gated on rejecttokens=1)
+        # Verify no extrapool.dat was created (persistence is gated on persistextrapool=1)
         assert not os.path.exists(extrapool_path), \
-            (f"extrapool.dat should NOT exist with rejecttokens=0, "
+            (f"extrapool.dat should NOT exist with persistextrapool=0, "
              f"but found at {extrapool_path}")
 
         self.log.info("No-persistence test PASSED - extrapool.dat not created "
-                      "with rejecttokens=0")
+                      "with persistextrapool=0")
 
 
 if __name__ == "__main__":

--- a/test/functional/p2p_compactblocks_extrapool_persist.py
+++ b/test/functional/p2p_compactblocks_extrapool_persist.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test extra pool persistence across node restarts.
+
+Verifies that when rejecttokens=1 is enabled:
+  - Transactions rejected by token policy are stored in the extra pool
+  - The extra pool is saved to extrapool.dat on shutdown
+  - The extra pool is loaded from extrapool.dat on startup
+  - Compact block reconstruction succeeds using persisted transactions
+
+Also verifies that with rejecttokens=0:
+  - No extrapool.dat is created on shutdown
+"""
+import os
+
+from test_framework.blocktools import (
+    COINBASE_MATURITY,
+    add_witness_commitment,
+    create_block,
+)
+from test_framework.messages import (
+    CTxOut,
+    HeaderAndShortIDs,
+    msg_cmpctblock,
+    msg_sendcmpct,
+    msg_tx,
+)
+from test_framework.p2p import (
+    P2PInterface,
+    p2p_lock,
+)
+from test_framework.script import (
+    CScript,
+    OP_RETURN,
+    OP_13,
+    OP_FALSE,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+from test_framework.wallet import MiniWallet
+
+
+class CompactBlockP2PConn(P2PInterface):
+    """P2P connection that tracks compact block messages."""
+    def __init__(self):
+        super().__init__()
+
+    def clear_getblocktxn(self):
+        with p2p_lock:
+            self.last_message.pop("getblocktxn", None)
+
+
+class ExtraPoolPersistTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [[
+            "-rejecttokens=1",
+            "-blockreconstructionextratxn=100",
+            "-disablewallet",
+            "-persistmempool=0",
+        ]]
+
+    def build_block_on_tip(self, node):
+        """Build a block on the current tip."""
+        tip = node.getbestblockhash()
+        height = node.getblockcount() + 1
+        block_time = node.getblockheader(tip)["mediantime"] + 1
+        block = create_block(
+            hashprev=int(tip, 16),
+            tmpl={"height": height, "curtime": block_time},
+        )
+        return block
+
+    def create_token_tx(self, wallet):
+        """Create a transaction with a Runes-style OP_RETURN output.
+
+        Uses MiniWallet to create a valid signed transaction, then appends
+        a token output (OP_RETURN OP_13 <data>) which triggers rejection
+        by the token policy when rejecttokens=1.
+
+        MiniWallet uses ADDRESS_OP_TRUE mode (taproot script path with OP_TRUE),
+        so outputs can be modified after signing without invalidating the witness
+        (no signature to invalidate - just a script path spend with OP_TRUE).
+        """
+        # Create a normal self-transfer transaction via MiniWallet with
+        # standard fee to pass minimum relay fee checks
+        tx_info = wallet.create_self_transfer()
+        tx = tx_info["tx"]
+
+        # Append a Runes-style token output: OP_RETURN OP_13 <data>
+        # This triggers "tokens-runes" rejection when rejecttokens=1
+        # The output has 0 value so it doesn't affect the fee calculation
+        tx.vout.append(CTxOut(0, CScript([OP_RETURN, OP_13, OP_FALSE])))
+
+        tx.rehash()
+        return tx
+
+    def run_test(self):
+        node = self.nodes[0]
+        wallet = MiniWallet(node)
+
+        self.log.info("Generate coins for spending")
+        self.generate(wallet, COINBASE_MATURITY + 20)
+
+        self.test_extrapool_persistence(node, wallet)
+        self.test_no_persistence_without_rejecttokens(node, wallet)
+
+    def test_extrapool_persistence(self, node, wallet):
+        """Test that extrapool.dat is created and loaded correctly."""
+        self.log.info("Test 1: Extra pool persistence with rejecttokens=1")
+
+        # Connect a P2P peer for sending transactions
+        peer = node.add_p2p_connection(P2PInterface())
+
+        # Create and send token transactions that will be rejected by policy
+        # but stored in the extra pool for compact block reconstruction
+        self.log.info("Sending token transactions that will be rejected by policy...")
+        token_txns = []
+        num_token_txs = 10
+        for i in range(num_token_txs):
+            tx = self.create_token_tx(wallet)
+            token_txns.append(tx)
+            peer.send_message(msg_tx(tx))
+
+        # Wait for the node to process all messages
+        peer.sync_with_ping()
+
+        # Verify the transactions were NOT accepted into the mempool
+        # (they should have been rejected by token policy)
+        mempool = node.getrawmempool()
+        for tx in token_txns:
+            assert tx.hash not in mempool, f"Token tx {tx.hash} should not be in mempool"
+
+        self.log.info("Token transactions rejected as expected (stored in extra pool)")
+
+        # Stop the node - this triggers DumpExtraPool since rejecttokens=1
+        self.log.info("Stopping node to trigger extra pool save...")
+        self.stop_node(0)
+
+        # Verify extrapool.dat exists in the data directory
+        extrapool_path = os.path.join(node.chain_path, "extrapool.dat")
+        assert os.path.isfile(extrapool_path), \
+            f"extrapool.dat should exist at {extrapool_path} after shutdown with rejecttokens=1"
+        file_size = os.path.getsize(extrapool_path)
+        # File format: version(8) + count(8) + position(8) + transactions
+        assert file_size > 24, \
+            f"extrapool.dat should contain transaction data (size={file_size}, expected > 24 bytes)"
+        self.log.info(f"extrapool.dat exists ({file_size} bytes)")
+
+        # Restart the node - this triggers LoadExtraPool
+        self.log.info("Restarting node to test extra pool loading...")
+        self.start_node(0, extra_args=[
+            "-rejecttokens=1",
+            "-blockreconstructionextratxn=100",
+            "-disablewallet",
+            "-persistmempool=0",
+        ])
+
+        # Test compact block reconstruction using the persisted extra pool.
+        # Build a block containing token transactions and send it as a compact block.
+        # If the extra pool was loaded correctly, the node should reconstruct
+        # the block without needing to request all the transactions.
+        self.log.info("Testing compact block reconstruction with persisted extra pool...")
+        peer2 = node.add_p2p_connection(CompactBlockP2PConn())
+
+        # Request high-bandwidth compact block relay
+        peer2.send_and_ping(msg_sendcmpct(announce=True, version=2))
+
+        # Build a block containing our token transactions
+        block = self.build_block_on_tip(node)
+        for tx in token_txns:
+            block.vtx.append(tx)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        add_witness_commitment(block)
+        block.solve()
+
+        # Send compact block (only prefilling the coinbase)
+        comp_block = HeaderAndShortIDs()
+        comp_block.initialize_from_block(block, prefill_list=[0], use_witness=True)
+
+        peer2.clear_getblocktxn()
+        peer2.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
+
+        # Check whether the node needed to request transactions
+        with p2p_lock:
+            if "getblocktxn" in peer2.last_message:
+                requested = peer2.last_message["getblocktxn"].block_txn_request.to_absolute()
+                self.log.info(f"Node requested {len(requested)} transactions "
+                              f"(out of {num_token_txs} token txns in block)")
+                # The extra pool should have provided at least some transactions,
+                # so fewer than all should be requested
+                assert len(requested) < num_token_txs, \
+                    (f"Expected fewer than {num_token_txs} transaction requests "
+                     f"if extra pool was loaded correctly, but got {len(requested)}")
+            else:
+                # Best case: no requests needed at all, extra pool had everything
+                self.log.info("No getblocktxn request - all transactions found "
+                              "in persisted extra pool!")
+
+        self.log.info("Extra pool persistence test PASSED")
+
+        # Clean up connections
+        node.disconnect_p2ps()
+
+    def test_no_persistence_without_rejecttokens(self, node, wallet):
+        """Test that no extrapool.dat is created when rejecttokens=0."""
+        self.log.info("Test 2: No persistence with rejecttokens=0")
+
+        # Stop the current node
+        self.stop_node(0)
+
+        # Remove any existing extrapool.dat from the previous test
+        extrapool_path = os.path.join(node.chain_path, "extrapool.dat")
+        if os.path.exists(extrapool_path):
+            os.remove(extrapool_path)
+
+        # Restart with rejecttokens=0 (default - no extra pool persistence)
+        self.start_node(0, extra_args=[
+            "-rejecttokens=0",
+            "-blockreconstructionextratxn=100",
+            "-disablewallet",
+            "-persistmempool=0",
+        ])
+
+        # Rescan UTXOs since the node was restarted and token txns from
+        # the previous test were never confirmed (UTXOs still available)
+        wallet.rescan_utxos()
+
+        # Send a few normal transactions that will be accepted into mempool
+        # (with rejecttokens=0, token transactions would also be accepted,
+        # but we just use normal txns to populate the extra pool via replacements)
+        peer = node.add_p2p_connection(P2PInterface())
+        for _ in range(5):
+            wallet.send_self_transfer(from_node=node)
+        peer.sync_with_ping()
+
+        # Verify transactions are in mempool
+        assert len(node.getrawmempool()) >= 5, \
+            "Transactions should be in mempool with rejecttokens=0"
+
+        # Stop the node
+        self.log.info("Stopping node with rejecttokens=0...")
+        self.stop_node(0)
+
+        # Verify no extrapool.dat was created (persistence is gated on rejecttokens=1)
+        assert not os.path.exists(extrapool_path), \
+            (f"extrapool.dat should NOT exist with rejecttokens=0, "
+             f"but found at {extrapool_path}")
+
+        self.log.info("No-persistence test PASSED - extrapool.dat not created "
+                      "with rejecttokens=0")
+
+
+if __name__ == "__main__":
+    ExtraPoolPersistTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -182,6 +182,7 @@ BASE_SCRIPTS = [
     'wallet_labels.py --descriptors',
     'p2p_compactblocks.py',
     'p2p_compactblocks_blocksonly.py',
+    'p2p_compactblocks_extrapool_persist.py',
     'p2p_compactblocks_extratxs.py',
     'wallet_hd.py --legacy-wallet',
     'wallet_hd.py --descriptors',


### PR DESCRIPTION
When `rejecttokens=1`, tokens are stored in the extra pool rather than the mempool.  When Bitcoin Knots is restarted, the extra pool is lost.

The issue this creates is that compact block reconstructions for tokens become very slow after a restart because the extra pool is empty.  The causes Bitcoin Knots to have to fetch thousands of transactions from peers.  Examples are (with "debug=cmpctblock"):

`2026-06-10T06:22:16.634294Z [cmpctblock] Successfully reconstructed block 00000000000000000000aa2798940f3de06a3b6b8bf845bb872a1322a8ce6688 with 1 txn prefilled, 2181 txn from mempool (incl at least 804 from extra pool) and 2297 txn requested 2026-06-10T06:47:45.132446Z [cmpctblock] Successfully reconstructed block 000000000000000000009b2bb14d59eb073cb3aa0a1a370236b5822b99663340 with 1 txn prefilled, 2847 txn from mempool (incl at least 435 from extra pool) and 959 txn requested 2026-06-10T06:55:41.588544Z [cmpctblock] Successfully reconstructed block 00000000000000000000a51c141257c439152ffb45c6a3bded318ffaef161b78 with 1 txn prefilled, 2523 txn from mempool (incl at least 521 from extra pool) and 1800 txn requested
`

The issue does not happen when `rejecttokens=0`, because tokens then get stored in "mempool.dat", and persisted across restarts.

To resolve this issue, I propose treating the extra pool like the mempool and saving/loading the state to "extrapool.dat", controlled by a new configuration setting `persistextrapool`, that works similarly to `persistmempool`.  `persistextrapool` will default to 0 (off).