### PR TITLE
policy: count bare data envelopes (OP_2DROP/pushnum runs) as datacarrier

### DIFF
--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -372,6 +372,7 @@ std::pair<size_t, size_t> CScript::DatacarrierBytes(const size_t remaining_outpu
     opcodetype opcode, last_opcode{OP_INVALIDOPCODE};
     std::vector<unsigned char> push_data;
     unsigned int inside_noop{0}, inside_conditional{0};
+    auto is_push = [](opcodetype op) { return op <= OP_16 && op != OP_RESERVED; };  // OP_0..OP_16 push data/numbers
     CScript::const_iterator opcode_it = begin(), data_began = begin();
     for (CScript::const_iterator it = begin(); it < end(); last_opcode = opcode) {
         opcode_it = it;
@@ -406,10 +407,10 @@ std::pair<size_t, size_t> CScript::DatacarrierBytes(const size_t remaining_outpu
         } else if (opcode == OP_IF && last_opcode == OP_FALSE) {
             inside_noop = 1;
             data_began = opcode_it;
-        // Match <data> OP_DROP
-        } else if (opcode <= OP_PUSHDATA4) {
-            data_began = opcode_it;
-        } else if (opcode == OP_DROP && last_opcode <= OP_PUSHDATA4) {
+        // Match <data> OP_DROP, or a run of <data>/pushnums ... OP_DROP/OP_2DROP (bare/BIP-110 envelope)
+        } else if (is_push(opcode)) {
+            if (!is_push(last_opcode)) data_began = opcode_it;  // only reset at the start of a push run
+        } else if ((opcode == OP_DROP || opcode == OP_2DROP) && is_push(last_opcode)) {
             counted += it - data_began;
         }
     }

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1650,6 +1650,10 @@ BOOST_AUTO_TEST_CASE(script_DataCarrierBytes)
     BOOST_CHECK_EQUAL("0+6", DatacarrierBytesStr(CScript() << OP_FALSE << OP_IF << OP_TRUE << OP_IF << OP_ENDIF << OP_ENDIF));
     // pushing then immediately dropping is data: length(1), zero(11), OP_DROP
     BOOST_CHECK_EQUAL("0+13", DatacarrierBytesStr(CScript() << zeros(11) << OP_DROP));
+    // bare/BIP-110 envelope: a run of pushes balanced by OP_2DROP is all data
+    BOOST_CHECK_EQUAL("0+25", DatacarrierBytesStr(CScript() << zeros(11) << zeros(11) << OP_2DROP));
+    // pushnums interleaved in the run don't strand earlier pushes: 12 + 1 (OP_7) + 12 + 1 (OP_2DROP)
+    BOOST_CHECK_EQUAL("0+26", DatacarrierBytesStr(CScript() << zeros(11) << OP_7 << zeros(11) << OP_2DROP));
     // OLGA data obfuscated as p2wsh
     const auto olga_header = CScript() << OP_0 << "003e7374616d703a000000000000000000000000000000000000000000000000"_hex;
     BOOST_CHECK_EQUAL("0+82", DatacarrierBytesStr(olga_header, 2));

--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -15,6 +15,7 @@ from test_framework.script import (
     CScript,
     OP_1,
     OP_2DROP,
+    OP_7,
     OP_DROP,
     OP_RETURN,
     taproot_construct,
@@ -92,6 +93,50 @@ class DataCarrierTest(BitcoinTestFramework):
                                     self.wallet.sendrawtransaction, from_node=node, tx_hex=tx_hex)
 
 
+    def test_bare_envelope(self, node: TestNode, data_len: int, success: bool, interleave_pushnum: bool = False) -> None:
+        # A bare inscription envelope: <marker> <data>... balanced by OP_2DROP,
+        # with no OP_IF wrapper (the shape ordinals/ord#4545 uses under BIP-110).
+        # A pushnum interleaved in the run (which ord's parser accepts as payload)
+        # must not strand the large push from datacarrier counting.
+        if interleave_pushnum:
+            envelope_script = CScript([randbytes(data_len), OP_7, randbytes(1), OP_2DROP, OP_DROP, OP_1])
+        else:
+            envelope_script = CScript([b'ord', randbytes(data_len), OP_2DROP, OP_1])
+        internal_key = b'\x01' * 32
+        tap = taproot_construct(internal_key, [("leaf", envelope_script), ("dummy", CScript([OP_1]))])
+        leaf = tap.leaves["leaf"]
+        control_block = bytes([leaf.version | tap.negflag]) + tap.internal_pubkey + leaf.merklebranch
+        assert len(control_block) == 65
+
+        utxo = self.wallet.get_utxo()
+        funding_tx = CTransaction()
+        funding_tx.vin = [CTxIn(COutPoint(int(utxo['txid'], 16), utxo['vout']))]
+        funding_value = int(utxo['value'] * 100_000_000) - 1000
+        funding_tx.vout = [CTxOut(funding_value, tap.scriptPubKey)]
+        funding_tx.version = 2
+        self.wallet.sign_tx(funding_tx)
+        funding_tx.rehash()
+        self.nodes[0].sendrawtransaction(funding_tx.serialize().hex())
+        self.generate(self.nodes[0], 1, sync_fun=self.sync_blocks)
+
+        spend_tx = CTransaction()
+        spend_tx.version = 2
+        spend_tx.vin = [CTxIn(COutPoint(int(funding_tx.hash, 16), 0))]
+        spend_tx.vout = [CTxOut(funding_value - 1000, tap.scriptPubKey)]
+        spend_tx.wit.vtxinwit = [CTxInWitness()]
+        spend_tx.wit.vtxinwit[0].scriptWitness.stack = [
+            bytes(envelope_script),  # tapscript
+            control_block,           # control block (65 bytes)
+        ]
+        tx_hex = spend_tx.serialize().hex()
+
+        if success:
+            self.wallet.sendrawtransaction(from_node=node, tx_hex=tx_hex)
+            assert spend_tx.rehash() in node.getrawmempool(True)
+        else:
+            assert_raises_rpc_error(-26, "txn-datacarrier-exceeded",
+                                    self.wallet.sendrawtransaction, from_node=node, tx_hex=tx_hex)
+
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])
 
@@ -140,6 +185,17 @@ class DataCarrierTest(BitcoinTestFramework):
 
         self.log.info("Testing an OPNet transaction (just pushing 'op') with -datacarriersize=2.")
         self.test_opnet_transaction(node=self.nodes[3], success=False)
+
+        self.log.info("Testing a bare OP_2DROP envelope larger than the default -datacarriersize.")
+        self.test_bare_envelope(node=self.nodes[0], data_len=MAX_OP_RETURN_RELAY, success=False)
+
+        self.log.info("Testing a bare OP_2DROP envelope smaller than the default -datacarriersize.")
+        # data_len >= 2 keeps the payload a minimal push; a 1-byte push of 1..16 or 0x81 would be
+        # rejected by MINIMALDATA in script verification rather than accepted by the datacarrier check.
+        self.test_bare_envelope(node=self.nodes[0], data_len=2, success=True)
+
+        self.log.info("Testing a bare envelope with a pushnum interleaved in the push run.")
+        self.test_bare_envelope(node=self.nodes[0], data_len=MAX_OP_RETURN_RELAY, success=False, interleave_pushnum=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`DatacarrierBytes` recognizes inscription data in two forms: `OP_FALSE OP_IF ... OP_ENDIF` envelopes and `<data> OP_DROP`. It does not match `OP_2DROP`, so a bare envelope of the form `push <marker> <data>... OP_2DROP...OP_DROP` counts as zero datacarrier bytes and evades the size limit.

This is the envelope shape ordinals/ord#4545 adopts to remain valid under BIP-110, which disables `OP_IF`/`OP_NOTIF` in tapscript.

Changes:
- Count a contiguous run of pushes/pushnums that is balanced by `OP_DROP`/`OP_2DROP`, anchoring `data_began` at the start of the run so the whole run is counted on the first drop rather than just the last push.
- Treat pushnums (`OP_1NEGATE`, `OP_1`..`OP_16`) as run members. ord's parser accepts pushnums as payload, so a pushnum interleaved between data pushes must not strand the earlier push from the count. This matches the counting to exactly the grammar ord's envelope parser accepts (pushes, pushnums, `OP_DROP`, `OP_2DROP`).

This makes counting slightly stricter for any push-run ending in a drop, not only the new envelope. Standard scripts that use `OP_DROP` drop a stack item preceded by a non-push opcode (e.g. `<locktime> OP_CHECKLOCKTIMEVERIFY OP_DROP`), which breaks the run and is not counted.

Testing:
- Unit (`script_DataCarrierBytes`): a `<data> <data> OP_2DROP` run, and a pushnum-interleaved `<data> OP_7 <data> OP_2DROP` run.
- Functional (`mempool_datacarrier.py`): builds P2TR script-path spends with bare envelope tapscripts and asserts `txn-datacarrier-exceeded` under default policy, including a pushnum-interleaved envelope, mirroring the existing OPNet case. Reverting the counting change alone makes the tests fail (the tx is accepted).
