### PR TITLE
descriptor: reject OP_IF/OP_NOTIF in Taproot miniscript under reduced-data

### DIFF
--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -2089,6 +2089,29 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
                 error = "Miniscript expressions can only be used in wsh or tr.";
                 return {};
             }
+            // Reduced-data (RDTS): OP_IF/OP_NOTIF-emitting fragments in a Tapscript leaf
+            // would be unspendable under reduced-data rules; reject them at parse time,
+            // consistent with the tr() nesting-depth cap above.
+            if (miniscript::IsTapscript(script_ctx)) {
+                std::vector<decltype(node.get())> stack{node.get()};
+                while (!stack.empty()) {
+                    const auto* subnode = stack.back();
+                    stack.pop_back();
+                    switch (subnode->fragment) {
+                    case miniscript::Fragment::OR_C:
+                    case miniscript::Fragment::OR_D:
+                    case miniscript::Fragment::OR_I:
+                    case miniscript::Fragment::ANDOR:
+                    case miniscript::Fragment::WRAP_D:
+                    case miniscript::Fragment::WRAP_J:
+                        error = "OP_IF/OP_NOTIF is not allowed in Taproot miniscript under reduced-data (outputs would be unspendable)";
+                        return {};
+                    default:
+                        break;
+                    }
+                    for (const auto& sub : subnode->subs) stack.push_back(sub.get());
+                }
+            }
             if (!node->IsSane() || node->IsNotSatisfiable()) {
                 // Try to find the first insane sub for better error reporting.
                 auto insane_node = node.get();

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -840,24 +840,24 @@ BOOST_AUTO_TEST_CASE(descriptor_test)
                 {{0x80000000UL + 48, 0x80000000UL + 1, 0x80000000UL, 0x80000000UL + 2, 1, 0}, {0x80000000UL + 48, 0x80000000UL + 1, 0x80000000UL, 0x80000000UL + 2, 1, 1}, {0x80000000UL + 48, 0x80000000UL + 1, 0x80000000UL, 0x80000000UL + 2, 1, 2}},
             }
     );
-    CheckMultipath("tr(xprv9yYge4PS54XkYT9KiLfCRwc8Jeuz8DucxQGtuEecJZYhKNiqbPxYHTPzXtskmzWBqdqkRAGsghNmZzNsfU2wstaB3XjDQFPv567aQSSuPyo,l:pk(xprvA1ADjaN8H3HGnZSmt4VF7YdWoV9oNq8jhqhurxsrYycBAFK555cECoaY22KWt6BTRNLuvobW5VQTF89PN3iA485LAg7epazevPyjCa4xTzd/<2;3>))",
-        "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK,l:pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ/<2;3>))",
+    CheckMultipath("tr(xprv9yYge4PS54XkYT9KiLfCRwc8Jeuz8DucxQGtuEecJZYhKNiqbPxYHTPzXtskmzWBqdqkRAGsghNmZzNsfU2wstaB3XjDQFPv567aQSSuPyo,pk(xprvA1ADjaN8H3HGnZSmt4VF7YdWoV9oNq8jhqhurxsrYycBAFK555cECoaY22KWt6BTRNLuvobW5VQTF89PN3iA485LAg7epazevPyjCa4xTzd/<2;3>))",
+        "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK,pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ/<2;3>))",
         {
-            "tr(xprv9yYge4PS54XkYT9KiLfCRwc8Jeuz8DucxQGtuEecJZYhKNiqbPxYHTPzXtskmzWBqdqkRAGsghNmZzNsfU2wstaB3XjDQFPv567aQSSuPyo,l:pk(xprvA1ADjaN8H3HGnZSmt4VF7YdWoV9oNq8jhqhurxsrYycBAFK555cECoaY22KWt6BTRNLuvobW5VQTF89PN3iA485LAg7epazevPyjCa4xTzd/2))",
-            "tr(xprv9yYge4PS54XkYT9KiLfCRwc8Jeuz8DucxQGtuEecJZYhKNiqbPxYHTPzXtskmzWBqdqkRAGsghNmZzNsfU2wstaB3XjDQFPv567aQSSuPyo,l:pk(xprvA1ADjaN8H3HGnZSmt4VF7YdWoV9oNq8jhqhurxsrYycBAFK555cECoaY22KWt6BTRNLuvobW5VQTF89PN3iA485LAg7epazevPyjCa4xTzd/3))",
+            "tr(xprv9yYge4PS54XkYT9KiLfCRwc8Jeuz8DucxQGtuEecJZYhKNiqbPxYHTPzXtskmzWBqdqkRAGsghNmZzNsfU2wstaB3XjDQFPv567aQSSuPyo,pk(xprvA1ADjaN8H3HGnZSmt4VF7YdWoV9oNq8jhqhurxsrYycBAFK555cECoaY22KWt6BTRNLuvobW5VQTF89PN3iA485LAg7epazevPyjCa4xTzd/2))",
+            "tr(xprv9yYge4PS54XkYT9KiLfCRwc8Jeuz8DucxQGtuEecJZYhKNiqbPxYHTPzXtskmzWBqdqkRAGsghNmZzNsfU2wstaB3XjDQFPv567aQSSuPyo,pk(xprvA1ADjaN8H3HGnZSmt4VF7YdWoV9oNq8jhqhurxsrYycBAFK555cECoaY22KWt6BTRNLuvobW5VQTF89PN3iA485LAg7epazevPyjCa4xTzd/3))",
         },
         {
-            "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK,l:pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ/2))",
-            "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK,l:pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ/3))",
+            "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK,pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ/2))",
+            "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK,pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ/3))",
         },
         {
-            "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK,l:pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ/2))",
-            "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK,l:pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ/3))",
+            "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK,pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ/2))",
+            "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK,pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ/3))",
         },
         XONLY_KEYS,
         {
-            {{"512094cb097990da64eebbad7b979b1326f3cbe356357abf4deb4c4ff80c7acbe902"}},
-            {{"5120f091450b88c606f5cbc3f0cebe89e00bc5dd27f92e22f54da06439bc0c401f41"}},
+            {{"512069c8653c4f1842c69eb66bfa97d1ee920fb73b0663d5d3d1ae6cdb8e2d610fdc"}},
+            {{"5120a1c68408c3d491464b2846d8478d50e8ed145808fb7daa53314899eef05e8afd"}},
         },
         OutputType::BECH32M,
         {
@@ -865,24 +865,24 @@ BOOST_AUTO_TEST_CASE(descriptor_test)
             {{3}, {}},
         }
     );
-    CheckMultipath("tr(xprv9yYge4PS54XkYT9KiLfCRwc8Jeuz8DucxQGtuEecJZYhKNiqbPxYHTPzXtskmzWBqdqkRAGsghNmZzNsfU2wstaB3XjDQFPv567aQSSuPyo/<2;3>,l:pk(xprvA1ADjaN8H3HGnZSmt4VF7YdWoV9oNq8jhqhurxsrYycBAFK555cECoaY22KWt6BTRNLuvobW5VQTF89PN3iA485LAg7epazevPyjCa4xTzd))",
-            "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK/<2;3>,l:pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ))",
+    CheckMultipath("tr(xprv9yYge4PS54XkYT9KiLfCRwc8Jeuz8DucxQGtuEecJZYhKNiqbPxYHTPzXtskmzWBqdqkRAGsghNmZzNsfU2wstaB3XjDQFPv567aQSSuPyo/<2;3>,pk(xprvA1ADjaN8H3HGnZSmt4VF7YdWoV9oNq8jhqhurxsrYycBAFK555cECoaY22KWt6BTRNLuvobW5VQTF89PN3iA485LAg7epazevPyjCa4xTzd))",
+            "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK/<2;3>,pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ))",
             {
-                "tr(xprv9yYge4PS54XkYT9KiLfCRwc8Jeuz8DucxQGtuEecJZYhKNiqbPxYHTPzXtskmzWBqdqkRAGsghNmZzNsfU2wstaB3XjDQFPv567aQSSuPyo/2,l:pk(xprvA1ADjaN8H3HGnZSmt4VF7YdWoV9oNq8jhqhurxsrYycBAFK555cECoaY22KWt6BTRNLuvobW5VQTF89PN3iA485LAg7epazevPyjCa4xTzd))",
-                "tr(xprv9yYge4PS54XkYT9KiLfCRwc8Jeuz8DucxQGtuEecJZYhKNiqbPxYHTPzXtskmzWBqdqkRAGsghNmZzNsfU2wstaB3XjDQFPv567aQSSuPyo/3,l:pk(xprvA1ADjaN8H3HGnZSmt4VF7YdWoV9oNq8jhqhurxsrYycBAFK555cECoaY22KWt6BTRNLuvobW5VQTF89PN3iA485LAg7epazevPyjCa4xTzd))",
+                "tr(xprv9yYge4PS54XkYT9KiLfCRwc8Jeuz8DucxQGtuEecJZYhKNiqbPxYHTPzXtskmzWBqdqkRAGsghNmZzNsfU2wstaB3XjDQFPv567aQSSuPyo/2,pk(xprvA1ADjaN8H3HGnZSmt4VF7YdWoV9oNq8jhqhurxsrYycBAFK555cECoaY22KWt6BTRNLuvobW5VQTF89PN3iA485LAg7epazevPyjCa4xTzd))",
+                "tr(xprv9yYge4PS54XkYT9KiLfCRwc8Jeuz8DucxQGtuEecJZYhKNiqbPxYHTPzXtskmzWBqdqkRAGsghNmZzNsfU2wstaB3XjDQFPv567aQSSuPyo/3,pk(xprvA1ADjaN8H3HGnZSmt4VF7YdWoV9oNq8jhqhurxsrYycBAFK555cECoaY22KWt6BTRNLuvobW5VQTF89PN3iA485LAg7epazevPyjCa4xTzd))",
             },
             {
-                "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK/2,l:pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ))",
-                "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK/3,l:pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ))",
+                "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK/2,pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ))",
+                "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK/3,pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ))",
             },
             {
-                "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK/2,l:pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ))",
-                "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK/3,l:pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ))",
+                "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK/2,pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ))",
+                "tr(xpub6CY33ZvKuS63kwDnpNCCo5YrrgkUXgdUKdCVhd4Dru5gCB3z8wGnqFiUP98Za5pYSYF5KmvBHTY3Ra8FAJGggzBjuHS69WzN8gscPupuZwK/3,pk(xpub6E9a95u27Qqa13XEz62FUgaFMWzHnHrb54dWfMHU7K9A33eDccvUkbu1sHYoByHAgJdR326rWqn9pGZgZHz1afDprW5gGwS4gUX8Ri6aGPZ))",
             },
             XONLY_KEYS,
             {
-                {{"51200e3c14456bfa30f9f0bed6e55f35e1e9ca17c835e9f71b25bac0dfaab38ff2cd"}},
-                {{"51202bdda29337ecaf8fcd5aa395febac6f99b8a866a0e8fb3f7bde2e24b1a7df2ba"}},
+                {{"5120abb85d76b638f0c4f51bbdcfb47e6e2d3c8de6d0d4a569beed5d22b929b3d2d2"}},
+                {{"5120168afb5aa4c5064776e56ea729371ee5d852cea025acfc93fd77cbb747a8a9f3"}},
             },
             OutputType::BECH32M,
             {

--- a/test/functional/wallet_miniscript.py
+++ b/test/functional/wallet_miniscript.py
@@ -49,12 +49,12 @@ DESCS = [
     *[f"wsh({ms})" for ms in P2WSH_MINISCRIPTS],
     # A Taproot with one of the above scripts as the single script path.
     f"tr(4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768,{P2WSH_MINISCRIPTS[0]})",
-    # A Taproot with two script paths among the above scripts.
-    f"tr(4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768,{{{P2WSH_MINISCRIPTS[0]},{P2WSH_MINISCRIPTS[1]}}})",
-    # A Taproot with three script paths among the above scripts.
-    f"tr(4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768,{{{{{P2WSH_MINISCRIPTS[0]},{P2WSH_MINISCRIPTS[1]}}},{P2WSH_MINISCRIPTS[2].replace('multi', 'multi_a')}}})",
-    # A Taproot with all above scripts in its tree.
-    f"tr(4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768,{{{{{P2WSH_MINISCRIPTS[0]},{P2WSH_MINISCRIPTS[1]}}},{{{P2WSH_MINISCRIPTS[2].replace('multi', 'multi_a')},{P2WSH_MINISCRIPTS[3]}}}}})",
+    # A Taproot with two (branch-free) script paths. Reduced-data (RDTS) forbids
+    # OP_IF/OP_NOTIF in Tapscript, so multi-leaf trees use non-branching leaves here;
+    # rejection of branching leaves is covered by reduced_data_op_if_guard_test().
+    f"tr(4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768,{{and_v(v:pk({TPUBS[0]}/*),pk({TPUBS[1]}/*)),and_v(v:pk({TPUBS[2]}/*),pk({TPUBS[3]}/*))}})",
+    # A branch-free depth-2 Taproot tree, exercising nested TapTree building.
+    f"tr(4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768,{{{{pk({TPUBS[0]}/*),pk({TPUBS[1]}/*)}},{{pk({TPUBS[2]}/*),and_v(v:pk({TPUBS[3]}/*),pk({TPUBS[4]}/*))}}}})",
 ]
 
 DESCS_PRIV = [
@@ -322,6 +322,46 @@ class WalletMiniscriptTest(BitcoinTestFramework):
                 )
             self.ms_sig_wallet.sendrawtransaction(res["hex"])
 
+    def reduced_data_op_if_guard_test(self):
+        """Reduced-data (RDTS): Taproot miniscript leaves that emit OP_IF/OP_NOTIF are
+        rejected at parse time (the guard lives in the shared descriptor parser, so
+        import active/watch-only alike), consistent with the tr() nesting-depth cap.
+        P2WSH branching and non-branching Tapscript are unaffected."""
+        self.log.info("Testing the reduced-data OP_IF-in-tapscript guard")
+        self.nodes[0].createwallet(
+            wallet_name="ms_rdts", descriptors=True, disable_private_keys=True
+        )
+        wallet = self.nodes[0].get_wallet_rpc("ms_rdts")
+        key = "4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768"
+        # P2WSH_MINISCRIPTS[1] uses or_d/or_c (OP_IF/OP_NOTIF); [0] uses or_b (OP_BOOLOR).
+        branch = P2WSH_MINISCRIPTS[1]
+        nobranch = P2WSH_MINISCRIPTS[0]
+
+        def imp(desc, active):
+            return wallet.importdescriptors(
+                [{"desc": descsum_create(desc), "active": active, "timestamp": "now"}]
+            )[0]
+
+        err = "OP_IF/OP_NOTIF is not allowed in Taproot"
+        # A branching Tapscript leaf is rejected whether imported active or watch-only.
+        for active in (True, False):
+            res = imp(f"tr({key},{branch})", active)
+            assert not res["success"], res
+            assert err in res["error"]["message"], res
+        # A multi-leaf tree is rejected if ANY leaf branches (here the second leaf).
+        res = imp(f"tr({key},{{{nobranch},{branch}}})", False)
+        assert not res["success"], res
+        assert err in res["error"]["message"], res
+        # The l: wrapper desugars to or_i (OP_IF) and is likewise rejected.
+        res = imp(f"tr({key},l:pk({TPUBS[0]}/*))", False)
+        assert not res["success"], res
+        assert err in res["error"]["message"], res
+        # A non-branching Tapscript miniscript is accepted (single and multi-leaf).
+        assert (res := imp(f"tr({key},{nobranch})", False))["success"], res
+        assert (res := imp(f"tr({key},{{pk({TPUBS[0]}/*),pk({TPUBS[1]}/*)}})", False))["success"], res
+        # Branching fragments in P2WSH (not Taproot) are unaffected.
+        assert (res := imp(f"wsh({branch})", False))["success"], res
+
     def run_test(self):
         self.log.info("Making a descriptor wallet")
         self.funder = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
@@ -331,6 +371,8 @@ class WalletMiniscriptTest(BitcoinTestFramework):
         self.ms_wo_wallet = self.nodes[0].get_wallet_rpc("ms_wo")
         self.nodes[0].createwallet(wallet_name="ms_sig", descriptors=True)
         self.ms_sig_wallet = self.nodes[0].get_wallet_rpc("ms_sig")
+
+        self.reduced_data_op_if_guard_test()
 
         # Sanity check we wouldn't let an insane Miniscript descriptor in
         res = self.ms_wo_wallet.importdescriptors(

--- a/test/functional/wallet_miniscript.py
+++ b/test/functional/wallet_miniscript.py
@@ -356,6 +356,17 @@ class WalletMiniscriptTest(BitcoinTestFramework):
         res = imp(f"tr({key},l:pk({TPUBS[0]}/*))", False)
         assert not res["success"], res
         assert err in res["error"]["message"], res
+        # Every OP_IF/OP_NOTIF-emitting fragment must be caught, so that dropping any
+        # single case from the parser's switch cannot silently re-enable it. The above
+        # cover or_c/or_d (branch) and or_i (l:); the rest are pinned individually here.
+        for frag in (
+            f"andor(pk({TPUBS[0]}/*),pk({TPUBS[1]}/*),pk({TPUBS[2]}/*))",  # ANDOR
+            f"j:pk({TPUBS[0]}/*)",                                          # j: (WRAP_J)
+            f"and_v(v:pk({TPUBS[0]}/*),dv:older(144))",                     # d: (WRAP_D)
+        ):
+            res = imp(f"tr({key},{frag})", False)
+            assert not res["success"], res
+            assert err in res["error"]["message"], res
         # A non-branching Tapscript miniscript is accepted (single and multi-leaf).
         assert (res := imp(f"tr({key},{nobranch})", False))["success"], res
         assert (res := imp(f"tr({key},{{pk({TPUBS[0]}/*),pk({TPUBS[1]}/*)}})", False))["success"], res

--- a/test/functional/wallet_miniscript.py
+++ b/test/functional/wallet_miniscript.py
@@ -326,7 +326,8 @@ class WalletMiniscriptTest(BitcoinTestFramework):
         """Reduced-data (RDTS): Taproot miniscript leaves that emit OP_IF/OP_NOTIF are
         rejected at parse time (the guard lives in the shared descriptor parser, so
         import active/watch-only alike), consistent with the tr() nesting-depth cap.
-        P2WSH branching and non-branching Tapscript are unaffected."""
+        P2WSH miniscript is unaffected even when it branches; only branching
+        fragments in Taproot (Tapscript) leaves are rejected."""
         self.log.info("Testing the reduced-data OP_IF-in-tapscript guard")
         self.nodes[0].createwallet(
             wallet_name="ms_rdts", descriptors=True, disable_private_keys=True


### PR DESCRIPTION
Reduced-data (RDTS) invalidates tapscripts that execute OP_IF/OP_NOTIF, so a Taproot output whose leaf uses them can't be spent. The wallet could still create such descriptors via miniscript (or_c, or_d, or_i, andor, and the d:/j:/l:/u: wrappers).

This rejects those fragments at descriptor parse time in Tapscript context, the same layer and style as the existing tr() nesting-depth cap. It applies to create, import and watch alike, matching how deep taptrees are already handled. P2WSH is unaffected (OP_IF is valid there); inference is unaffected.

Tests: adds a guard test to wallet_miniscript.py; updates two descriptor_tests.cpp vectors that used l:pk (an or_i) tapscript leaf, now invalid, to non-branching leaves with recomputed scriptPubKeys.
