### PR TITLE
mempool: honor reduced-data grandfathering when relaying spends

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -433,10 +433,34 @@ void Chainstate::MaybeUpdateMempoolForReorg(
 * signature and script validity results will be reused if we validate this
 * transaction again during block validation.
 * */
+/** Per-input script-verification flags with the reduced-data (RDTS) flags stripped for
+ *  inputs spending UTXOs created before reduced-data activation ("grandfathered"),
+ *  mirroring ConnectBlock. Returns an empty vector (meaning: use `flags` uniformly) when
+ *  no input needs the exemption. Pre-activation nothing is exempted, so the reduced-data
+ *  relay filter is preserved. */
+static std::vector<unsigned int> ReducedDataFlagsPerInput(const CTransaction& tx, const CCoinsViewCache& view,
+                unsigned int flags, Chainstate& chainstate)
+                EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    const CBlockIndex* tip = chainstate.m_chain.Tip();
+    const int reduced_data_start_height = DeploymentActiveAfter(tip, chainstate.m_chainman, Consensus::DEPLOYMENT_REDUCED_DATA)
+        ? chainstate.m_chainman.m_versionbitscache.StateSinceHeight(tip, chainstate.m_chainman.GetConsensus(), Consensus::DEPLOYMENT_REDUCED_DATA)
+        : 0; // not active: exempt nothing, preserving the pre-activation relay filter
+    std::vector<unsigned int> flags_per_input;
+    for (size_t j = 0; j < tx.vin.size(); j++) {
+        if (view.AccessCoin(tx.vin[j].prevout).nHeight < reduced_data_start_height) {
+            flags_per_input.resize(tx.vin.size(), flags);
+            flags_per_input[j] = flags & ~REDUCED_DATA_MANDATORY_VERIFY_FLAGS;
+        }
+    }
+    return flags_per_input;
+}
+
 static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationState& state,
                 const CCoinsViewCache& view, const CTxMemPool& pool,
                 unsigned int flags, PrecomputedTransactionData& txdata, CCoinsViewCache& coins_tip,
-                ValidationCache& validation_cache)
+                ValidationCache& validation_cache,
+                const std::vector<unsigned int>& flags_per_input = {})
                 EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
     AssertLockHeld(cs_main);
@@ -468,7 +492,7 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationS
     }
 
     // Call CheckInputScripts() to cache signature and script validity against current tip consensus rules.
-    return CheckInputScripts(tx, state, view, flags, /* cacheSigStore= */ true, /* cacheFullScriptStore= */ true, txdata, validation_cache);
+    return CheckInputScripts(tx, state, view, flags, /* cacheSigStore= */ true, /* cacheFullScriptStore= */ true, txdata, validation_cache, /*pvChecks=*/nullptr, flags_per_input);
 }
 
 namespace {
@@ -1516,9 +1540,13 @@ bool MemPoolAccept::PolicyScriptChecks(const ATMPArgs& args, Workspace& ws)
 
     const unsigned int scriptVerifyFlags = PolicyScriptVerifyFlags(args.m_ignore_rejects);
 
+    // Reduced-data (RDTS): exempt inputs spending pre-activation (grandfathered) UTXOs,
+    // matching consensus, so those spends are not filtered as non-standard at relay.
+    const std::vector<unsigned int> flags_per_input = ReducedDataFlagsPerInput(tx, m_view, scriptVerifyFlags, m_active_chainstate);
+
     // Check input scripts and signatures.
     // This is done last to help prevent CPU exhaustion denial-of-service attacks.
-    if (!CheckInputScripts(tx, state, m_view, scriptVerifyFlags, true, false, ws.m_precomputed_txdata, GetValidationCache())) {
+    if (!CheckInputScripts(tx, state, m_view, scriptVerifyFlags, true, false, ws.m_precomputed_txdata, GetValidationCache(), /*pvChecks=*/nullptr, flags_per_input)) {
         // Detect a failure due to a missing witness so that p2p code can handle rejection caching appropriately.
         if (!tx.HasWitness() && SpendsNonAnchorWitnessProg(tx, m_view)) {
             state.Invalid(TxValidationResult::TX_WITNESS_STRIPPED,
@@ -1554,8 +1582,9 @@ bool MemPoolAccept::ConsensusScriptChecks(const ATMPArgs& args, Workspace& ws)
     // invalid blocks (using TestBlockValidity), however allowing such
     // transactions into the mempool can be exploited as a DoS attack.
     unsigned int currentBlockScriptVerifyFlags{GetBlockScriptFlags(*m_active_chainstate.m_chain.Tip(), m_active_chainstate.m_chainman)};
+    const std::vector<unsigned int> flags_per_input = ReducedDataFlagsPerInput(tx, m_view, currentBlockScriptVerifyFlags, m_active_chainstate);
     if (!CheckInputsFromMempoolAndCache(tx, state, m_view, m_pool, currentBlockScriptVerifyFlags,
-                                        ws.m_precomputed_txdata, m_active_chainstate.CoinsTip(), GetValidationCache())) {
+                                        ws.m_precomputed_txdata, m_active_chainstate.CoinsTip(), GetValidationCache(), flags_per_input)) {
         LogError("BUG! PLEASE REPORT THIS! CheckInputScripts failed against latest-block but not STANDARD flags %s, %s", hash.ToString(), state.ToString());
         return Assume(false);
     }

--- a/test/functional/feature_reduced_data_utxo_height.py
+++ b/test/functional/feature_reduced_data_utxo_height.py
@@ -31,12 +31,17 @@ from test_framework.messages import (
     CTxInWitness,
     CTxOut,
 )
+from test_framework.key import compute_xonly_pubkey, generate_privkey
 from test_framework.p2p import P2PDataStore
 from test_framework.script import (
     CScript,
+    OP_ELSE,
+    OP_ENDIF,
+    OP_IF,
     OP_TRUE,
     OP_DROP,
     hash256,
+    taproot_construct,
 )
 from test_framework.script_util import (
     script_to_p2wsh_script,
@@ -113,6 +118,30 @@ class ReducedDataUTXOHeightTest(BitcoinTestFramework):
         ]
         spending_tx.rehash()
 
+        return funding_tx, spending_tx
+
+    def create_taproot_opif_funding_and_spend(self, wallet, node):
+        """Create a Taproot output with an OP_IF script leaf (a reduced-data violation
+        that, unlike an oversized push, is not masked by other standardness rules), plus
+        a script-path spending tx to a standard output. Returns (funding_tx, spending_tx)."""
+        internal_pubkey, _ = compute_xonly_pubkey(generate_privkey())
+        leaf = CScript([OP_IF, OP_TRUE, OP_ELSE, OP_TRUE, OP_ENDIF])
+        taproot_info = taproot_construct(internal_pubkey, [("leaf", leaf)])
+
+        funding_txid = wallet.send_to(from_node=node, scriptPubKey=taproot_info.scriptPubKey, amount=100000)['txid']
+        funding_tx = CTransaction()
+        funding_tx.deserialize(BytesIO(bytes.fromhex(node.getrawtransaction(funding_txid))))
+        funding_tx.rehash()
+        vout = next(i for i, o in enumerate(funding_tx.vout) if o.scriptPubKey == taproot_info.scriptPubKey)
+
+        spending_tx = CTransaction()
+        spending_tx.vin = [CTxIn(COutPoint(funding_tx.sha256, vout))]
+        spending_tx.vout = [CTxOut(funding_tx.vout[vout].nValue - 1000, script_to_p2wsh_script(CScript([OP_TRUE])))]
+        leaf_info = taproot_info.leaves["leaf"]
+        control_block = bytes([leaf_info.version + taproot_info.negflag]) + internal_pubkey + leaf_info.merklebranch
+        spending_tx.wit.vtxinwit.append(CTxInWitness())
+        spending_tx.wit.vtxinwit[0].scriptWitness.stack = [b'\x01', leaf, control_block]  # b'\x01' selects the OP_IF branch
+        spending_tx.rehash()
         return funding_tx, spending_tx
 
     def create_test_block(self, txs, signal=False):
@@ -237,6 +266,11 @@ class ReducedDataUTXOHeightTest(BitcoinTestFramework):
 
         self.log.info(f"Created old P2WSH UTXO at height {old_utxo_height} (< {ACTIVATION_HEIGHT})")
 
+        # Also create a grandfathered Taproot OP_IF UTXO (for the mempool/relay test below).
+        old_opif_funding, old_opif_spending = self.create_taproot_opif_funding_and_spend(wallet, node)
+        block = self.create_test_block([old_opif_funding], signal=False)
+        assert_equal(node.submitblock(block.serialize().hex()), None)
+
         # ======================================================================
         # Test 2: Mine to activation height
         # ======================================================================
@@ -281,6 +315,26 @@ class ReducedDataUTXOHeightTest(BitcoinTestFramework):
         self.mine_blocks(5, signal=False)
         current_height = node.getblockcount()
         self.log.info(f"Current height: {current_height}")
+
+        # ======================================================================
+        # Test 3b: reduced-data grandfathering must also hold at the mempool/relay
+        # layer, not just in blocks. OP_IF-in-tapscript is used because (unlike an
+        # oversized push) no other standardness rule masks it. Same tx shape for both;
+        # only the spent UTXO's age differs.
+        # ======================================================================
+        self.log.info("Test 3b: mempool relay of grandfathered vs new OP_IF-tapscript spends...")
+
+        # Grandfathered (pre-activation) OP_IF-tapscript UTXO -> spend must be relayable.
+        res = node.testmempoolaccept([old_opif_spending.serialize().hex()])[0]
+        assert res["allowed"], f"grandfathered OP_IF-tapscript spend rejected at relay: {res}"
+
+        # New (post-activation) OP_IF-tapscript UTXO -> spend must be rejected at relay.
+        new_opif_funding, new_opif_spending = self.create_taproot_opif_funding_and_spend(wallet, node)
+        block = self.create_test_block([new_opif_funding], signal=False)
+        assert_equal(node.submitblock(block.serialize().hex()), None)
+        res = node.testmempoolaccept([new_opif_spending.serialize().hex()])[0]
+        assert not res["allowed"], f"new OP_IF-tapscript spend wrongly relayed: {res}"
+        self.log.info("✓ SUCCESS: grandfathered OP_IF-tapscript spend relayable, new spend rejected")
 
         # ======================================================================
         # Test 4: Spend OLD UTXO with oversized witness - should be ACCEPTED


### PR DESCRIPTION
Reduced-data (RDTS) exempts inputs spending UTXOs created before activation from the reduced-data rules. Consensus applies this per-input in ConnectBlock (validation.cpp), but the mempool script checks do not: PolicyScriptChecks and ConsensusScriptChecks apply the reduced-data flags uniformly to every input. As a result a spend of a grandfathered UTXO is valid in a block but rejected as non-standard at relay, so Knots nodes won't propagate it.

This strips the reduced-data flags for inputs spending pre-activation UTXOs in both mempool script checks, using the per-input flags that CheckInputScripts already supports and mirroring ConnectBlock. Pre-activation behavior is unchanged (nothing is exempted, the relay filter still applies).

Test: feature_reduced_data_utxo_height.py gains a mempool case, a spend of a grandfathered OP_IF-tapscript UTXO is relayable, while a newly-created one is still rejected. (OP_IF-in-tapscript is used rather than an oversized push because the latter is masked by the unrelated 80-byte witness-stack-item standardness rule.)
