### PR TITLE
validation: keep script cache enabled when RDTS deployment inactive

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2918,10 +2918,12 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     std::vector<PrecomputedTransactionData> txsdata(block.vtx.size());
     CCheckQueueControl<CScriptCheck> control(fScriptChecks && parallel_script_checks ? &m_chainman.GetCheckQueue() : nullptr);
 
-    // For BIP9 deployments, get the activation height dynamically
+    // For BIP9 deployments, get the activation height dynamically. When RDTS is
+    // inactive the start height is 0, so no input is treated as pre-activation and
+    // flags_per_input stays empty (keeping the script-execution cache enabled).
     const auto reduced_data_start_height = DeploymentActiveAt(*pindex, m_chainman, Consensus::DEPLOYMENT_REDUCED_DATA)
         ? m_chainman.m_versionbitscache.StateSinceHeight(pindex->pprev, params.GetConsensus(), Consensus::DEPLOYMENT_REDUCED_DATA)
-        : std::numeric_limits<int>::max();
+        : 0;
 
     const CheckTxInputsRules chk_input_rules{DeploymentActiveAt(*pindex, m_chainman, Consensus::DEPLOYMENT_REDUCED_DATA) ? CheckTxInputsRules::OutputSizeLimit : CheckTxInputsRules::None};
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2921,11 +2921,12 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     // For BIP9 deployments, get the activation height dynamically. When RDTS is
     // inactive the start height is 0, so no input is treated as pre-activation and
     // flags_per_input stays empty (keeping the script-execution cache enabled).
-    const auto reduced_data_start_height = DeploymentActiveAt(*pindex, m_chainman, Consensus::DEPLOYMENT_REDUCED_DATA)
+    const bool reduced_data_active{DeploymentActiveAt(*pindex, m_chainman, Consensus::DEPLOYMENT_REDUCED_DATA)};
+    const auto reduced_data_start_height = reduced_data_active
         ? m_chainman.m_versionbitscache.StateSinceHeight(pindex->pprev, params.GetConsensus(), Consensus::DEPLOYMENT_REDUCED_DATA)
         : 0;
 
-    const CheckTxInputsRules chk_input_rules{DeploymentActiveAt(*pindex, m_chainman, Consensus::DEPLOYMENT_REDUCED_DATA) ? CheckTxInputsRules::OutputSizeLimit : CheckTxInputsRules::None};
+    const CheckTxInputsRules chk_input_rules{reduced_data_active ? CheckTxInputsRules::OutputSizeLimit : CheckTxInputsRules::None};
 
     // Check generation tx output sizes if REDUCED_DATA is active
     if (chk_input_rules.test(CheckTxInputsRules::OutputSizeLimit)) {


### PR DESCRIPTION
In `Chainstate::ConnectBlock`, when the `REDUCED_DATA` deployment is **inactive** at the block being connected, `GetBlockScriptFlags` does not set `REDUCED_DATA_MANDATORY_VERIFY_FLAGS` and `reduced_data_start_height` is set to `std::numeric_limits<int>::max()`.

The per-input loop then evaluates:

```cpp
if (prevheights[j] < reduced_data_start_height) {   // < INT_MAX, true for every input
    flags_per_input.resize(tx.vin.size(), flags);
    flags_per_input[j] = flags & ~REDUCED_DATA_MANDATORY_VERIFY_FLAGS;   // == flags, bits already absent
}
```

So `flags_per_input` gets populated for every input even though each element equals `flags`. The script-verification results are identical (there is no consensus difference), but `CheckInputScripts` only writes to the script-execution cache when `flags_per_input` is empty:

```cpp
if (cacheFullScriptStore && (!pvChecks) && flags_per_input.empty()) {
    validation_cache.m_script_execution_cache.insert(hashCacheEntry);
}
```

The net effect is that the script-execution cache is silently bypassed for every block connected while `REDUCED_DATA` is inactive, i.e. the entire pre-activation history on every node syncing from genesis. This is a pure performance regression with no effect on validation results.

This gates the per-input branch on `reduced_data_active` so `flags_per_input` stays empty when the deployment is inactive, restoring the cache. The `DeploymentActiveAt` result is also computed once instead of twice.

Behavior when `REDUCED_DATA` is active is unchanged: inputs spending pre-activation coins still receive per-input flags (and correctly forgo caching for those transactions).

Fix suggested by @chrisguida in review of #238.

Verification: builds cleanly; `feature_rdts.py` passes.
