### PR TITLE
mempool: add reduced-data ignore-reject to relay grandfathered spends

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -433,10 +433,48 @@ void Chainstate::MaybeUpdateMempoolForReorg(
 * signature and script validity results will be reused if we validate this
 * transaction again during block validation.
 * */
+/** Per-input script-verification flags with the reduced-data (RDTS) flags stripped for
+ *  inputs spending UTXOs created before `reduced_data_start_height` ("grandfathered").
+ *  Returns an empty vector (meaning: use `flags` uniformly) when no input needs the
+ *  exemption. If `prevheights` is non-null it is filled with each input's creation height
+ *  (for BIP68), reusing the same UTXO lookup. Shared by ConnectBlock (consensus) and the
+ *  mempool opt-in path below so the two cannot drift. */
+static std::vector<unsigned int> ReducedDataFlagsPerInput(const CTransaction& tx, const CCoinsViewCache& view,
+                unsigned int flags, int reduced_data_start_height, std::vector<int>* prevheights = nullptr)
+                EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    std::vector<unsigned int> flags_per_input;
+    for (size_t j = 0; j < tx.vin.size(); j++) {
+        // Coin::nHeight is a 31-bit unsigned field, so it always fits in an int.
+        const int coin_height{static_cast<int>(view.AccessCoin(tx.vin[j].prevout).nHeight)};
+        if (prevheights) (*prevheights)[j] = coin_height;
+        if (coin_height < reduced_data_start_height) {
+            flags_per_input.resize(tx.vin.size(), flags);
+            flags_per_input[j] = flags & ~REDUCED_DATA_MANDATORY_VERIFY_FLAGS;
+        }
+    }
+    return flags_per_input;
+}
+
+/** Mempool opt-in variant: the tx is evaluated against the next block, so the activation
+ *  height is derived from the current tip. Pre-activation nothing is exempted. Only used
+ *  when the caller opts in via the "reduced-data" ignore-reject. */
+static std::vector<unsigned int> ReducedDataFlagsPerInput(const CTransaction& tx, const CCoinsViewCache& view,
+                unsigned int flags, Chainstate& chainstate)
+                EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    const CBlockIndex* tip = chainstate.m_chain.Tip();
+    const int reduced_data_start_height = DeploymentActiveAfter(tip, chainstate.m_chainman, Consensus::DEPLOYMENT_REDUCED_DATA)
+        ? chainstate.m_chainman.m_versionbitscache.StateSinceHeight(tip, chainstate.m_chainman.GetConsensus(), Consensus::DEPLOYMENT_REDUCED_DATA)
+        : 0; // not active: exempt nothing
+    return ReducedDataFlagsPerInput(tx, view, flags, reduced_data_start_height);
+}
+
 static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationState& state,
                 const CCoinsViewCache& view, const CTxMemPool& pool,
                 unsigned int flags, PrecomputedTransactionData& txdata, CCoinsViewCache& coins_tip,
-                ValidationCache& validation_cache)
+                ValidationCache& validation_cache,
+                const std::vector<unsigned int>& flags_per_input = {})
                 EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
     AssertLockHeld(cs_main);
@@ -468,7 +506,7 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationS
     }
 
     // Call CheckInputScripts() to cache signature and script validity against current tip consensus rules.
-    return CheckInputScripts(tx, state, view, flags, /* cacheSigStore= */ true, /* cacheFullScriptStore= */ true, txdata, validation_cache);
+    return CheckInputScripts(tx, state, view, flags, /* cacheSigStore= */ true, /* cacheFullScriptStore= */ true, txdata, validation_cache, /*pvChecks=*/nullptr, flags_per_input);
 }
 
 namespace {
@@ -1516,9 +1554,18 @@ bool MemPoolAccept::PolicyScriptChecks(const ATMPArgs& args, Workspace& ws)
 
     const unsigned int scriptVerifyFlags = PolicyScriptVerifyFlags(args.m_ignore_rejects);
 
+    // Reduced-data (RDTS): by default a grandfathered spend is rejected at relay
+    // (intentional). If the caller opts in via the "reduced-data" ignore-reject, exempt
+    // inputs spending pre-activation UTXOs per-input, matching consensus. Non-grandfathered
+    // inputs are unaffected, so a genuinely reduced-data-invalid spend is still rejected.
+    std::vector<unsigned int> flags_per_input;
+    if (args.m_ignore_rejects.count(rejectmsg_reduced_data)) {
+        flags_per_input = ReducedDataFlagsPerInput(tx, m_view, scriptVerifyFlags, m_active_chainstate);
+    }
+
     // Check input scripts and signatures.
     // This is done last to help prevent CPU exhaustion denial-of-service attacks.
-    if (!CheckInputScripts(tx, state, m_view, scriptVerifyFlags, true, false, ws.m_precomputed_txdata, GetValidationCache())) {
+    if (!CheckInputScripts(tx, state, m_view, scriptVerifyFlags, true, false, ws.m_precomputed_txdata, GetValidationCache(), /*pvChecks=*/nullptr, flags_per_input)) {
         // Detect a failure due to a missing witness so that p2p code can handle rejection caching appropriately.
         if (!tx.HasWitness() && SpendsNonAnchorWitnessProg(tx, m_view)) {
             state.Invalid(TxValidationResult::TX_WITNESS_STRIPPED,
@@ -1554,8 +1601,14 @@ bool MemPoolAccept::ConsensusScriptChecks(const ATMPArgs& args, Workspace& ws)
     // invalid blocks (using TestBlockValidity), however allowing such
     // transactions into the mempool can be exploited as a DoS attack.
     unsigned int currentBlockScriptVerifyFlags{GetBlockScriptFlags(*m_active_chainstate.m_chain.Tip(), m_active_chainstate.m_chainman)};
+    // Match the grandfather exemption applied in PolicyScriptChecks when opted in, so the
+    // two checks stay consistent (a policy pass with a consensus-check fail is a bug).
+    std::vector<unsigned int> flags_per_input;
+    if (args.m_ignore_rejects.count(rejectmsg_reduced_data)) {
+        flags_per_input = ReducedDataFlagsPerInput(tx, m_view, currentBlockScriptVerifyFlags, m_active_chainstate);
+    }
     if (!CheckInputsFromMempoolAndCache(tx, state, m_view, m_pool, currentBlockScriptVerifyFlags,
-                                        ws.m_precomputed_txdata, m_active_chainstate.CoinsTip(), GetValidationCache())) {
+                                        ws.m_precomputed_txdata, m_active_chainstate.CoinsTip(), GetValidationCache(), flags_per_input)) {
         LogError("BUG! PLEASE REPORT THIS! CheckInputScripts failed against latest-block but not STANDARD flags %s, %s", hash.ToString(), state.ToString());
         return Assume(false);
     }
@@ -2970,14 +3023,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             // BIP68 lock checks (as opposed to nLockTime checks) must
             // be in ConnectBlock because they require the UTXO set
             prevheights.resize(tx.vin.size());
-            flags_per_input.clear();
-            for (size_t j = 0; j < tx.vin.size(); j++) {
-                prevheights[j] = view.AccessCoin(tx.vin[j].prevout).nHeight;
-                if (prevheights[j] < reduced_data_start_height) {
-                    flags_per_input.resize(tx.vin.size(), flags);
-                    flags_per_input[j] = flags & ~REDUCED_DATA_MANDATORY_VERIFY_FLAGS;
-                }
-            }
+            flags_per_input = ReducedDataFlagsPerInput(tx, view, flags, reduced_data_start_height, &prevheights);
 
             if (!SequenceLocks(tx, nLockTimeFlags, prevheights, *pindex)) {
                 state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-txns-nonfinal",

--- a/src/validation.h
+++ b/src/validation.h
@@ -263,6 +263,10 @@ static const std::string rejectmsg_lowfee_mempool = "mempool min fee not met";
 static const std::string rejectmsg_lowfee_relay = "min relay fee not met";
 static const std::string rejectmsg_mempoolfull = "mempool full";
 static const std::string rejectmsg_zero_mempool_entry_seq = "zero mempool entry sequence";
+// Opt-in (e.g. for miners): relay/accept spends of pre-activation ("grandfathered")
+// UTXOs that violate reduced-data rules, which consensus exempts but relay policy
+// rejects by default.
+static const std::string rejectmsg_reduced_data = "reduced-data";
 
 /**
  * Try to add a transaction to the mempool. This is an internal function and is exposed only for testing.

--- a/test/functional/feature_reduced_data_utxo_height.py
+++ b/test/functional/feature_reduced_data_utxo_height.py
@@ -31,12 +31,17 @@ from test_framework.messages import (
     CTxInWitness,
     CTxOut,
 )
+from test_framework.key import compute_xonly_pubkey, generate_privkey
 from test_framework.p2p import P2PDataStore
 from test_framework.script import (
     CScript,
+    OP_ELSE,
+    OP_ENDIF,
+    OP_IF,
     OP_TRUE,
     OP_DROP,
     hash256,
+    taproot_construct,
 )
 from test_framework.script_util import (
     script_to_p2wsh_script,
@@ -113,6 +118,30 @@ class ReducedDataUTXOHeightTest(BitcoinTestFramework):
         ]
         spending_tx.rehash()
 
+        return funding_tx, spending_tx
+
+    def create_taproot_opif_funding_and_spend(self, wallet, node):
+        """Create a Taproot output with an OP_IF script leaf (a reduced-data violation
+        that, unlike an oversized push, is not masked by other standardness rules), plus
+        a script-path spending tx to a standard output. Returns (funding_tx, spending_tx)."""
+        internal_pubkey, _ = compute_xonly_pubkey(generate_privkey())
+        leaf = CScript([OP_IF, OP_TRUE, OP_ELSE, OP_TRUE, OP_ENDIF])
+        taproot_info = taproot_construct(internal_pubkey, [("leaf", leaf)])
+
+        funding_txid = wallet.send_to(from_node=node, scriptPubKey=taproot_info.scriptPubKey, amount=100000)['txid']
+        funding_tx = CTransaction()
+        funding_tx.deserialize(BytesIO(bytes.fromhex(node.getrawtransaction(funding_txid))))
+        funding_tx.rehash()
+        vout = next(i for i, o in enumerate(funding_tx.vout) if o.scriptPubKey == taproot_info.scriptPubKey)
+
+        spending_tx = CTransaction()
+        spending_tx.vin = [CTxIn(COutPoint(funding_tx.sha256, vout))]
+        spending_tx.vout = [CTxOut(funding_tx.vout[vout].nValue - 1000, script_to_p2wsh_script(CScript([OP_TRUE])))]
+        leaf_info = taproot_info.leaves["leaf"]
+        control_block = bytes([leaf_info.version + taproot_info.negflag]) + internal_pubkey + leaf_info.merklebranch
+        spending_tx.wit.vtxinwit.append(CTxInWitness())
+        spending_tx.wit.vtxinwit[0].scriptWitness.stack = [b'\x01', leaf, control_block]  # b'\x01' selects the OP_IF branch
+        spending_tx.rehash()
         return funding_tx, spending_tx
 
     def create_test_block(self, txs, signal=False):
@@ -237,6 +266,11 @@ class ReducedDataUTXOHeightTest(BitcoinTestFramework):
 
         self.log.info(f"Created old P2WSH UTXO at height {old_utxo_height} (< {ACTIVATION_HEIGHT})")
 
+        # Also create a grandfathered Taproot OP_IF UTXO (for the miner-override test below).
+        old_opif_funding, old_opif_spending = self.create_taproot_opif_funding_and_spend(wallet, node)
+        block = self.create_test_block([old_opif_funding], signal=False)
+        assert_equal(node.submitblock(block.serialize().hex()), None)
+
         # ======================================================================
         # Test 2: Mine to activation height
         # ======================================================================
@@ -281,6 +315,35 @@ class ReducedDataUTXOHeightTest(BitcoinTestFramework):
         self.mine_blocks(5, signal=False)
         current_height = node.getblockcount()
         self.log.info(f"Current height: {current_height}")
+
+        # ======================================================================
+        # Test 3b: miner override. A grandfathered reduced-data spend is rejected at
+        # relay by default (intentional), but can be opted into via the "reduced-data"
+        # ignore-reject. A non-grandfathered spend stays rejected even with the override.
+        # ======================================================================
+        self.log.info("Test 3b: miner override of the reduced-data relay rejection...")
+        override = ["reduced-data"]
+
+        # Default: grandfathered OP_IF-tapscript spend is rejected at relay, and the
+        # rejection is specifically the reduced-data script-verify failure (not some
+        # unrelated reason, which would make the override test below meaningless).
+        res = node.testmempoolaccept(rawtxs=[old_opif_spending.serialize().hex()])[0]
+        assert not res["allowed"], f"grandfathered spend unexpectedly relayed by default: {res}"
+        assert "script-verify-flag-failed" in res["reject-reason"], f"unexpected reject reason: {res}"
+
+        # With the override: it is accepted.
+        res = node.testmempoolaccept(rawtxs=[old_opif_spending.serialize().hex()], ignore_rejects=override)[0]
+        assert res["allowed"], f"override failed to relay grandfathered spend: {res}"
+
+        # The override does not help a newly-created (non-grandfathered) reduced-data
+        # spend: it is still rejected for the same reduced-data script-verify failure.
+        new_opif_funding, new_opif_spending = self.create_taproot_opif_funding_and_spend(wallet, node)
+        block = self.create_test_block([new_opif_funding], signal=False)
+        assert_equal(node.submitblock(block.serialize().hex()), None)
+        res = node.testmempoolaccept(rawtxs=[new_opif_spending.serialize().hex()], ignore_rejects=override)[0]
+        assert not res["allowed"], f"override wrongly relayed a non-grandfathered spend: {res}"
+        assert "script-verify-flag-failed" in res["reject-reason"], f"unexpected reject reason: {res}"
+        self.log.info("✓ SUCCESS: override relays grandfathered spend only, default still rejects")
 
         # ======================================================================
         # Test 4: Spend OLD UTXO with oversized witness - should be ACCEPTED


### PR DESCRIPTION
Follow-up to #322 (closed). The reduced-data relay rejection is intentional, but a miner should be able to opt into relaying/accepting spends of pre-activation ("grandfathered") UTXOs, which consensus already exempts in ConnectBlock.

Adds a "reduced-data" ignore_rejects token (usable via sendrawtransaction/testmempoolaccept). Default behavior is unchanged: those spends stay rejected at relay. When the token is set, inputs spending pre-activation UTXOs are exempted per-input in both mempool script checks (Policy and Consensus), matching ConnectBlock so the two checks stay consistent. Non-grandfathered spends stay rejected even with the token, since they are genuinely reduced-data-invalid.

Test: feature_reduced_data_utxo_height.py adds a case where the grandfathered OP_IF-tapscript spend is rejected by default, accepted with the token, and a non-grandfathered spend is still rejected with the token.
