### PR TITLE
ci: install librsvg2-bin and imagemagick for test each commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           echo "TEST_BASE=$(git rev-list -n$((${{ env.MAX_COUNT }} + 1)) --reverse HEAD $EXCLUDE_MERGE_BASE_ANCESTORS | head -1)" >> "$GITHUB_ENV"
       - run: |
           sudo apt-get update
-          sudo apt-get install clang ccache build-essential cmake pkgconf python3-zmq libevent-dev libboost-dev libsqlite3-dev libdb++-dev systemtap-sdt-dev libminiupnpc-dev libzmq3-dev qtbase5-dev qttools5-dev qttools5-dev-tools qtwayland5 libqrencode-dev -y
+          sudo apt-get install clang ccache build-essential cmake pkgconf python3-zmq libevent-dev libboost-dev libsqlite3-dev libdb++-dev systemtap-sdt-dev libminiupnpc-dev libzmq3-dev qtbase5-dev qttools5-dev qttools5-dev-tools qtwayland5 libqrencode-dev librsvg2-bin imagemagick -y
       - name: Compile and run tests
         run: |
           # Run tests on commits after the last merge commit and before the PR head commit


### PR DESCRIPTION
The `test each commit` job configures with `-DBUILD_GUI=ON`, but does not install the icon-rendering tools that `BUILD_GUI` requires, so CMake aborts during configure:

```
CMake Error at CMakeLists.txt:722 (find_program):
  Could not find RSVG_CONVERT using the following names: rsvg-convert
```

`CMakeLists.txt` requires both tools when building the GUI on non-Darwin:

```cmake
if(BUILD_GUI)
  find_program(RSVG_CONVERT rsvg-convert REQUIRED)
  ...
  else()
    find_program(IMAGEMAGICK_CONVERT NAMES magick convert REQUIRED)
```

`test each commit` is the only job missing them. Every other CI path already installs them: `ci/test/00_setup_env.sh`, `ci/test/00_setup_env_mac_cross.sh`, `ci/test/00_setup_env_native_centos.sh`, and the macOS `brew install ... librsvg` step in this same workflow.

The job runs only on pull requests with more than one commit, which is why it does not fail on every PR.

Example failure: https://github.com/bitcoinknots/bitcoin/actions/runs/28277646974/job/85830663679

### Verification

In a clean `ubuntu:24.04` container, installing the job's current package list leaves all three binaries absent:

```
rsvg-convert   MISSING
magick         MISSING
convert        MISSING
```

Running the job's exact cmake configure line then reproduces the CI error verbatim:

```
CMake Error at CMakeLists.txt:722 (find_program):
  Could not find RSVG_CONVERT using the following names: rsvg-convert
```

After adding `librsvg2-bin` and `imagemagick`, `rsvg-convert` and `convert` resolve, and the same configure completes:

```
-- Configuring done (16.6s)
-- Generating done (0.1s)
```

`imagemagick` is included because `find_program(IMAGEMAGICK_CONVERT NAMES magick convert REQUIRED)` is reached immediately after the `rsvg-convert` check, and it is likewise absent both from the job's package list and from the `ubuntu-24.04` runner image's apt manifest.

Refs #327.
