### PR TITLE
contrib: don't use the default datadir in gen-bitcoin-conf.sh

### DIFF
--- a/contrib/devtools/gen-bitcoin-conf.sh
+++ b/contrib/devtools/gen-bitcoin-conf.sh
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 export LC_ALL=C
+set -eo pipefail
 TOPDIR=${TOPDIR:-$(git rev-parse --show-toplevel)}
 BUILDDIR=${BUILDDIR:-$TOPDIR/build}
 BINDIR=${BINDIR:-$BUILDDIR/bin}
@@ -13,8 +14,13 @@ EXAMPLE_CONF_FILE=${EXAMPLE_CONF_FILE:-$SHARE_EXAMPLES_DIR/bitcoin.conf}
 
 [ ! -x "$BITCOIND" ] && echo "$BITCOIND not found or not executable." && exit 1
 
+# bitcoind reads and creates files in its datadir before handling -version and
+# -help, so point it at a throwaway directory rather than the default one.
+DATADIR=$(mktemp -d)
+trap 'rm -rf "$DATADIR"' EXIT
+
 DIRTY=""
-VERSION_OUTPUT=$($BITCOIND --version)
+VERSION_OUTPUT=$($BITCOIND -datadir="$DATADIR" --version)
 if [[ $VERSION_OUTPUT == *"dirty"* ]]; then
   DIRTY="${DIRTY}${BITCOIND}\n"
 fi
@@ -49,7 +55,7 @@ EOF
 # parse the output from bitcoind --help
 # adding newlines is a bit funky to ensure portability for BSD
 # see here for more details: https://stackoverflow.com/a/24575385
-${BITCOIND} --help \
+${BITCOIND} -datadir="$DATADIR" --help \
     | sed '1,/Options:/d' \
     | sed -E '/^[[:space:]]{2}-help/,/^[[:space:]]*$/d' \
     | sed -E 's/^[[:space:]]{2}\-/#/' \


### PR DESCRIPTION
Fixes #304.

`gen-bitcoin-conf.sh` invokes `bitcoind --version` and `bitcoind --help`. Both of these run `common::InitConfig()` (`src/bitcoind.cpp:122`) *before* the `-help`/`-version` early return (`src/bitcoind.cpp:138`), despite the comment there claiming help and version are processed "before taking care about datadir". So each invocation touches the default datadir:

- `fs::create_directories(base_path / "wallets")` (`src/common/init.cpp:58`) creates `$HOME/.bitcoin`
- `fs::exists(base_path / BITCOIN_CONF_FILENAME)` (`src/common/init.cpp:68`) stats `$HOME/.bitcoin/bitcoin.conf`
- `WriteSettingsFile()` (`src/common/init.cpp:111`) writes `$HOME/.bitcoin/settings.json`

If `$HOME/.bitcoin` exists but is not traversable, the `fs::exists` call throws `filesystem_error` on `EACCES` and both invocations fail, as @pdath reproduced in the issue.

Point `bitcoind` at a throwaway datadir instead. Note that `-noconf` alone is *not* sufficient: the `fs::exists()` call above runs regardless of whether a config file is in use, and `-nosettings` does not help either. Only `-datadir` avoids all three accesses. Verified by running each variant against a build of this tree.

Also add `set -eo pipefail`, per the second half of the issue. Previously a failing `bitcoind` was not detected at all: the `VERSION_OUTPUT=$(...)` assignment went unchecked, and the exit status of the `bitcoind --help | sed | ... | sed` pipeline was that of the trailing `sed`. The script printed `bitcoind`'s errors and then exited 0 with a truncated `bitcoin.conf`, which is the failure mode seen in the issue report.

Bare `mktemp -d` matches the existing usage in `contrib/devtools/check-deps.sh` and is portable to the BSDs, whose `mktemp` behaves "as if `-t tmp` was supplied" when only `-d` is passed.

## Testing

Built with `-DWITH_ZMQ=ON -DWITH_MINIUPNPC=ON` and confirmed the patched script regenerates `share/examples/bitcoin.conf` byte-for-byte identically to the committed file, so this change is output-neutral. `bitcoind --help` output is unchanged by `-datadir`.

Comparing against the script before this change:

| Scenario | Before | After |
| --- | --- | --- |
| Fresh `$HOME` | creates `.bitcoin/`, `wallets/`, `settings.json` | nothing created |
| Unwritable `$HOME` | fails | succeeds |
| `chmod 444 ~/.bitcoin` (issue #304) | `Permission denied`, but exits 0 | succeeds, silent |
| `bitcoind --version` fails | exits 0 | propagates exit status |
| `bitcoind --help` fails | exits 0 | propagates exit status |
| `bitcoind` missing / not executable | exits 1 | exits 1 |

The temporary datadir is removed on exit. `test/lint/lint-shell.py` passes.

One pre-existing wart is left alone: if `bitcoind` fails midway, the header has already been written and `share/examples/bitcoin.conf` is left truncated. That is now at least signalled by a non-zero exit status. Generating into a temporary file and renaming it into place on success would close it, if wanted.
