### PR TITLE
GUI/NetWatch: Fix heap corruption from off-thread model mutation

### DIFF
--- a/src/qt/netwatch.cpp
+++ b/src/qt/netwatch.cpp
@@ -280,12 +280,22 @@ void NetWatchValidationInterface::ValidationInterfaceUnregistering()
 
 void NetWatchValidationInterface::BlockConnected(ChainstateRole role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex)
 {
-    model.LogBlock(pindex, block);
+    // Callbacks run on the scheduler thread; Qt models may only be mutated on
+    // the GUI thread. Marshal there (capturing the model, not this interface,
+    // which may be deleted before the event is delivered).
+    NetWatchLogModel* const model_ptr = &model;
+    QMetaObject::invokeMethod(model_ptr, [model_ptr, block, pindex] {
+        model_ptr->LogBlock(pindex, block);
+    }, Qt::QueuedConnection);
 }
 
 void NetWatchValidationInterface::TransactionAddedToMempool(const NewMempoolTransactionInfo& txinfo, uint64_t mempool_sequence)
 {
-    model.LogTransaction(txinfo.info.m_tx);
+    NetWatchLogModel* const model_ptr = &model;
+    const CTransactionRef tx = txinfo.info.m_tx;
+    QMetaObject::invokeMethod(model_ptr, [model_ptr, tx] {
+        model_ptr->LogTransaction(tx);
+    }, Qt::QueuedConnection);
 }
 
 NetWatchLogModel::NetWatchLogModel(QWidget *parent) :

--- a/src/qt/netwatch.cpp
+++ b/src/qt/netwatch.cpp
@@ -175,7 +175,7 @@ void LogEntry::clear()
             break;
         default: assert(false);
     }
-    delete m_data;
+    ::operator delete(m_data);
 }
 
 LogEntry::~LogEntry()

--- a/src/qt/netwatch.cpp
+++ b/src/qt/netwatch.cpp
@@ -690,8 +690,12 @@ void NetWatchLogModel::LogTransaction(const CTransactionRef& tx)
 void NetWatchLogModel::setClientModel(ClientModel *model)
 {
     if (m_client_model) {
-        delete m_validation_interface;
-        m_validation_interface = nullptr;
+        if (m_validation_interface) {
+            Assert(m_client_model->node().context()->validation_signals);
+            m_client_model->node().context()->validation_signals->UnregisterValidationInterface(m_validation_interface);
+            delete m_validation_interface;
+            m_validation_interface = nullptr;
+        }
 
         disconnect(m_client_model->getOptionsModel(), &OptionsModel::displayUnitChanged, this, &NetWatchLogModel::updateDisplayUnit);
         disconnect(m_client_model->getOptionsModel(), &OptionsModel::fontForMoneyChanged, this, &NetWatchLogModel::updateDisplayUnit);


### PR DESCRIPTION
Fixes #306.

The Net Watch model was mutated from validation-interface callbacks running on the scheduler thread (`BlockConnected`, `TransactionAddedToMempool`), while the GUI thread read and painted the same model. Qt models are single-threaded; the concurrent `beginInsertRows`/`beginRemoveRows`/`dataChanged` calls corrupted Qt-internal selection state, producing the heap corruption in #306. The callbacks now marshal the model mutations onto the GUI thread with a queued invocation, as `GuiBlockView` already does.

Reproduced on release and ASan builds by flooding the mempool while the Net Watch view painted; deterministic crash before, clean after (ASan clean through churn and shutdown).

Two adjacent memory-safety bugs found in the same file while verifying, fixed as separate commits:
- `setClientModel(nullptr)` deleted the validation interface without unregistering it, leaving a dangling pointer dereferenced during shutdown flush (use-after-free).
- `LogEntry::clear()` freed `::operator new` memory with a `delete`-expression on `uint8_t*` (mismatched deallocation, UB under sized delete).
