### PR TITLE
GUI: Add RPC console option to follow the wallet displayed in the main window

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -454,7 +454,6 @@ void BitcoinGUI::createActions()
                 connect(action, &QAction::triggered, [this, path] {
                     auto activity = new OpenWalletActivity(m_wallet_controller, this);
                     connect(activity, &OpenWalletActivity::opened, this, &BitcoinGUI::setCurrentWallet, Qt::QueuedConnection);
-                    connect(activity, &OpenWalletActivity::opened, rpcConsole, &RPCConsole::setCurrentWallet, Qt::QueuedConnection);
                     activity->open(path);
                 });
             }
@@ -488,7 +487,6 @@ void BitcoinGUI::createActions()
 
             auto activity = new RestoreWalletActivity(m_wallet_controller, this);
             connect(activity, &RestoreWalletActivity::restored, this, &BitcoinGUI::setCurrentWallet, Qt::QueuedConnection);
-            connect(activity, &RestoreWalletActivity::restored, rpcConsole, &RPCConsole::setCurrentWallet, Qt::QueuedConnection);
 
             auto backup_file_path = fs::PathFromString(backup_file.toStdString());
             activity->restore(backup_file_path, wallet_name.toStdString());
@@ -853,6 +851,7 @@ void BitcoinGUI::setCurrentWallet(WalletModel* wallet_model)
 {
     if (!walletFrame || !m_wallet_controller) return;
     walletFrame->setCurrentWallet(wallet_model);
+    rpcConsole->setDisplayedWallet(wallet_model);
     for (int index = 0; index < m_wallet_selector->count(); ++index) {
         if (m_wallet_selector->itemData(index).value<WalletModel*>() == wallet_model) {
             m_wallet_selector->setCurrentIndex(index);
@@ -1330,7 +1329,6 @@ void BitcoinGUI::createWallet()
 #ifdef ENABLE_WALLET
     auto activity = new CreateWalletActivity(getWalletController(), this);
     connect(activity, &CreateWalletActivity::created, this, &BitcoinGUI::setCurrentWallet);
-    connect(activity, &CreateWalletActivity::created, rpcConsole, &RPCConsole::setCurrentWallet);
     activity->create();
 #endif // ENABLE_WALLET
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -67,6 +67,12 @@ const int INITIAL_TRAFFIC_GRAPH_MINS = 30;
 const QSize FONT_RANGE(4, 40);
 const char fontSizeSettingsKey[] = "consoleFontSize";
 
+#ifdef ENABLE_WALLET
+//! Index of the wallet selector entry that follows the wallet displayed in the main window.
+//! Entry 0 is "(none)", from the form; wallets are appended after this one.
+const int WALLET_SELECTOR_DISPLAYED = 1;
+#endif // ENABLE_WALLET
+
 const struct {
     const char *url;
     const char *source;
@@ -626,6 +632,11 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
     connect(ui->fontSmallerButton, &QAbstractButton::clicked, this, &RPCConsole::fontSmaller);
     connect(ui->btnClearTrafficGraph, &QPushButton::clicked, ui->trafficGraph, &TrafficGraphWidget::clear);
 
+#ifdef ENABLE_WALLET
+    ui->WalletSelector->insertItem(WALLET_SELECTOR_DISPLAYED, QString());
+    setDisplayedWallet(nullptr);
+#endif // ENABLE_WALLET
+
     // disable the wallet selector by default
     ui->WalletSelector->setVisible(false);
     ui->WalletSelectorLabel->setVisible(false);
@@ -981,11 +992,11 @@ void RPCConsole::addWallet(WalletModel * const walletModel)
 {
     // use name for text and wallet model for internal data object (to allow to move to a wallet id later)
     ui->WalletSelector->addItem(walletModel->getDisplayName(), QVariant::fromValue(walletModel));
-    if (ui->WalletSelector->count() == 2) {
-        // First wallet added, set to default to match wallet RPC behavior
-        ui->WalletSelector->setCurrentIndex(1);
+    if (ui->WalletSelector->count() == 3) {
+        // First wallet added, follow the wallet displayed in the main window
+        ui->WalletSelector->setCurrentIndex(WALLET_SELECTOR_DISPLAYED);
     }
-    if (ui->WalletSelector->count() > 2) {
+    if (ui->WalletSelector->count() > 3) {
         ui->WalletSelector->setVisible(true);
         ui->WalletSelectorLabel->setVisible(true);
     }
@@ -994,16 +1005,28 @@ void RPCConsole::addWallet(WalletModel * const walletModel)
 void RPCConsole::removeWallet(WalletModel * const walletModel)
 {
     ui->WalletSelector->removeItem(ui->WalletSelector->findData(QVariant::fromValue(walletModel)));
-    if (ui->WalletSelector->count() == 2) {
+    if (ui->WalletSelector->count() == 3) {
         ui->WalletSelector->setVisible(false);
         ui->WalletSelectorLabel->setVisible(false);
     }
+    // The main window switches to another wallet before removing this one, so
+    // this only hits when the last wallet is unloaded
+    if (m_displayed_wallet_model == walletModel) setDisplayedWallet(nullptr);
 }
 
-void RPCConsole::setCurrentWallet(WalletModel* const wallet_model)
+void RPCConsole::setDisplayedWallet(WalletModel* const wallet_model)
 {
-    QVariant data = QVariant::fromValue(wallet_model);
-    ui->WalletSelector->setCurrentIndex(ui->WalletSelector->findData(data));
+    m_displayed_wallet_model = wallet_model;
+    ui->WalletSelector->setItemText(WALLET_SELECTOR_DISPLAYED,
+                                    wallet_model ? tr("Use displayed wallet (%1)").arg(wallet_model->getDisplayName())
+                                                 : tr("Use displayed wallet"));
+}
+
+WalletModel* RPCConsole::currentWalletModel() const
+{
+    const int index = ui->WalletSelector->currentIndex();
+    if (index == WALLET_SELECTOR_DISPLAYED) return m_displayed_wallet_model;
+    return ui->WalletSelector->itemData(index).value<WalletModel*>();
 }
 #endif
 
@@ -1259,7 +1282,7 @@ void RPCConsole::on_lineEdit_returnPressed()
 
     WalletModel* wallet_model{nullptr};
 #ifdef ENABLE_WALLET
-    wallet_model = ui->WalletSelector->currentData().value<WalletModel*>();
+    wallet_model = currentWalletModel();
 
     if (m_last_wallet_model != wallet_model) {
         if (wallet_model) {

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -153,8 +153,8 @@ public Q_SLOTS:
     /** set which tab has the focus (is visible) */
     void setTabFocus(enum TabTypes tabType);
 #ifdef ENABLE_WALLET
-    /** Set the current (ie - active) wallet */
-    void setCurrentWallet(WalletModel* const wallet_model);
+    /** Set the wallet displayed in the main window, followed when the selector is on "Use displayed wallet" */
+    void setDisplayedWallet(WalletModel* const wallet_model);
 #endif // ENABLE_WALLET
 
 private:
@@ -198,6 +198,11 @@ private:
     QThread thread;
     RPCExecutor* m_executor{nullptr};
     WalletModel* m_last_wallet_model{nullptr};
+#ifdef ENABLE_WALLET
+    /** Wallet the selector resolves to while "Use displayed wallet" is selected */
+    WalletModel* m_displayed_wallet_model{nullptr};
+    WalletModel* currentWalletModel() const;
+#endif // ENABLE_WALLET
     bool m_is_executing{false};
     QByteArray m_peer_widget_header_state;
     QByteArray m_banlist_widget_header_state;


### PR DESCRIPTION
Switching wallets with the main window's toolbar selector does not update the RPC console's wallet selector, so console commands can silently run against a different wallet than the one displayed.

99c0eb9701 ("Fix RPCConsole wallet selection") connected the console to the open, restore and create wallet activities, but not to the toolbar selector or wallet migration.

Rather than forcing the two selectors to match, which would override a console selection made on purpose, the console gets a "Use displayed wallet (<name>)" entry. It is selected by default and its label follows the main window. Picking any other entry pins the console to that wallet.

![wallet selector](https://raw.githubusercontent.com/privkeyio/bitcoin/assets/rpcconsole-wallet-selector/wallet-selector.png)

`BitcoinGUI::setCurrentWallet()` now reports the displayed wallet to the console, covering every path that changes the active wallet. The three per-callsite connects are redundant with this and are removed, same as #344, which is the bugfix on its own.

## Testing

`bitcoin-qt` on regtest with two wallets loaded, `wallet_a` and `wallet_b`.

- Before this change, with the main window on `wallet_b`, the console stayed on `wallet_a` and commands ran against `wallet_a`. After it, the same steps run against `wallet_b`.
- Pinned to `wallet_a`: switching the toolbar back and forth leaves the console on `wallet_a`.
- Create Wallet, Restore Wallet, File > Open Wallet and `loadwallet`: the console follows the newly displayed wallet.
- `unloadwallet` on the pinned wallet, and on the last wallet: no crash, commands fall back to the remaining wallet and then to no wallet.
- Selecting "(none)": commands run without any wallet.
- Built with `-DENABLE_WALLET=OFF`: builds and runs, console unaffected.
- `test_bitcoin-qt` passes.

Wallet migration is not covered, this build has no bdb support so there is no legacy wallet to migrate. It uses the same `setCurrentWallet()` path.
