### PR TITLE
GUI: Don't assert on translated field labels in ReceiveRequestDialog

### DIFF
--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -67,9 +67,12 @@ void ReceiveRequestDialog::updateInfoWidget()
             if (i == 1) {
                 html += "<b>" + text + "</b><br>";
             } else if (i % 2 == 0) {
-                assert(text.endsWith(":"));
-                text.chop(1);
-                html += "<b>" + text + "</b>: ";
+                // Bold only the field name, leaving its trailing separator
+                // unbolded. Don't assume an ASCII colon: translations may end
+                // with a non-ASCII colon, or none at all.
+                int name_len = text.size();
+                while (name_len > 0 && !text.at(name_len - 1).isLetterOrNumber()) --name_len;
+                html += "<b>" + text.left(name_len) + "</b>" + text.mid(name_len) + " ";
             } else {
                 html += text + "<br>";
             }


### PR DESCRIPTION
Fixes #316.

`ReceiveRequestDialog::updateInfoWidget()` asserted that every field label ends with an ASCII colon, then chopped it off:

```cpp
assert(text.endsWith(":"));
text.chop(1);
html += "<b>" + text + "</b>: ";
```

The labels come from the `.ui` form and are run through `tr()`, so `text` is *translated* text. Asserting on it makes any translation that doesn't end in U+003A abort the process. Since asserts are enabled in release builds, this aborts `bitcoin-qt` outright when the user opens the receive request dialog.

The reporter hit it with Chinese, where `Label:` is translated `标签：` (U+FF1A FULLWIDTH COLON). It is not limited to Chinese: 37 of the shipped locales have at least one affected label.

`setInfo()` calls `updateInfoWidget()` (via `updateDisplayUnit()`) *before* it hides `label_tag`, `message_tag` and `wallet_tag`, so those three are always visible on the first pass. That is why the crash reproduces on a completely empty form, as in the reporter's screenshot. Only `amount_tag` is hidden in time, so locales whose sole bad label is `Amount:` abort only when an amount is requested.

A sample of what the locales actually ship:

| Locale | Source | Translation | Trailing char |
|---|---|---|---|
| zh_CN, zh-Hans, zh, zh_HK, zh-Hant, cmn, hak, yue | `Label:` | `标签：` | U+FF1A fullwidth colon |
| de | `Wallet:` | `Wallet: ` | U+0020 trailing space |
| da | `Address:` | `Adresse` | no colon |
| sv | `Address:` | `Adress` | no colon |
| km | `Address:` | `អាសយដ្ឋានៈ` | U+17C8 |
| tr | `Amount:` | `Miktar` | no colon |

## Fix

Drop the assert and the chop. Bold only the field name and leave its trailing separator unbolded, without assuming an ASCII colon:

```cpp
int name_len = text.size();
while (name_len > 0 && !text.at(name_len - 1).isLetterOrNumber()) --name_len;
html += "<b>" + text.left(name_len) + "</b>" + text.mid(name_len) + " ";
```

The trailing separator is whatever the translation provides: an ASCII colon, a non-ASCII colon, or nothing. Rendered plain text is unchanged for English, and the colon stays outside the bold run as before.

## Testing

Verified end-to-end by driving the real widget in `test_bitcoin-qt` with the real compiled `.qm` translations, installing the translator exactly as `bitcoin.cpp` does.

Before, on an empty form:

```
test_bitcoin-qt: ./qt/receiverequestdialog.cpp:70: void ReceiveRequestDialog::updateInfoWidget():
Assertion `text.endsWith(":")' failed.        [SIGABRT]
```

matching the reporter's screenshot exactly (same file, line and expression). `en` passed; `zh_CN`, `zh-Hans`, `de`, `da`, `sv`, `km`, `vi` aborted with an empty form; `tr`, `th`, `et` aborted once an amount was entered.

After the fix, all 34 tested locales pass with both `amount=0` and `amount=1`, hidden rows are still correctly omitted, the colon is not bolded, and there is no doubled colon:

```
en     Address: bcrt1q5j7…    Label: TEST_LABEL_1
zh_CN  地址: bcrt1q0k6…       标签： TEST_LABEL_1
de     Adresse: bcrt1qj7t…    Bezeichnung: TEST_LABEL_1
da     Adresse bcrt1q79y…     Mærkat: TEST_LABEL_1
tr     Adres: bcrt1q5ns…      Miktar 0.00000001 BTC
```

Full `test_bitcoin-qt` suite passes (21 tests), including the existing `WalletTests` checks on the English label texts.

