### PR TITLE
GUI: Use locale-aware GUIUtil::dateTimeStr for datetime fields

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -210,7 +210,7 @@ bool ClientModel::isReleaseVersion() const
 
 QString ClientModel::formatClientStartupTime() const
 {
-    return QDateTime::currentDateTime().addSecs(-TicksSeconds(GetUptime())).toString();
+    return GUIUtil::dateTimeStr(QDateTime::currentDateTime().addSecs(-TicksSeconds(GetUptime())));
 }
 
 QString ClientModel::dataDir() const

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -150,7 +150,7 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
     }
 
     // show the last block date
-    ui->newestBlockDate->setText(blockDate.toString());
+    ui->newestBlockDate->setText(GUIUtil::dateTimeStr(blockDate));
 
     // show the percentage done according to nVerificationProgress
     ui->percentageProgress->setText(QString::number(nVerificationProgress*100, 'f', 2)+"%");

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -931,7 +931,7 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
         ui->blocksDir->setText(model->blocksDir());
         ui->startupTime->setText(model->formatClientStartupTime());
         if (g_software_expiry > 0) {
-            m_label_softwareexpiry->setText(QDateTime::fromSecsSinceEpoch(g_software_expiry).toString());
+            m_label_softwareexpiry->setText(GUIUtil::dateTimeStr(g_software_expiry));
         } else {
             //: Software expiry, if it never expires
             m_label_softwareexpiry->setText(tr("Never"));

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1188,7 +1188,7 @@ void RPCConsole::setNumBlocks(int count, const QDateTime& blockDate, double nVer
 {
     if (synctype == SyncType::BLOCK_SYNC) {
         ui->numberOfBlocks->setText(QString::number(count));
-        ui->lastBlockTime->setText(blockDate.toString());
+        ui->lastBlockTime->setText(GUIUtil::dateTimeStr(blockDate));
     }
 }
 


### PR DESCRIPTION
Fixes #335

Startup time, Expiry time, and Last block time (in the Information tab and the sync overlay) were formatted with bare `QDateTime::toString()`. On Qt 5.15, which the release binaries are built against, that produces asctime-style ordering (`Thu Jul 16 20:43:39 2026`) with the time wedged between the day and the year, and it ignores the user's locale. Qt 6.7+ changed the default ordering, which is why this only shows up on Qt5 builds.

Switch these fields to `GUIUtil::dateTimeStr`, the same locale-aware formatting used for every other datetime in the GUI. Seconds are no longer shown, consistent with datetimes elsewhere.

### Before / After

| Before | After |
|---|---|
| ![Information tab before](https://raw.githubusercontent.com/privkeyio/bitcoin/issue-335-assets/information-tab-before.png) | ![Information tab after](https://raw.githubusercontent.com/privkeyio/bitcoin/issue-335-assets/information-tab-after.png) |
| ![Sync overlay before](https://raw.githubusercontent.com/privkeyio/bitcoin/issue-335-assets/overlay-before.png) | ![Sync overlay after](https://raw.githubusercontent.com/privkeyio/bitcoin/issue-335-assets/overlay-after.png) |
