### PR TITLE
mining: Increase minimum feerate as the block fills up

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -81,6 +81,16 @@ Notable changes
   (e.g. containers), automatic sizing may not match effective limits. The
   previous behavior can be restored by setting `-dbcache` explicitly. (#34641)
 
+- Block creation now demands a progressively higher feerate as the block fills
+  up, in the spirit of Satoshi's original client, so a block is only extended
+  when the space is paid for. The new `-blockmintxfeerampstart` option is the
+  percentage a block must be filled to before `-blockmintxfee` starts being
+  scaled up, defaulting to `50` as it did originally. Unlike the original, which
+  jumped straight to twice the minimum feerate at that point, the requirement
+  rises continuously from the unscaled minimum. Setting it to `100` restores the
+  previous behaviour, and it has no effect if `-blockmintxfee` is set to `0`.
+  (knots#338)
+
 ### New spam filters
 
 - Transactions creating outputs with a value less than the expected value to

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -784,6 +784,9 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-blockmaxweight=<n>", strprintf("Set maximum BIP141 block weight (default: %d)", DEFAULT_BLOCK_MAX_WEIGHT), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     argsman.AddArg("-blockreservedweight=<n>", strprintf("Reserve space for the fixed-size block header plus the largest coinbase transaction the mining software may add to the block. (default: %d).", DEFAULT_BLOCK_RESERVED_WEIGHT), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     argsman.AddArg("-blockmintxfee=<amt>", strprintf("Set lowest fee rate (in %s/kvB) for transactions to be included in block creation. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_BLOCK_MIN_TX_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    // Negation and elision are disallowed because both parse as 0, which is the most aggressive
+    // setting rather than the "off" a user writing -noblockmintxfeerampstart would expect (100).
+    argsman.AddArg("-blockmintxfeerampstart=<n>", strprintf("Percentage a block must be filled to before -blockmintxfee is scaled up, requiring progressively higher feerates as the block fills. Has no effect if -blockmintxfee is 0. 100 disables scaling. (default: %u)", DEFAULT_BLOCK_MIN_TX_FEE_RAMP_START), ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION | ArgsManager::DISALLOW_ELISION, OptionsCategory::BLOCK_CREATION);
     argsman.AddArg("-blockprioritysize=<n>", strprintf("Set maximum size of high-priority/low-fee transactions in bytes (default: %d)", DEFAULT_BLOCK_PRIORITY_SIZE), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     argsman.AddArg("-blockversion=<n>", "Override block version to test forking scenarios", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::BLOCK_CREATION);
 
@@ -1191,6 +1194,16 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     if (args.IsArgSet("-blockmintxfee")) {
         if (!ParseMoney(args.GetArg("-blockmintxfee", ""))) {
             return InitError(AmountErrMsg("blockmintxfee", args.GetArg("-blockmintxfee", "")));
+        }
+    }
+
+    if (args.IsArgSet("-blockmintxfeerampstart")) {
+        // Parsed strictly rather than with GetIntArg, which maps unparseable values to 0: the
+        // most aggressive ramp, and not something to select by typo.
+        const std::string ramp_str{args.GetArg("-blockmintxfeerampstart", "")};
+        const auto ramp{ToIntegral<int64_t>(ramp_str)};
+        if (!ramp || *ramp < 0 || *ramp > 100) {
+            return InitError(strprintf(_("Specified -blockmintxfeerampstart (%s) must be a number between 0 and 100"), ramp_str));
         }
     }
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -21,6 +21,7 @@
 #include <policy/policy.h>
 #include <pow.h>
 #include <primitives/transaction.h>
+#include <util/check.h>
 #include <util/moneystr.h>
 #include <util/time.h>
 #include <validation.h>
@@ -86,6 +87,8 @@ BlockCreateOptions BlockCreateOptions::Clamped() const
     // Limit weight to between block_reserved_weight and MAX_BLOCK_WEIGHT for sanity:
     // block_reserved_weight can safely exceed -blockmaxweight, but the rest of the block template will be empty.
     options.nBlockMaxWeight = std::clamp<size_t>(options.nBlockMaxWeight, options.block_reserved_weight, MAX_BLOCK_WEIGHT);
+    // Bound the ramp here too, since options can be supplied directly rather than parsed.
+    options.blockMinFeeRateRampStart = std::min<unsigned int>(options.blockMinFeeRateRampStart, 100);
     return options;
 }
 
@@ -121,6 +124,7 @@ void ApplyArgsManOptions(const ArgsManager& args, BlockAssembler::Options& optio
     if (const auto blockmintxfee{args.GetArg("-blockmintxfee")}) {
         if (const auto parsed{ParseMoney(*blockmintxfee)}) options.blockMinFeeRate = CFeeRate{*parsed};
     }
+    options.blockMinFeeRateRampStart = std::clamp<int64_t>(args.GetIntArg("-blockmintxfeerampstart", options.blockMinFeeRateRampStart), 0, 100);
     options.print_modified_fee = args.GetBoolArg("-printpriority", options.print_modified_fee);
     options.block_reserved_weight = args.GetIntArg("-blockreservedweight", options.block_reserved_weight);
 }
@@ -253,6 +257,60 @@ bool BlockAssembler::TestPackage(uint64_t packageSize, int64_t packageSigOpsCost
         return false;
     }
     return true;
+}
+
+CAmount ScaledBlockMinFee(CAmount base_fee, uint64_t used, uint64_t limit, unsigned int ramp)
+{
+    if (ramp >= 100 || base_fee <= 0) {
+        return base_fee;
+    }
+    Assume(limit <= MAX_BLOCK_WEIGHT);
+
+    const uint64_t ramp_start{limit * ramp / 100};
+    if (used <= ramp_start) {
+        return base_fee;
+    }
+    if (used >= limit) {
+        return MAX_MONEY;
+    }
+
+    // Raise the price as the block approaches full: the multiplier is 1 at the ramp start and
+    // grows without bound as the block fills, so ever higher feerates are needed to get in.
+    //
+    // Two deliberate deviations from Satoshi's client, which used
+    // nMinFee *= MAX_BLOCK_SIZE_GEN / (MAX_BLOCK_SIZE_GEN - nNewBlockSize):
+    //  - The numerator is the size of the ramp rather than the whole limit, so the multiplier
+    //    starts at 1 and rises continuously. The original divided the full limit, jumping
+    //    straight to 2x at the ramp start and stepping through integer multiples from there.
+    //  - Fullness excludes the candidate transaction itself. Including it, as the original did,
+    //    would make the threshold depend on the candidate's size, breaking the assumption in
+    //    addPackageTxs that a package failing this check can never be followed by one that passes.
+    const CAmount numerator{static_cast<CAmount>(limit - ramp_start)};
+    const CAmount denominator{static_cast<CAmount>(limit - used)};
+    // Saturate rather than overflow. Reaching this needs a package whose unscaled minimum fee
+    // is already MAX_MONEY/numerator (5.25 BTC for a 4M weight block), and the scaled minimum
+    // is never smaller than the unscaled one, so demanding MAX_MONEY here rejects the same
+    // packages the exact result would. Below it the product cannot exceed MAX_MONEY.
+    if (base_fee > MAX_MONEY / numerator) {
+        return MAX_MONEY;
+    }
+    return base_fee * numerator / denominator;
+}
+
+CAmount BlockAssembler::MinFeeForPackage(uint64_t packageSize) const
+{
+    // Measure fullness against whichever of the weight or size limits is tighter, since only one
+    // of the two may have been configured. Products are bounded by MAX_BLOCK_WEIGHT^2.
+    // Both fractions only grow as the block fills, so the feerate demanded only rises, which is
+    // what lets addPackageTxs stop at the first package that cannot pay it. Switching dimension
+    // mid-block can shift the result by a rounding unit, at most one marginal package.
+    uint64_t used{nBlockWeight}, limit{m_options.nBlockMaxWeight};
+    if (fNeedSizeAccounting && nBlockSize * m_options.nBlockMaxWeight > nBlockWeight * m_options.nBlockMaxSize) {
+        used = nBlockSize;
+        limit = m_options.nBlockMaxSize;
+    }
+    return ScaledBlockMinFee(m_options.blockMinFeeRate.GetFee(packageSize), used, limit,
+                             m_options.blockMinFeeRateRampStart);
 }
 
 // Perform transaction-level checks before adding to block:
@@ -439,8 +497,9 @@ void BlockAssembler::addPackageTxs(const CTxMemPool& mempool, int& nPackagesSele
             packageSigOpsCost = modit->nSigOpCostWithAncestors;
         }
 
-        if (packageFees < m_options.blockMinFeeRate.GetFee(packageSize)) {
-            // Everything else we might consider has a lower fee rate
+        if (packageFees < MinFeeForPackage(packageSize)) {
+            // Everything else we might consider has a lower fee rate, and the minimum only ever
+            // rises as the block fills, so nothing further can qualify.
             return;
         }
 

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -216,6 +216,8 @@ private:
     void onlyUnconfirmed(CTxMemPool::setEntries& testSet);
     /** Test if a new package would "fit" in the block */
     bool TestPackage(uint64_t packageSize, int64_t packageSigOpsCost) const;
+    /** Minimum fee a package of the given size must pay, raised as the block fills up */
+    CAmount MinFeeForPackage(uint64_t packageSize) const;
     /** Perform checks on each transaction in a package:
       * locktime, premature-witness, serialized size (if necessary)
       * These checks should always succeed, and they're here
@@ -236,6 +238,13 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 
 /** Update an old GenerateCoinbaseCommitment from CreateNewBlock after the block txs have changed */
 void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
+
+/**
+ * Scale a package's minimum fee up as the block fills past the ramp start, so that space later
+ * in the block costs progressively more. `limit` is a block resource limit, so it is bounded by
+ * MAX_BLOCK_WEIGHT.
+ */
+CAmount ScaledBlockMinFee(CAmount base_fee, uint64_t used, uint64_t limit, unsigned int ramp);
 
 /** Apply -blockmintxfee and -blockmaxweight options from ArgsManager to BlockAssembler options. */
 void ApplyArgsManOptions(const ArgsManager& gArgs, BlockAssembler::Options& options);

--- a/src/node/types.h
+++ b/src/node/types.h
@@ -75,6 +75,8 @@ struct BlockCreateOptions {
     size_t nBlockMaxWeight{DEFAULT_BLOCK_MAX_WEIGHT};
     size_t nBlockMaxSize{DEFAULT_BLOCK_MAX_SIZE};
     CFeeRate blockMinFeeRate{DEFAULT_BLOCK_MIN_TX_FEE};
+    // Percentage a block must be filled to before blockMinFeeRate is scaled up; 100 disables the ramp
+    unsigned int blockMinFeeRateRampStart{DEFAULT_BLOCK_MIN_TX_FEE_RAMP_START};
     // Whether to call TestBlockValidity() at the end of CreateNewBlock().
     bool test_block_validity{true};
     bool print_modified_fee{DEFAULT_PRINT_MODIFIED_FEE};

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -43,6 +43,9 @@ static constexpr unsigned int DEFAULT_BLOCK_RESERVED_WEIGHT{8000};
 static constexpr unsigned int MINIMUM_BLOCK_RESERVED_WEIGHT{2000};
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
 static constexpr unsigned int DEFAULT_BLOCK_MIN_TX_FEE{1000};
+/** Default for -blockmintxfeerampstart, the percentage a block must be filled to before -blockmintxfee is
+ * scaled up; 100 disables the ramp **/
+static constexpr unsigned int DEFAULT_BLOCK_MIN_TX_FEE_RAMP_START{50};
 /** The maximum weight for transactions we're willing to relay/mine */
 static constexpr int32_t MAX_STANDARD_TX_WEIGHT{400000};
 /** The minimum non-witness size for transactions we're willing to relay/mine: one larger than 64  */

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -644,6 +644,11 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
     blockmintxfee = new BitcoinAmountField(tabMining);
     CreateOptionUI(verticalLayout_Mining, blockmintxfee, tr("Only mine transactions paying a fee of at least %s per kvB."));
 
+    blockmintxfeerampstart = new QSpinBox(tabMining);
+    blockmintxfeerampstart->setMinimum(0);
+    blockmintxfeerampstart->setMaximum(100);
+    CreateOptionUI(verticalLayout_Mining, blockmintxfeerampstart, tr("Once a block is %s% full, progressively raise the fee required above that minimum (100% to disable; no effect if the minimum is 0)."));
+
     blockmaxsize = new QSpinBox(tabMining);
     blockmaxsize->setMinimum(1);
     blockmaxsize->setMaximum((MAX_BLOCK_SERIALIZED_SIZE - 1000) / 1000);
@@ -997,6 +1002,7 @@ void OptionsDialog::setMapper()
     /* Mining tab */
 
     mapper->addMapping(blockmintxfee, OptionsModel::blockmintxfee);
+    mapper->addMapping(blockmintxfeerampstart, OptionsModel::blockmintxfeerampstart);
     mapper->addMapping(blockmaxsize, OptionsModel::blockmaxsize);
     mapper->addMapping(blockprioritysize, OptionsModel::blockprioritysize);
     mapper->addMapping(blockmaxweight, OptionsModel::blockmaxweight);

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -167,7 +167,7 @@ private:
     QSpinBox *dustdynamic_mempool_kvB;
 
     BitcoinAmountField *blockmintxfee;
-    QSpinBox *blockmaxsize, *blockprioritysize, *blockmaxweight;
+    QSpinBox *blockmaxsize, *blockprioritysize, *blockmaxweight, *blockmintxfeerampstart;
 };
 
 #endif // BITCOIN_QT_OPTIONSDIALOG_H

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -115,6 +115,7 @@ static const char* SettingName(OptionsModel::OptionID option)
     case OptionsModel::dustrelayfee: return "dustrelayfee";
     case OptionsModel::dustdynamic: return "dustdynamic";
     case OptionsModel::blockmintxfee: return "blockmintxfee";
+    case OptionsModel::blockmintxfeerampstart: return "blockmintxfeerampstart";
     case OptionsModel::blockmaxsize: return "blockmaxsize";
     case OptionsModel::blockprioritysize: return "blockprioritysize";
     case OptionsModel::blockmaxweight: return "blockmaxweight";
@@ -783,6 +784,8 @@ QVariant OptionsModel::getOption(OptionID option, const std::string& suffix) con
         } else {
             return qlonglong(DEFAULT_BLOCK_MIN_TX_FEE);
         }
+    case blockmintxfeerampstart:
+        return qlonglong(gArgs.GetIntArg("-blockmintxfeerampstart", DEFAULT_BLOCK_MIN_TX_FEE_RAMP_START));
     case blockmaxsize:
         return qlonglong(gArgs.GetIntArg("-blockmaxsize", DEFAULT_BLOCK_MAX_SIZE) / 1000);
     case blockprioritysize:
@@ -1454,6 +1457,13 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
             std::string strNv = FormatMoney(value.toLongLong());
             gArgs.ForceSetArg("-blockmintxfee", strNv);
             gArgs.ModifyRWConfigFile("blockmintxfee", strNv);
+        }
+        break;
+    case blockmintxfeerampstart:
+        if (changed()) {
+            std::string strNv = value.toString().toStdString();
+            gArgs.ForceSetArg("-blockmintxfeerampstart", strNv);
+            gArgs.ModifyRWConfigFile("blockmintxfeerampstart", strNv);
         }
         break;
     case blockmaxsize:

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -115,6 +115,7 @@ public:
         dustrelayfee,
         dustdynamic,            // QString
         blockmintxfee,
+        blockmintxfeerampstart,
         blockmaxsize,
         blockprioritysize,
         blockmaxweight,

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -647,6 +647,7 @@ static RPCHelpMan getblocktemplate()
                 }},
                 {"longpollid", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "delay processing request until the result would vary significantly from the \"longpollid\" of a prior template"},
                 {"minfeerate", RPCArg::Type::NUM, RPCArg::DefaultHint{"set by -blockmintxfee"}, "only include transactions with a minimum sats/vbyte (disables template cache)"},
+                {"minfeeraterampstart", RPCArg::Type::NUM, RPCArg::DefaultHint{"set by -blockmintxfeerampstart"}, "percentage the block must be filled to before \"minfeerate\" is scaled up; 100 disables scaling (disables template cache)"},
                 {"data", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "proposed block data to check, encoded in hexadecimal; valid only for mode=\"proposal\""},
             },
             },
@@ -802,6 +803,15 @@ static RPCHelpMan getblocktemplate()
         }
         if (!oparam["minfeerate"].isNull()) {
             options.blockMinFeeRate = CFeeRate{AmountFromValue(oparam["minfeerate"]), COIN /* sat/vB */};
+        }
+        if (!oparam["minfeeraterampstart"].isNull()) {
+            // Rejected rather than clamped: clamping an out-of-range value would silently
+            // disable the ramp, so a typo would quietly fill blocks at the base feerate.
+            const int64_t ramp{oparam["minfeeraterampstart"].getInt<int64_t>()};
+            if (ramp < 0 || ramp > 100) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "minfeeraterampstart must be between 0 and 100");
+            }
+            options.blockMinFeeRateRampStart = ramp;
         }
         options = options.Clamped();
         bypass_cache |= !(options == options_def);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -735,4 +735,94 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     TestPrioritisedMining(scriptPubKey, txFirst);
 }
 
+BOOST_AUTO_TEST_CASE(block_min_fee_ramp)
+{
+    using node::ScaledBlockMinFee;
+
+    // A ramp of 100 disables scaling no matter how full the block is.
+    for (const uint64_t used : {0UL, 50UL, 99UL, 100UL}) {
+        BOOST_CHECK_EQUAL(ScaledBlockMinFee(1000, used, 100, 100), 1000);
+    }
+
+    // Hand-computed points on the curve. With a ramp of 50 the multiplier is 50/(100 - used).
+    BOOST_CHECK_EQUAL(ScaledBlockMinFee(1000, 49, 100, 50), 1000);
+    BOOST_CHECK_EQUAL(ScaledBlockMinFee(1000, 50, 100, 50), 1000); // exactly at the ramp start
+    BOOST_CHECK_EQUAL(ScaledBlockMinFee(1000, 75, 100, 50), 2000);
+    BOOST_CHECK_EQUAL(ScaledBlockMinFee(1000, 90, 100, 50), 5000);
+    BOOST_CHECK_EQUAL(ScaledBlockMinFee(1000, 100, 100, 50), MAX_MONEY); // full
+    BOOST_CHECK_EQUAL(ScaledBlockMinFee(1000, 101, 100, 50), MAX_MONEY); // past full
+    // A ramp of 0 scales from the first byte, with a multiplier of 100/(100 - used).
+    BOOST_CHECK_EQUAL(ScaledBlockMinFee(1000, 0, 100, 0), 1000);
+    BOOST_CHECK_EQUAL(ScaledBlockMinFee(1000, 50, 100, 0), 2000);
+    // A base fee of zero cannot be scaled, so the ramp has no effect.
+    BOOST_CHECK_EQUAL(ScaledBlockMinFee(0, 90, 100, 50), 0);
+
+    // Sweep the domain, checking the properties the block assembler relies on.
+    for (const uint64_t limit : {2000UL, 90000UL, 300000UL, 4000000UL}) {
+        for (unsigned int ramp = 0; ramp <= 100; ++ramp) {
+            for (const CAmount base_fee : {CAmount{0}, CAmount{1}, CAmount{1000},
+                                           CAmount{525000000}, MAX_MONEY}) {
+                CAmount previous{0};
+                for (uint64_t used = 0; used <= limit; used += std::max<uint64_t>(limit / 512, 1)) {
+                    const CAmount scaled{ScaledBlockMinFee(base_fee, used, limit, ramp)};
+                    BOOST_CHECK(scaled >= 0);
+                    BOOST_CHECK(scaled <= MAX_MONEY);
+                    // Never cheaper than the unscaled fee: the multiplier is at least 1.
+                    BOOST_CHECK(scaled >= base_fee);
+                    // addPackageTxs stops at the first package that cannot pay this fee, which
+                    // is only sound because the fee never decreases as the block fills up.
+                    BOOST_CHECK(scaled >= previous);
+                    previous = scaled;
+                    // Below the ramp start the fee is untouched.
+                    if (ramp == 100 || used <= limit * ramp / 100) {
+                        BOOST_CHECK_EQUAL(scaled, base_fee);
+                    }
+                }
+            }
+        }
+    }
+
+    // Exhaustive over every small limit and every position within it, so that each boundary
+    // (empty block, ramp start, one unit from full, exactly full) is hit for every ramp rather
+    // than only where a stride happens to land.
+    for (uint64_t limit = 1; limit <= 64; ++limit) {
+        for (unsigned int ramp = 0; ramp <= 100; ++ramp) {
+            for (const CAmount base_fee : {CAmount{1}, CAmount{1000}, MAX_MONEY}) {
+                CAmount previous{0};
+                for (uint64_t used = 0; used <= limit; ++used) {
+                    const CAmount scaled{ScaledBlockMinFee(base_fee, used, limit, ramp)};
+                    BOOST_CHECK(scaled >= base_fee);
+                    BOOST_CHECK(scaled <= MAX_MONEY);
+                    BOOST_CHECK(scaled >= previous);
+                    previous = scaled;
+                }
+                // A full block always demands more than anything can pay.
+                BOOST_CHECK_EQUAL(ScaledBlockMinFee(base_fee, limit, limit, ramp),
+                                  ramp >= 100 ? base_fee : MAX_MONEY);
+            }
+        }
+    }
+
+    // Straddle the saturation boundary at every ramp, since that is the one input where the
+    // exact result is replaced by MAX_MONEY, and it is also where a multiply would overflow.
+    for (unsigned int ramp = 0; ramp < 100; ++ramp) {
+        const uint64_t limit{MAX_BLOCK_WEIGHT};
+        const uint64_t ramp_start{limit * ramp / 100};
+        const CAmount boundary{MAX_MONEY / static_cast<CAmount>(limit - ramp_start)};
+        for (const CAmount base_fee : {boundary - 1, boundary, boundary + 1}) {
+            for (const uint64_t used : {ramp_start + 1, limit - 1}) {
+                const CAmount scaled{ScaledBlockMinFee(base_fee, used, limit, ramp)};
+                BOOST_CHECK(scaled >= base_fee);
+                BOOST_CHECK(scaled <= MAX_MONEY);
+            }
+        }
+    }
+
+    // Saturation only replaces the exact result when the unscaled fee is already enormous, so
+    // no transaction that could have paid the exact fee is rejected by the saturated one.
+    const CAmount huge{MAX_MONEY / 4000000 + 1};
+    BOOST_CHECK_EQUAL(ScaledBlockMinFee(huge, 3999999, 4000000, 0), MAX_MONEY);
+    BOOST_CHECK(huge > 525000000); // 5.25 BTC, as documented at the saturation guard
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/mining_blockmintxfeerampstart.py
+++ b/test/functional/mining_blockmintxfeerampstart.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Knots developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test -blockmintxfeerampstart, which raises the required feerate as the block fills up."""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_node import ErrorMatch
+from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error
+from test_framework.wallet import MiniWallet
+
+# Block resource limits pinned by the node's arguments, in weight units.
+MAX_WEIGHT = 90000
+RESERVED_WEIGHT = 8000
+# Used only by the size-limited phase. DEFAULT_BLOCK_RESERVED_SIZE is not configurable.
+MAX_SIZE = 20000
+RESERVED_SIZE = 1000
+# Every test transaction is padded to this vsize, so each costs ~4000 weight.
+TX_VSIZE = 1000
+# Byte budget for the coin-age priority pass, which runs before the fee pass.
+PRIORITY_SIZE = 20000
+# -blockmintxfee, in BTC/kvB. At TX_VSIZE this is exactly 1000 satoshis.
+MIN_TX_FEE = Decimal("0.00001")
+
+
+class BlockMinTxFeeRampTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [[
+            f"-blockmaxweight={MAX_WEIGHT}",
+            f"-blockreservedweight={RESERVED_WEIGHT}",
+            f"-blockmintxfee={MIN_TX_FEE}",
+            "-blockprioritysize=0",
+            "-blockmintxfeerampstart=100",
+            # MiniWallet pads transactions to a target vsize with OP_RETURN outputs.
+            "-datacarriersize=100000",
+            "-acceptnonstdtxn=1",
+        ]]
+
+    def template_tx_count(self):
+        return len(self.nodes[0].getblocktemplate({"rules": ["segwit"]})["transactions"])
+
+    def template_size(self):
+        """Serialized size the assembler accounts for, including its reserved allowance."""
+        template = self.nodes[0].getblocktemplate({"rules": ["segwit"]})
+        return RESERVED_SIZE + sum(len(tx["data"]) // 2 for tx in template["transactions"])
+
+    def base_args(self):
+        return [a for a in self.extra_args[0] if not a.startswith("-blockmintxfeerampstart")]
+
+    def restart_with_ramp(self, ramp):
+        expected_mempool = self.nodes[0].getmempoolinfo()["size"]
+        self.restart_node(0, extra_args=self.base_args() + [f"-blockmintxfeerampstart={ramp}"])
+        assert_equal(self.nodes[0].getmempoolinfo()["size"], expected_mempool)
+
+    def fill_mempool(self, fee_rate, count):
+        # Each transaction spends its own confirmed UTXO, so every package is a single
+        # transaction and its feerate is its own.
+        for _ in range(count):
+            self.wallet.send_self_transfer(from_node=self.nodes[0], fee_rate=fee_rate,
+                                           target_vsize=TX_VSIZE, utxo_to_spend=self.utxos.pop())
+
+    def run_test(self):
+        node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+        self.generate(self.wallet, 200)
+        self.utxos = self.wallet.get_utxos(confirmed_only=True)
+        assert len(self.utxos) >= 70
+
+        # The assembler tracks nBlockWeight starting from RESERVED_WEIGHT and each transaction
+        # adds ~4000 weight, so after n transactions it stands at 8000 + ~4000n. The expected
+        # counts below all clear their boundary by far more than the few weight units a padded
+        # transaction can fall short of 4 * TX_VSIZE.
+        self.log.info("Fill the mempool with transactions paying exactly -blockmintxfee")
+        self.fill_mempool(MIN_TX_FEE, 25)
+
+        self.log.info("With the ramp disabled the block fills to the weight limit")
+        # Added while nBlockWeight + 4000 < 90000, i.e. while 8000 + 4000n < 86000, so n runs
+        # to 19 and the 20th transaction is the last one in.
+        assert_equal(self.template_tx_count(), 20)
+
+        self.log.info("A getblocktemplate request can override the configured ramp")
+        # The node is running with the ramp disabled, so a per-request ramp of 50 has to
+        # reproduce the cutoff that -blockmintxfeerampstart=50 produces below.
+        template = node.getblocktemplate({"rules": ["segwit"], "minfeeraterampstart": 50})
+        assert_equal(len(template["transactions"]), 10)
+        # Out of range is an error, not a silent clamp to "disabled", which would fill the block
+        # at the base feerate and look like success.
+        for bad in (-1, 101):
+            assert_raises_rpc_error(-8, "minfeeraterampstart must be between 0 and 100",
+                                    node.getblocktemplate,
+                                    {"rules": ["segwit"], "minfeeraterampstart": bad})
+        # The configured value still applies when the request omits it.
+        assert_equal(self.template_tx_count(), 20)
+
+        self.log.info("The ramp start defaults to 50")
+        self.restart_node(0, extra_args=self.base_args())
+        assert_equal(self.template_tx_count(), 10)
+
+        self.log.info("A ramp of 50 cuts off transactions paying exactly -blockmintxfee")
+        # The ramp starts at 45000 weight. Above it the required fee is scaled by
+        # (90000 - 45000) / (90000 - used), which exceeds 1 as soon as used passes 45000, so a
+        # transaction paying exactly the base feerate needs 8000 + 4000n <= 45000: n runs to 9
+        # and the 10th transaction is the last one in.
+        self.restart_with_ramp(50)
+        assert_equal(self.template_tx_count(), 10)
+
+        self.log.info("Transactions paying twice -blockmintxfee ride the ramp further")
+        # These sort ahead of the 1x transactions, so they are selected first. The multiplier
+        # stays at or below 2 while 45000 <= 2 * (90000 - used), i.e. used <= 67500, so it needs
+        # 8000 + 4000n <= 67500: n runs to 14 and the 15th transaction is the last one in. The
+        # 1x transactions are then rejected too, since the multiplier is already past 2.
+        self.fill_mempool(MIN_TX_FEE * 2, 25)
+        assert_equal(node.getmempoolinfo()["size"], 50)
+        # Restart so getblocktemplate rebuilds instead of serving its cached template.
+        self.restart_with_ramp(50)
+        template = node.getblocktemplate({"rules": ["segwit"]})
+        assert_equal(len(template["transactions"]), 15)
+        # Every selected transaction is one of the 2x payers.
+        assert_equal({tx["fee"] for tx in template["transactions"]}, {2000})
+
+        self.log.info("A ramp of 0 scales the required fee from an empty block")
+        # ramp_start is 0, so the multiplier is 90000 / (90000 - used). The 2x transactions are
+        # admitted while that stays at or below 2, i.e. used <= 45000: the 10th is the last in.
+        self.restart_with_ramp(0)
+        assert_equal(self.template_tx_count(), 10)
+
+        self.log.info("The ramp follows the size limit when that is the tighter one")
+        # -blockmaxsize below MAX_BLOCK_SERIALIZED_SIZE turns on byte accounting, which is the
+        # default configuration on mainnet. Here the weight limit is left wide open, so fullness
+        # has to be measured against the size limit for the ramp to engage at all.
+        size_args = [a for a in self.base_args() if not a.startswith("-blockmaxweight")]
+        size_args.append(f"-blockmaxsize={MAX_SIZE}")
+
+        self.restart_node(0, extra_args=size_args + ["-blockmintxfeerampstart=100"])
+        assert_greater_than(self.template_size(), MAX_SIZE * 0.9)
+
+        self.restart_node(0, extra_args=size_args + ["-blockmintxfeerampstart=50"])
+        # The 2x payers are admitted while (MAX_SIZE - MAX_SIZE/2) / (MAX_SIZE - used) <= 2,
+        # i.e. while used <= 0.75 * MAX_SIZE, and the 1x payers are already priced out by then.
+        ramped_size = self.template_size()
+        assert_greater_than(ramped_size, MAX_SIZE * 0.6)
+        assert_greater_than(MAX_SIZE * 0.85, ramped_size)
+
+        self.log.info("Priority transactions push the fee-selected portion up the ramp")
+        # -blockprioritysize is nonzero by default on mainnet. Its pass runs before the fee pass
+        # and is exempt from -blockmintxfee, so it fills PRIORITY_SIZE bytes (19 transactions of
+        # 1029 bytes on top of the 1000 reserved) and leaves the block at ~84000 weight, already
+        # past the 45000 ramp start. Without a ramp one more transaction still fits by weight;
+        # with a ramp of 50 the required fee at that fullness prices it out.
+        priority_args = [a for a in self.base_args()
+                         if not a.startswith("-blockprioritysize")] + \
+                        [f"-blockprioritysize={PRIORITY_SIZE}"]
+
+        self.restart_node(0, extra_args=priority_args + ["-blockmintxfeerampstart=100"])
+        assert_equal(self.template_tx_count(), 20)
+
+        self.restart_node(0, extra_args=priority_args + ["-blockmintxfeerampstart=50"])
+        template = node.getblocktemplate({"rules": ["segwit"]})
+        assert_equal(len(template["transactions"]), 19)
+        # The priority pass ignores fees, so it takes both payer classes; the fee pass, which
+        # would only have taken 2x payers, added nothing on top.
+        assert_equal({tx["fee"] for tx in template["transactions"]}, {1000, 2000})
+        assert_greater_than(RESERVED_SIZE + sum(len(tx["data"]) // 2
+                                                for tx in template["transactions"]), PRIORITY_SIZE)
+
+        self.log.info("Degenerate and extreme configurations are handled without crashing")
+        # A block with no room at all leaves used == limit, the divide-by-zero guard.
+        self.restart_node(0, extra_args=[a for a in self.base_args()
+                                         if not a.startswith("-blockmaxweight")]
+                          + ["-blockmaxweight=8000", "-blockmintxfeerampstart=50"])
+        assert_equal(self.template_tx_count(), 0)
+        # A -blockmintxfee far beyond any payable fee exercises the saturation guard, with the
+        # ramp starting from an empty block so that the scaling is applied at all.
+        self.restart_node(0, extra_args=[a for a in self.base_args()
+                                         if not a.startswith("-blockmintxfee")]
+                          + ["-blockmintxfee=1000", "-blockmintxfeerampstart=0"])
+        assert_equal(self.template_tx_count(), 0)
+        assert_equal(node.getmempoolinfo()["size"], 50)
+
+        self.log.info("The ramp applies to blocks that are actually mined, not just templates")
+        self.restart_with_ramp(50)
+        blockhash = self.generate(self.wallet, 1)[0]
+        block = node.getblock(blockhash, 2)
+        # The coinbase plus the same 15 transactions the template selected.
+        assert_equal(len(block["tx"]) - 1, 15)
+        assert_equal({tx["fee"] for tx in block["tx"][1:]}, {Decimal("0.00002000")})
+        assert_equal(node.getmempoolinfo()["size"], 35)
+        # The block stopped well short of the limit it was allowed to fill.
+        assert block["weight"] < MAX_WEIGHT * 0.8, block["weight"]
+
+        self.log.info("The ramp prices whole ancestor packages, not individual transactions")
+        # Everything above used single-transaction packages. Here each package is a CPFP pair:
+        # a parent paying 1x that could never get in alone, and a child paying 3x. The assembler
+        # sees one package of 2000 vbytes paying 4000 satoshis, so it must scale the 2000
+        # satoshi base fee for the pair, not for either transaction. At an ancestor feerate of
+        # 2x the pair is admitted while used <= 67500, and each pair costs 8000 weight:
+        # 8000 + 8000n <= 67500 admits 8 pairs, so 16 transactions.
+        # Drain the leftover singles by mining them, so the packages are the only candidates.
+        # Clearing via -persistmempool=0 would leave a stale mempool.dat for later restarts.
+        self.restart_with_ramp(100)
+        while node.getmempoolinfo()["size"] > 0:
+            self.generate(self.wallet, 1)
+        for _ in range(11):
+            parent = self.wallet.send_self_transfer(from_node=node, fee_rate=MIN_TX_FEE,
+                                                    target_vsize=TX_VSIZE,
+                                                    utxo_to_spend=self.utxos.pop())
+            self.wallet.send_self_transfer(from_node=node, fee_rate=MIN_TX_FEE * 3,
+                                           target_vsize=TX_VSIZE,
+                                           utxo_to_spend=parent["new_utxo"])
+        assert_equal(node.getmempoolinfo()["size"], 22)
+
+        # Without a ramp the pairs fill the block: 8000 + 8000n < 90000 admits 10 pairs.
+        self.restart_with_ramp(100)
+        assert_equal(self.template_tx_count(), 20)
+        self.restart_with_ramp(50)
+        template = node.getblocktemplate({"rules": ["segwit"]})
+        assert_equal(len(template["transactions"]), 16)
+        # Both halves of every selected pair are present, parents included.
+        assert_equal(sorted({tx["fee"] for tx in template["transactions"]}), [1000, 3000])
+
+        self.log.info("Out-of-range values are rejected at startup")
+        self.stop_node(0)
+        # "abc" and "" would both reach 0, the most aggressive ramp, under a lenient parse.
+        for bad in (-1, 101, "abc", ""):
+            node.assert_start_raises_init_error(
+                extra_args=self.base_args() + [f"-blockmintxfeerampstart={bad}"],
+                expected_msg="must be a number between 0 and 100",
+                match=ErrorMatch.PARTIAL_REGEX,
+            )
+
+        # Both spellings would otherwise parse as 0, the most aggressive ramp, when a user
+        # writing them plainly means "off" (which is 100).
+        self.log.info("Negated and valueless forms are rejected rather than meaning 0")
+        node.assert_start_raises_init_error(
+            extra_args=self.base_args() + ["-noblockmintxfeerampstart"],
+            expected_msg="Negating of -blockmintxfeerampstart is meaningless and therefore forbidden",
+            match=ErrorMatch.PARTIAL_REGEX,
+        )
+        node.assert_start_raises_init_error(
+            extra_args=self.base_args() + ["-blockmintxfeerampstart"],
+            expected_msg="Can not set -blockmintxfeerampstart with no value",
+            match=ErrorMatch.PARTIAL_REGEX,
+        )
+
+
+if __name__ == '__main__':
+    BlockMinTxFeeRampTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -334,6 +334,7 @@ BASE_SCRIPTS = [
     'wallet_upgradewallet.py --legacy-wallet',
     'wallet_crosschain.py',
     'mining_basic.py',
+    'mining_blockmintxfeerampstart.py',
     'mining_mainnet.py',
     'feature_signet.py',
     'p2p_mutated_blocks.py',


### PR DESCRIPTION
Closes #59.

Satoshi's client raised the fee a transaction had to pay as the block filled up, so a block was only extended when the space was paid for:

```c
// Raise the price as the block approaches full
if (nBlockSize != 1 && nNewBlockSize >= MAX_BLOCK_SIZE_GEN/2)
{
    if (nNewBlockSize >= MAX_BLOCK_SIZE_GEN)
        return MAX_MONEY;
    nMinFee *= MAX_BLOCK_SIZE_GEN / (MAX_BLOCK_SIZE_GEN - nNewBlockSize);
}
```

This was never deliberately dropped. c555400ca1 (2012) reworked `CreateNewBlock` to sort the paid area by fee-per-kb, and in the process replaced the size-dependent minimum with a flat one, which is the `blockMinFeeRate` check still in `addPackageTxs` today. The ramp survived unused in `GetMinFee` until 87cce04c17 (2013) removed it as dead code, correctly so by then: its only remaining caller passed a constant `nBlockSize` of 1000, far below the threshold that would trigger it.

### Behavior

Past `-blockmintxfeerampstart` percent full, a package's minimum fee is scaled by `(limit - ramp_start) / (limit - used)`, so it is unchanged at the ramp start, grows without bound as the block fills, and reaches `MAX_MONEY` when full. Fullness is measured against whichever of `-blockmaxsize` or `-blockmaxweight` is tighter, since only one of the two may be set.

The default is 50, where the original engaged. Setting it to 100 disables the scaling. It scales `-blockmintxfee`, so a `-blockmintxfee` of 0 also disables it. The option is also on the Mining tab, and can be overridden per `getblocktemplate` request alongside `minfeerate`.

Two things differ from the original. The multiplier is continuous instead of integer steps that jump straight to 2x at the halfway mark. And fullness excludes the candidate transaction: making the threshold depend on the candidate's own size would break the assumption in `addPackageTxs` that a package failing the check cannot be followed by one that passes, which is what lets it return instead of scanning the rest of the mempool. The threshold lags by at most one transaction as a result.

Coin-age priority transactions are exempt from `-blockmintxfee` and are selected first, so they advance the fullness counter and can start the fee pass partway up the ramp, as they did originally. At the defaults the priority area is 100000 of 300000 bytes, below the 50% start, so this only engages if `-blockprioritysize` is raised past `-blockmintxfeerampstart` percent of the block. Where it is, free transactions from aged UTXOs raise the floor for fee-paying ones.

### The default

Turning the ramp on by default is the part worth arguing about. With `-blockmintxfee=1000`, a package paying 2 sat/vB is admitted while the block is under 75% full, so a mempool whose marginal transactions sit at that feerate leaves a quarter of the block empty; measured at a full 4M weight block, 75% against 99% with the ramp off. How much that costs depends on the mempool, since selection stops where the falling feerate curve meets the rising threshold: a steep fee distribution is barely affected, a flat low-fee one fully. 50 is what the original used, and shipping it off would leave the issue unaddressed for anyone who does not go looking for the option.

### Testing

`ScaledBlockMinFee` is covered in `miner_tests` at every ramp value, including across the saturation boundary, asserting that the fee demanded never decreases as the block fills, which is the property the early return relies on. `mining_blockmintxfeerampstart.py` drives the option end to end against expected transaction counts, covering the size-limited path, `-blockprioritysize`, CPFP packages priced as whole ancestor sets, the `getblocktemplate` override, and startup validation, and mines a block to check its contents.

Enabling the ramp by default adds roughly 15% to functional test runtime, since smaller blocks mean the tests mine more of them.

### GUI

![Mining options tab](https://raw.githubusercontent.com/privkeyio/bitcoin/pr-assets/pr59-mining-tab.png)
