### PR TITLE
cmake: Check PIE link support for C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ string(APPEND CMAKE_CXX_LINK_EXECUTABLE " ${APPEND_LDFLAGS}")
 set(configure_warnings)
 
 include(CheckLinkerSupportsPIE)
-check_linker_supports_pie(configure_warnings)
+check_linker_supports_pie(configure_warnings CXX)
 
 # The core_interface library aims to encapsulate common build flags.
 # It is a usage requirement for all targets except for secp256k1, which

--- a/cmake/module/CheckLinkerSupportsPIE.cmake
+++ b/cmake/module/CheckLinkerSupportsPIE.cmake
@@ -4,24 +4,24 @@
 
 include_guard(GLOBAL)
 
-function(check_linker_supports_pie warnings)
+function(check_linker_supports_pie warnings lang)
   # Workaround for a bug in the check_pie_supported() function.
   # See:
   # - https://gitlab.kitware.com/cmake/cmake/-/issues/26463
   # - https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10034
   if(CMAKE_VERSION VERSION_LESS 3.32)
-    # CMAKE_CXX_COMPILE_OPTIONS_PIE is a list, whereas CMAKE_REQUIRED_FLAGS
+    # CMAKE_<LANG>_COMPILE_OPTIONS_PIE is a list, whereas CMAKE_REQUIRED_FLAGS
     # must be a string. Therefore, a proper conversion is required.
-    list(JOIN CMAKE_CXX_COMPILE_OPTIONS_PIE " " CMAKE_REQUIRED_FLAGS)
+    list(JOIN CMAKE_${lang}_COMPILE_OPTIONS_PIE " " CMAKE_REQUIRED_FLAGS)
   endif()
 
   include(CheckPIESupported)
-  check_pie_supported(OUTPUT_VARIABLE output LANGUAGES CXX)
-  if(CMAKE_CXX_LINK_PIE_SUPPORTED)
+  check_pie_supported(OUTPUT_VARIABLE output LANGUAGES ${lang})
+  if(CMAKE_${lang}_LINK_PIE_SUPPORTED)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON PARENT_SCOPE)
   elseif(NOT WIN32)
     # The warning is superfluous for Windows.
-    message(WARNING "PIE is not supported at link time. See the configure log for details.")
-    set(${warnings} ${${warnings}} "Position independent code disabled." PARENT_SCOPE)
+    message(WARNING "PIE is not supported at link time for ${lang}. See the configure log for details.")
+    set(${warnings} ${${warnings}} "Position independent code disabled for ${lang}." PARENT_SCOPE)
   endif()
 endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,13 @@ string(STRIP "${SECP256K1_APPEND_LDFLAGS} ${APPEND_LDFLAGS}" SECP256K1_APPEND_LD
 set(SECP256K1_APPEND_LDFLAGS ${SECP256K1_APPEND_LDFLAGS} CACHE STRING "" FORCE)
 # We want to build libsecp256k1 with the most tested RelWithDebInfo configuration.
 enable_language(C)
+# check_pie_supported() is per-language, and the top-level call only covers CXX.
+# Without this, secp256k1's C test executables are compiled with -fPIE but
+# linked without -pie.
+if(CMAKE_POSITION_INDEPENDENT_CODE)
+  check_linker_supports_pie(configure_warnings C)
+  set(configure_warnings ${configure_warnings} PARENT_SCOPE)
+endif()
 foreach(config IN LISTS CMAKE_BUILD_TYPE CMAKE_CONFIGURATION_TYPES)
   if(config STREQUAL "")
     continue()


### PR DESCRIPTION
Fixes #173

`check_linker_supports_pie()` only checks CXX, so CMake drops `-pie` when linking C executables, which are secp256k1's `tests`, `noverify_tests` and `exhaustive_tests`.

Guix isn't built with `--enable-default-pie`, so these link as ET_EXEC in release builds today and ET_DYN with this patch. On Debian/Ubuntu the compiler default hides that and blhc only sees the missing flags.

Nothing installed changes, these have no install rule. Untested on macOS.