### PR TITLE
bitcoind: process -help/-version before touching the datadir

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -119,10 +119,6 @@ static bool ParseArgs(NodeContext& node, int argc, char* argv[])
         return InitError(Untranslated(strprintf("Error parsing command line arguments: %s", error)));
     }
 
-    if (auto error = common::InitConfig(args)) {
-        return InitError(error->message, error->details);
-    }
-
     // Error out when loose non-argument tokens are encountered on command line
     for (int i = 1; i < argc; i++) {
         if (!IsSwitchChar(argv[i][0])) {
@@ -134,7 +130,9 @@ static bool ParseArgs(NodeContext& node, int argc, char* argv[])
 
 static bool ProcessInitCommands(ArgsManager& args)
 {
-    // Process help and version before taking care about datadir
+    // Process help and version before taking care about datadir, so these do
+    // not create or touch the datadir. This means the config file has not been
+    // read yet, so only command line arguments affect the output.
     if (HelpRequested(args) || args.GetBoolArg("-version", false)) {
         std::string strUsage = CLIENT_NAME " daemon version " + FormatFullVersion() + "\n";
 
@@ -278,6 +276,10 @@ MAIN_FUNCTION
     if (!ParseArgs(node, argc, argv)) return EXIT_FAILURE;
     // Process early info return commands such as -help or -version
     if (ProcessInitCommands(args)) return EXIT_SUCCESS;
+    if (auto error = common::InitConfig(args)) {
+        InitError(error->message, error->details);
+        return EXIT_FAILURE;
+    }
 
     // Start application
     if (!AppInit(node) || !Assert(node.shutdown_signal)->wait()) {


### PR DESCRIPTION
Follow-up to #329, where @luke-jr asked about the comment in `ProcessInitCommands()` claiming help and version are processed "before taking care about datadir", when in fact `ParseArgs()` calls `common::InitConfig()` first.

`InitConfig()` creates the datadir and its `wallets/` subdirectory, stats `bitcoin.conf`, and writes `settings.json`. So `bitcoind --help` and `bitcoind --version` both create `$HOME/.bitcoin`, and fail outright if it exists but is not traversable (issue #304).

Move the `InitConfig()` call after `ProcessInitCommands()`, so the comment becomes true. This is the ordering `bitcoin-cli` already uses: `ParseParameters()`, then help/version, then config.

## Testing

Built with clang and compared against a pre-patch build of the same tree.

| Scenario | Before | After | `bitcoin-cli` |
| --- | --- | --- | --- |
| fresh `$HOME`, `--version` / `--help` | creates `.bitcoin/`, `wallets/`, `settings.json` | nothing created | nothing created |
| `chmod 444 ~/.bitcoin`, `--version` / `--help` (#304) | `Permission denied`, exit 1 | exit 0 | exit 0 |
| `--help` / `--version` output | | byte-identical | |
| `--help foo` (loose token) | error, exit 1 | unchanged | |
| unparseable `bitcoin.conf`, normal startup | error, exit 1 | unchanged | |
| `-datadir=/nonexistent`, normal startup | error, exit 1 | unchanged | |

Because the config file is no longer read before help/version, three things change, all of them matching `bitcoin-cli`'s existing behavior:

| Scenario | Before | After | `bitcoin-cli` |
| --- | --- | --- | --- |
| `help-debug=1` in `bitcoin.conf`, `--help` | expands help output | no effect | no effect |
| `-conf=/nonexistent.conf -version` | error, exit 1 | prints version, exit 0 | prints version, exit 0 |
| `-datadir=/nonexistent -version` / `-help` | error, exit 1 | prints output, exit 0 | prints output, exit 0 |

`-help-debug` on the command line still works, and both `-conf` and `-datadir` are still validated on a normal startup.

`feature_help.py`, `feature_config_args.py`, `feature_settings.py` and `feature_init.py` pass.
