### PR TITLE
miner: account for package block weight using consensus weight

### DIFF
--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -119,6 +119,7 @@ private:
     int64_t m_count_with_ancestors{1};
     // Using int64_t instead of int32_t to avoid signed integer overflow issues.
     int64_t nSizeWithAncestors;
+    int64_t nWeightWithAncestors;
     CAmount nModFeesWithAncestors;
     int64_t nSigOpCostWithAncestors;
 
@@ -150,6 +151,7 @@ public:
           nSizeWithDescendants{GetTxSize()},
           nModFeesWithDescendants{nFee},
           nSizeWithAncestors{GetTxSize()},
+          nWeightWithAncestors{GetTxWeight()},
           nModFeesWithAncestors{nFee},
           nSigOpCostWithAncestors{sigOpCost} {
             CAmount nValueIn = tx->GetValueOut() + nFee;
@@ -200,7 +202,7 @@ public:
     // Adjusts the descendant state.
     void UpdateDescendantState(int32_t modifySize, CAmount modifyFee, int64_t modifyCount);
     // Adjusts the ancestor state
-    void UpdateAncestorState(int32_t modifySize, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps);
+    void UpdateAncestorState(int32_t modifySize, int64_t modifyWeight, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps);
     // Updates the modified fees with descendants/ancestors.
     void UpdateModifiedFee(CAmount fee_diff)
     {
@@ -223,6 +225,9 @@ public:
 
     uint64_t GetCountWithAncestors() const { return m_count_with_ancestors; }
     int64_t GetSizeWithAncestors() const { return nSizeWithAncestors; }
+    //! Consensus weight of this entry and all its in-mempool ancestors. Unlike
+    //! GetSizeWithAncestors(), this is never adjusted by policy.
+    int64_t GetWeightWithAncestors() const { return nWeightWithAncestors; }
     CAmount GetModFeesWithAncestors() const { return nModFeesWithAncestors; }
     int64_t GetSigOpCostWithAncestors() const { return nSigOpCostWithAncestors; }
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -243,10 +243,9 @@ void BlockAssembler::onlyUnconfirmed(CTxMemPool::setEntries& testSet)
     }
 }
 
-bool BlockAssembler::TestPackage(uint64_t packageSize, int64_t packageSigOpsCost) const
+bool BlockAssembler::TestPackage(uint64_t packageWeight, int64_t packageSigOpsCost) const
 {
-    // TODO: switch to weight-based accounting for packages instead of vsize-based accounting.
-    if (nBlockWeight + WITNESS_SCALE_FACTOR * packageSize >= m_options.nBlockMaxWeight) {
+    if (nBlockWeight + packageWeight >= m_options.nBlockMaxWeight) {
         return false;
     }
     if (nBlockSigOpsCost + packageSigOpsCost >= MAX_BLOCK_SIGOPS_COST) {
@@ -430,11 +429,15 @@ void BlockAssembler::addPackageTxs(const CTxMemPool& mempool, int& nPackagesSele
         // contain anything that is inBlock.
         assert(!inBlock.count(iter));
 
+        // packageSize stays a policy vsize: it is what the feerate gate below is
+        // denominated in. Block fit is checked against real consensus weight.
         uint64_t packageSize = iter->GetSizeWithAncestors();
+        uint64_t packageWeight = iter->GetWeightWithAncestors();
         CAmount packageFees = iter->GetModFeesWithAncestors();
         int64_t packageSigOpsCost = iter->GetSigOpCostWithAncestors();
         if (fUsingModified) {
             packageSize = modit->nSizeWithAncestors;
+            packageWeight = modit->nWeightWithAncestors;
             packageFees = modit->nModFeesWithAncestors;
             packageSigOpsCost = modit->nSigOpCostWithAncestors;
         }
@@ -444,7 +447,7 @@ void BlockAssembler::addPackageTxs(const CTxMemPool& mempool, int& nPackagesSele
             return;
         }
 
-        if (!TestPackage(packageSize, packageSigOpsCost)) {
+        if (!TestPackage(packageWeight, packageSigOpsCost)) {
             if (fUsingModified) {
                 // Since we always look at the best entry in mapModifiedTx,
                 // we must erase failed entries so that we can consider the

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -53,18 +53,21 @@ struct CTxMemPoolModifiedEntry {
     {
         iter = entry;
         nSizeWithAncestors = entry->GetSizeWithAncestors();
+        nWeightWithAncestors = entry->GetWeightWithAncestors();
         nModFeesWithAncestors = entry->GetModFeesWithAncestors();
         nSigOpCostWithAncestors = entry->GetSigOpCostWithAncestors();
     }
 
     CAmount GetModifiedFee() const { return iter->GetModifiedFee(); }
     uint64_t GetSizeWithAncestors() const { return nSizeWithAncestors; }
+    int64_t GetWeightWithAncestors() const { return nWeightWithAncestors; }
     CAmount GetModFeesWithAncestors() const { return nModFeesWithAncestors; }
     size_t GetTxSize() const { return iter->GetTxSize(); }
     const CTransaction& GetTx() const { return iter->GetTx(); }
 
     CTxMemPool::txiter iter;
     uint64_t nSizeWithAncestors;
+    int64_t nWeightWithAncestors;
     CAmount nModFeesWithAncestors;
     int64_t nSigOpCostWithAncestors;
 };
@@ -138,6 +141,7 @@ struct update_for_parent_inclusion
     {
         e.nModFeesWithAncestors -= iter->GetModifiedFee();
         e.nSizeWithAncestors -= iter->GetTxSize();
+        e.nWeightWithAncestors -= iter->GetTxWeight();
         e.nSigOpCostWithAncestors -= iter->GetSigOpCost();
     }
 
@@ -215,7 +219,7 @@ private:
     /** Remove confirmed (inBlock) entries from given set */
     void onlyUnconfirmed(CTxMemPool::setEntries& testSet);
     /** Test if a new package would "fit" in the block */
-    bool TestPackage(uint64_t packageSize, int64_t packageSigOpsCost) const;
+    bool TestPackage(uint64_t packageWeight, int64_t packageSigOpsCost) const;
     /** Perform checks on each transaction in a package:
       * locktime, premature-witness, serialized size (if necessary)
       * These checks should always succeed, and they're here

--- a/src/policy/coin_age_priority.cpp
+++ b/src/policy/coin_age_priority.cpp
@@ -148,9 +148,9 @@ bool BlockAssembler::isStillDependent(const CTxMemPool& mempool, CTxMemPool::txi
 
 bool BlockAssembler::TestForBlock(CTxMemPool::txiter iter)
 {
-    uint64_t packageSize = iter->GetSizeWithAncestors();
+    uint64_t packageWeight = iter->GetWeightWithAncestors();
     int64_t packageSigOps = iter->GetSigOpCostWithAncestors();
-    if (!TestPackage(packageSize, packageSigOps)) {
+    if (!TestPackage(packageWeight, packageSigOps)) {
         // If the block is so close to full that no more txs will fit
         // or if we've tried more than 50 times to fill remaining space
         // then flag that the block is finished

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -41,6 +41,7 @@ struct MinerTestingSetup : public TestingSetup {
     void TestPackageSelection(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     void TestBasicMining(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst, int baseheight) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     void TestPrioritisedMining(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void TestDiscountedVsizeWeightLimit(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool TestSequenceLocks(const CTransaction& tx, CTxMemPool& tx_mempool) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         CCoinsViewMemPool view_mempool{&m_node.chainman->ActiveChainstate().CoinsTip(), tx_mempool};
@@ -570,6 +571,64 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
     BOOST_CHECK_EQUAL(block.vtx.size(), 5U);
 }
 
+// A policy-only weight discount (negative extra weight) makes an entry's vsize
+// smaller than its real consensus weight. TestPackage() extrapolates block usage
+// from that vsize, so the assembler must not rely on it alone: AddToBlock()
+// accumulates the real weight, and the block must still respect nBlockMaxWeight.
+void MinerTestingSetup::TestDiscountedVsizeWeightLimit(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst)
+{
+    CTxMemPool& tx_mempool{MakeMempool()};
+    auto mining{MakeMining()};
+    BlockAssembler::Options options;
+    options.coinbase_output_script = scriptPubKey;
+    options.block_reserved_weight = DEFAULT_BLOCK_RESERVED_WEIGHT;
+
+    LOCK(tx_mempool.cs);
+    TestMemPoolEntryHelper entry;
+
+    // One sizeable transaction per available coinbase, each with half its weight
+    // discounted away for policy purposes (the maximum the coinblocks discount
+    // applies).
+    // The fee has to clear blockMinFeeRate against the *discounted* vsize,
+    // otherwise addPackageTxs() bails out before the weight limit can bind.
+    constexpr CAmount fee{1000000};
+    int32_t tx_weight{0};
+    for (size_t i = 0; i < txFirst.size(); ++i) {
+        CMutableTransaction tx;
+        tx.vin.resize(1);
+        tx.vin[0].scriptSig = CScript() << OP_1;
+        tx.vin[0].prevout.hash = txFirst[i]->GetHash();
+        tx.vin[0].prevout.n = 0;
+        tx.vout.assign(200, CTxOut{(5000000000LL - fee) / 200, CScript() << OP_1});
+        tx_weight = GetTransactionWeight(CTransaction(tx));
+        AddToMempool(tx_mempool, entry.Fee(fee).SpendsCoinbase(true).ExtraWeight(-tx_weight / 2).FromTx(tx));
+    }
+    BOOST_REQUIRE(tx_weight > 0);
+    BOOST_REQUIRE_EQUAL(tx_mempool.size(), txFirst.size());
+
+    // Pick a limit that lands inside the window where the discounted estimate
+    // (4 * vsize == tx_weight / 2) still appears to fit but the real weight does
+    // not: room for one transaction plus one discounted estimate.
+    options.nBlockMaxWeight = options.block_reserved_weight + tx_weight + (tx_weight / 2) + 1;
+
+    const auto block_template{mining->createNewBlock(options)};
+    BOOST_REQUIRE(block_template);
+    const CBlock& block{block_template->getBlock()};
+
+    // Mirror BlockAssembler::nBlockWeight: the reserved weight it starts from
+    // plus the real weight of every transaction it selected.
+    uint64_t assembled{options.block_reserved_weight};
+    for (size_t i = 1; i < block.vtx.size(); ++i) {
+        assembled += GetTransactionWeight(*block.vtx[i]);
+    }
+    // The limit must actually bind, otherwise this test proves nothing.
+    BOOST_REQUIRE(block.vtx.size() > 1);
+    BOOST_REQUIRE(block.vtx.size() - 1 < txFirst.size());
+    BOOST_CHECK_MESSAGE(assembled <= options.nBlockMaxWeight,
+                        "assembled weight " << assembled << " exceeds nBlockMaxWeight "
+                                            << options.nBlockMaxWeight);
+}
+
 void MinerTestingSetup::TestPrioritisedMining(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst)
 {
     auto mining{MakeMining()};
@@ -728,6 +787,11 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     SetMockTime(0);
 
     TestPackageSelection(scriptPubKey, txFirst);
+
+    m_node.chainman->ActiveChain().Tip()->nHeight--;
+    SetMockTime(0);
+
+    TestDiscountedVsizeWeightLimit(scriptPubKey, txFirst);
 
     m_node.chainman->ActiveChain().Tip()->nHeight--;
     SetMockTime(0);

--- a/src/test/util/txmempool.cpp
+++ b/src/test/util/txmempool.cpp
@@ -38,7 +38,7 @@ CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CMutableTransaction& tx) co
 
 CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CTransactionRef& tx) const
 {
-    return CTxMemPoolEntry{tx, nFee, TicksSinceEpoch<std::chrono::seconds>(time), nHeight, m_sequence, COIN_AGE_CACHE_ZERO, spendsCoinbase, /*extra_weight=*/0, sigOpCost, lp};
+    return CTxMemPoolEntry{tx, nFee, TicksSinceEpoch<std::chrono::seconds>(time), nHeight, m_sequence, COIN_AGE_CACHE_ZERO, spendsCoinbase, extra_weight, sigOpCost, lp};
 }
 
 std::optional<std::string> CheckPackageMempoolAcceptResult(const Package& txns,

--- a/src/test/util/txmempool.h
+++ b/src/test/util/txmempool.h
@@ -25,6 +25,7 @@ struct TestMemPoolEntryHelper {
     uint64_t m_sequence{0};
     bool spendsCoinbase{false};
     unsigned int sigOpCost{4};
+    int32_t extra_weight{0};
     LockPoints lp;
 
     CTxMemPoolEntry FromTx(const CMutableTransaction& tx) const;
@@ -37,6 +38,7 @@ struct TestMemPoolEntryHelper {
     TestMemPoolEntryHelper& Sequence(uint64_t _seq) { m_sequence = _seq; return *this; }
     TestMemPoolEntryHelper& SpendsCoinbase(bool _flag) { spendsCoinbase = _flag; return *this; }
     TestMemPoolEntryHelper& SigOpsCost(unsigned int _sigopsCost) { sigOpCost = _sigopsCost; return *this; }
+    TestMemPoolEntryHelper& ExtraWeight(int32_t _extra_weight) { extra_weight = _extra_weight; return *this; }
 };
 
 /** Check expected properties for every PackageMempoolAcceptResult, regardless of value. Returns

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -104,7 +104,7 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap& cachedDescendan
             cachedDescendants[updateIt].insert(mapTx.iterator_to(descendant));
             // Update ancestor state for each descendant
             mapTx.modify(mapTx.iterator_to(descendant), [=](CTxMemPoolEntry& e) {
-              e.UpdateAncestorState(updateIt->GetTxSize(), updateIt->GetModifiedFee(), 1, updateIt->GetSigOpCost());
+              e.UpdateAncestorState(updateIt->GetTxSize(), updateIt->GetTxWeight(), updateIt->GetModifiedFee(), 1, updateIt->GetSigOpCost());
             });
             // Don't directly remove the transaction here -- doing so would
             // invalidate iterators in cachedDescendants. Mark it for removal
@@ -317,14 +317,16 @@ void CTxMemPool::UpdateEntryForAncestors(txiter it, const setEntries &setAncesto
 {
     int64_t updateCount = setAncestors.size();
     int64_t updateSize = 0;
+    int64_t updateWeight = 0;
     CAmount updateFee = 0;
     int64_t updateSigOpsCost = 0;
     for (txiter ancestorIt : setAncestors) {
         updateSize += ancestorIt->GetTxSize();
+        updateWeight += ancestorIt->GetTxWeight();
         updateFee += ancestorIt->GetModifiedFee();
         updateSigOpsCost += ancestorIt->GetSigOpCost();
     }
-    mapTx.modify(it, [=](CTxMemPoolEntry& e){ e.UpdateAncestorState(updateSize, updateFee, updateCount, updateSigOpsCost); });
+    mapTx.modify(it, [=](CTxMemPoolEntry& e){ e.UpdateAncestorState(updateSize, updateWeight, updateFee, updateCount, updateSigOpsCost); });
 }
 
 void CTxMemPool::UpdateChildrenForRemoval(txiter it)
@@ -351,10 +353,11 @@ void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, b
             CalculateDescendants(removeIt, setDescendants);
             setDescendants.erase(removeIt); // don't update state for self
             int32_t modifySize = -removeIt->GetTxSize();
+            int64_t modifyWeight = -removeIt->GetTxWeight();
             CAmount modifyFee = -removeIt->GetModifiedFee();
             int modifySigOps = -removeIt->GetSigOpCost();
             for (txiter dit : setDescendants) {
-                mapTx.modify(dit, [=](CTxMemPoolEntry& e){ e.UpdateAncestorState(modifySize, modifyFee, -1, modifySigOps); });
+                mapTx.modify(dit, [=](CTxMemPoolEntry& e){ e.UpdateAncestorState(modifySize, modifyWeight, modifyFee, -1, modifySigOps); });
             }
         }
     }
@@ -401,10 +404,12 @@ void CTxMemPoolEntry::UpdateDescendantState(int32_t modifySize, CAmount modifyFe
     assert(m_count_with_descendants > 0);
 }
 
-void CTxMemPoolEntry::UpdateAncestorState(int32_t modifySize, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps)
+void CTxMemPoolEntry::UpdateAncestorState(int32_t modifySize, int64_t modifyWeight, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps)
 {
     nSizeWithAncestors += modifySize;
     assert(nSizeWithAncestors > 0);
+    nWeightWithAncestors += modifyWeight;
+    assert(nWeightWithAncestors > 0);
     nModFeesWithAncestors = SaturatingAdd(nModFeesWithAncestors, modifyFee);
     m_count_with_ancestors += modifyCount;
     assert(m_count_with_ancestors > 0);
@@ -840,17 +845,20 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
         auto ancestors{AssumeCalculateMemPoolAncestors(__func__, *it, Limits::NoLimits())};
         uint64_t nCountCheck = ancestors.size() + 1;
         int32_t nSizeCheck = it->GetTxSize();
+        int64_t nWeightCheck = it->GetTxWeight();
         CAmount nFeesCheck = it->GetModifiedFee();
         int64_t nSigOpCheck = it->GetSigOpCost();
 
         for (txiter ancestorIt : ancestors) {
             nSizeCheck += ancestorIt->GetTxSize();
+            nWeightCheck += ancestorIt->GetTxWeight();
             nFeesCheck += ancestorIt->GetModifiedFee();
             nSigOpCheck += ancestorIt->GetSigOpCost();
         }
 
         assert(it->GetCountWithAncestors() == nCountCheck);
         assert(it->GetSizeWithAncestors() == nSizeCheck);
+        assert(it->GetWeightWithAncestors() == nWeightCheck);
         assert(it->GetSigOpCostWithAncestors() == nSigOpCheck);
         assert(it->GetModFeesWithAncestors() == nFeesCheck);
         // Sanity check: we are walking in ascending ancestor count order.
@@ -1048,7 +1056,7 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, double dPriorityDelt
             CalculateDescendants(it, setDescendants);
             setDescendants.erase(it);
             for (txiter descendantIt : setDescendants) {
-                mapTx.modify(descendantIt, [=](CTxMemPoolEntry& e){ e.UpdateAncestorState(0, nFeeDelta, 0, 0); });
+                mapTx.modify(descendantIt, [=](CTxMemPoolEntry& e){ e.UpdateAncestorState(0, 0, nFeeDelta, 0, 0); });
             }
             ++nTransactionsUpdated;
         }


### PR DESCRIPTION
`TestPackage()` decided whether a package fits in the block by scaling its policy vsize by `WITNESS_SCALE_FACTOR`, while `AddToBlock()` adds the real consensus weight. That is only correct while policy vsize is never below weight/4. It holds today because the only policy weight adjustment is the `-datacarriercost` surcharge, which is never negative. Any policy discount breaks it, and block assembly then exceeds `-blockmaxweight`.

Track the consensus weight of each entry and its in-mempool ancestors, the same way ancestor sigop cost is already tracked, and use that in `TestPackage()`. This resolves the existing TODO there.

No behavior change on its own: with `extra_weight >= 0` the old estimate is always at least the package weight, so every package accepted before is still accepted. `addPriorityTxs()` is covered as well, through `TestForBlock()`.

The added unit test drives a negative policy weight through `CTxMemPoolEntry`. Without this change it fails:

```
assembled weight 24416 exceeds nBlockMaxWeight 20313
```
