### PR TITLE
GUI: Keep the RPC console on the wallet it is set to

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -412,7 +412,6 @@ void BitcoinGUI::createActions()
                 connect(action, &QAction::triggered, [this, path] {
                     auto activity = new OpenWalletActivity(m_wallet_controller, this);
                     connect(activity, &OpenWalletActivity::opened, this, &BitcoinGUI::setCurrentWallet, Qt::QueuedConnection);
-                    connect(activity, &OpenWalletActivity::opened, rpcConsole, &RPCConsole::setCurrentWallet, Qt::QueuedConnection);
                     activity->open(path);
                 });
             }
@@ -442,7 +441,6 @@ void BitcoinGUI::createActions()
 
             auto activity = new RestoreWalletActivity(m_wallet_controller, this);
             connect(activity, &RestoreWalletActivity::restored, this, &BitcoinGUI::setCurrentWallet, Qt::QueuedConnection);
-            connect(activity, &RestoreWalletActivity::restored, rpcConsole, &RPCConsole::setCurrentWallet, Qt::QueuedConnection);
 
             auto backup_file_path = fs::PathFromString(backup_file.toStdString());
             activity->restore(backup_file_path, wallet_name.toStdString());
@@ -1196,7 +1194,6 @@ void BitcoinGUI::createWallet()
 #endif // USE_SQLITE
     auto activity = new CreateWalletActivity(getWalletController(), this);
     connect(activity, &CreateWalletActivity::created, this, &BitcoinGUI::setCurrentWallet);
-    connect(activity, &CreateWalletActivity::created, rpcConsole, &RPCConsole::setCurrentWallet);
     activity->create();
 #endif // ENABLE_WALLET
 }


### PR DESCRIPTION
Bugfix-only alternative to #331, for the case where the feature in that PR is not wanted.

99c0eb9701 ("Fix RPCConsole wallet selection") made the RPC console follow the wallet opened from the menu bar, but only for the open, restore and create activities. The toolbar selector and wallet migration were never connected, so the console follows the main window on some paths and not others, and a wallet deliberately picked in the console gets overridden by the paths that are connected.

This drops those three connects, so the console keeps whatever wallet it is set to. It defaults to the first wallet loaded, as `RPCConsole::addWallet()` already does, and only the console's own selector changes it.

Based on branch-26 (96ec3b67a7a), the oldest branch carrying the connects.

## Testing

`bitcoin-qt` on regtest, started with `wallet_a` and `wallet_b`, console selector on `wallet_a`.

- File > Open Wallet on a third wallet: the main window switches to it, the console stays on `wallet_a` and commands run against `wallet_a`. Before this change the console jumped to the newly opened wallet.
- File > Create Wallet: same, the console stays on `wallet_a`.
- Merged into 29.x-knots and `test_bitcoin-qt` passes.
