### PR TITLE
depends: update libevent to 2.1.13-stable

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -6,6 +6,7 @@ $(package)_sha256_hash=f7e9383b8c0baa81b687e5b5eecc01beefaf1b19b64151d95ed61647f
 $(package)_patches=cmake_fixups.patch
 $(package)_patches += netbsd_fixup.patch
 $(package)_patches += winver_fixup.patch
+$(package)_patches += cl_te_fixup.patch
 $(package)_build_subdir=build
 
 # When building for Windows, we set _WIN32_WINNT to target the same Windows
@@ -27,7 +28,8 @@ endef
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/cmake_fixups.patch && \
   patch -p1 < $($(package)_patch_dir)/netbsd_fixup.patch && \
-  patch -p1 < $($(package)_patch_dir)/winver_fixup.patch
+  patch -p1 < $($(package)_patch_dir)/winver_fixup.patch && \
+  patch -p1 < $($(package)_patch_dir)/cl_te_fixup.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -1,8 +1,8 @@
 package=libevent
-$(package)_version=2.1.12-stable
+$(package)_version=2.1.13-stable
 $(package)_download_path=https://github.com/libevent/libevent/releases/download/release-$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
+$(package)_sha256_hash=f7e9383b8c0baa81b687e5b5eecc01beefaf1b19b64151d95ed61647fe7a315c
 $(package)_patches=cmake_fixups.patch
 $(package)_patches += netbsd_fixup.patch
 $(package)_patches += winver_fixup.patch

--- a/depends/patches/libevent/cl_te_fixup.patch
+++ b/depends/patches/libevent/cl_te_fixup.patch
@@ -1,0 +1,54 @@
+Tolerate requests sending both Content-Length and Transfer-Encoding.
+
+libevent 2.1.13 rejects these outright. RFC 9112 section 6.3 also permits
+processing the request according to the Transfer-Encoding alone, provided
+the connection is closed afterwards, which avoids breaking existing RPC
+clients that send both headers.
+
+Only requests whose Transfer-Encoding actually frames the body are accepted
+this way; duplicate Content-Length and non-chunked encodings stay ambiguous
+and are still rejected.
+
+diff --git a/http.c b/http.c
+index 18775872..cc115061 100644
+--- a/http.c
++++ b/http.c
+@@ -2267,11 +2267,13 @@ evhttp_validate_len_and_encoding_(struct evhttp_request *req)
+ 	struct evkeyval *h = NULL;
+ 	int is_chunked = 0;
+ 	int dup_cl = 0;
++	int te_and_cl = 0;
+ 
+-	if (evhttp_find_header(headers, "Transfer-Encoding") != NULL &&
+-	    evhttp_find_unique_header(headers, "Content-Length", &dup_cl) != NULL) {
+-		/* Both TE and CL were present: Not allowed. */
+-		return -1;
++	if (evhttp_find_unique_header(headers, "Content-Length", &dup_cl) != NULL &&
++	    evhttp_find_header(headers, "Transfer-Encoding") != NULL) {
++		/* Both TE and CL were present. Defer the decision until we know
++		 * whether the Transfer-Encoding actually frames the body. */
++		te_and_cl = 1;
+ 	}
+ 	if (dup_cl) {
+ 		/* CL was present twice: Not allowed.
+@@ -2307,6 +2309,20 @@ evhttp_validate_len_and_encoding_(struct evhttp_request *req)
+ 
+ 	req->chunked = is_chunked;
+ 
++	if (te_and_cl) {
++		/* RFC 9112 section 6.3 permits processing such a message
++		 * according to the Transfer-Encoding alone, as long as the
++		 * connection is closed afterwards. Only do so for requests
++		 * whose encoding actually frames the body; anything else stays
++		 * ambiguous and is still rejected. */
++		if (!is_chunked || req->kind != EVHTTP_REQUEST)
++			return -1;
++		while (evhttp_remove_header(headers, "Content-Length") == 0)
++			continue;
++		evhttp_remove_header(headers, "Connection");
++		evhttp_add_header(headers, "Connection", "close");
++	}
++
+ 	return 0;
+ }
+ 

--- a/depends/patches/libevent/winver_fixup.patch
+++ b/depends/patches/libevent/winver_fixup.patch
@@ -58,7 +58,7 @@ index 2ec80560..8647f72b 100644
  #endif
  
 diff --git a/evutil.c b/evutil.c
-index 9817f086..8537ffe8 100644
+index bb06087a..a613fa2b 100644
 --- a/evutil.c
 +++ b/evutil.c
 @@ -24,6 +24,14 @@
@@ -67,8 +67,8 @@ index 9817f086..8537ffe8 100644
  
 +#ifdef _WIN32
 +#ifndef _WIN32_WINNT
-+/* For structs needed by GetAdaptersAddresses */
-+#define _WIN32_WINNT 0x0501
++/* For structs needed by GetAdaptersAddresses and AI_NUMERICSERV */
++#define _WIN32_WINNT 0x0600
 +#endif
 +#define WIN32_LEAN_AND_MEAN
 +#endif
@@ -76,22 +76,20 @@ index 9817f086..8537ffe8 100644
  #include "event2/event-config.h"
  #include "evconfig-private.h"
  
-@@ -31,15 +39,10 @@
+@@ -31,13 +39,7 @@
  #include <winsock2.h>
  #include <winerror.h>
  #include <ws2tcpip.h>
+-#ifndef _WIN32_WINNT
+-/* For structs needed by GetAdaptersAddresses and AI_NUMERICSERV */
+-#define _WIN32_WINNT 0x0600
+-#endif
 -#define WIN32_LEAN_AND_MEAN
  #include <windows.h>
 -#undef WIN32_LEAN_AND_MEAN
  #include <io.h>
  #include <tchar.h>
  #include <process.h>
--#undef _WIN32_WINNT
--/* For structs needed by GetAdaptersAddresses */
--#define _WIN32_WINNT 0x0501
- #include <iphlpapi.h>
- #include <netioapi.h>
- #endif
 diff --git a/listener.c b/listener.c
 index f5c00c9c..d1080e76 100644
 --- a/listener.c

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -19,7 +19,7 @@ Bitcoin Core requires one of the following compilers.
 | --- | --- | --- | --- | --- |
 | CMake | [link](https://cmake.org/) | N/A | [3.22](https://github.com/bitcoin/bitcoin/pull/30454) | No |
 | [Boost](../depends/packages/boost.mk) | [link](https://www.boost.org/users/download/) | [1.81.0](https://github.com/bitcoin/bitcoin/pull/26557) | [1.73.0](https://github.com/bitcoin/bitcoin/pull/29066) | No |
-| [libevent](../depends/packages/libevent.mk) | [link](https://github.com/libevent/libevent/releases) | [2.1.12-stable](https://github.com/bitcoin/bitcoin/pull/21991) | [2.1.8](https://github.com/bitcoin/bitcoin/pull/24681) | No |
+| [libevent](../depends/packages/libevent.mk) | [link](https://github.com/libevent/libevent/releases) | 2.1.13-stable | [2.1.8](https://github.com/bitcoin/bitcoin/pull/24681) | No |
 | glibc | [link](https://www.gnu.org/software/libc/) | N/A | [2.31](https://github.com/bitcoin/bitcoin/pull/29987) | Yes |
 | Linux Kernel (if building that platform) | [link](https://www.kernel.org/) | N/A | [3.17.0](https://github.com/bitcoin/bitcoin/pull/27699) | Yes |
 


### PR DESCRIPTION
Updates libevent from 2.1.12-stable (2020) to 2.1.13-stable, released 2026-07-01. This is a security release.

Fixes relevant to the modules we use (`evhttp` and `bufferevent`, via `src/httpserver.cpp`):

- Heap out-of-bounds write with AF_UNIX sockets (GHSA-cvq5-vrvr-j338)
- HTTP trailer discarding to prevent header smuggling (GHSA-2gmv-p5m7-98p6)
- Restricted header parsing against request smuggling (GHSA-q39v-w2g7-gr8j)
- Stricter CRLF and null-byte handling in headers (GHSA-jcwh-pvf2-73p2)
- Dangling pointer in `evbuffer_add_reference` (GHSA-c2pj-cg4r-88c8)

The release also fixes issues in `evdns`, `evrpc` and `evtag`, which are not used here.

libevent is built statically into the release binaries (`-DEVENT__LIBRARY_TYPE=STATIC`), so users cannot pick these fixes up from their system packages. Header parsing is reachable pre-authentication when `-rest` is enabled, since REST accepts public requests.

`winver_fixup.patch` is rebased: upstream restructured `evutil.c` in 2.1.13 and now uses `_WIN32_WINNT 0x0600` instead of `0x0501`, so one hunk no longer applied. The rebased patch keeps upstream's `0x0600` and preserves the original intent of defining `_WIN32_WINNT` and `WIN32_LEAN_AND_MEAN` before the first include. The other three files it touches were unchanged upstream. `cmake_fixups.patch` and `netbsd_fixup.patch` apply unmodified.

Tarball verification:

- sha256 `f7e9383b8c0baa81b687e5b5eecc01beefaf1b19b64151d95ed61647fe7a315c`
- Signed by Nick Mathewson (key `7A02B3521DC75C542BA015456AFEE6D49E92B601`). Note the signing key differs from 2.1.12, which was signed by Azat Khuzhin. Both are libevent maintainers.

The second commit stops libevent rejecting requests that send both `Content-Length` and `Transfer-Encoding`. 2.1.13 returns a 400 for these, which breaks RPC clients that send both (DATUM Gateway). This affects any bitcoind built against 2.1.13, not just Knots.

RFC 9112 section 6.3 allows a server to either reject such a request or process it per the `Transfer-Encoding` alone, as long as the connection is closed afterwards. This takes the second route for requests: drop `Content-Length`, let `Transfer-Encoding` govern, force the connection closed. Only encodings that actually frame the body are accepted this way; responses, duplicate `Content-Length` and non-chunked encodings are still rejected exactly as upstream does.

Closing the connection is what prevents the desync, so smuggled bytes are discarded rather than read as the next request.

| Request | 2.1.13 | with this patch |
| --- | --- | --- |
| `Content-Length` only | 200, keep-alive | 200, keep-alive |
| `Content-Length` + `Transfer-Encoding` | 400 | 200, connection closed |
| CL.TE smuggling attempt | 400 | 1 response, connection closed |

It is a separate commit so it can be reverted on its own if the affected clients are fixed first.

Testing done on x86_64-linux-gnu:

- `make -C depends` builds libevent 2.1.13 and stages `2.1.13-stable`
- `bitcoind` embeds `2.1.13-stable`, `ldd` shows no dynamic libevent
- `interface_http.py`, `interface_rest.py`, `rpc_bind.py` pass
- Full functional suite passes (318 tests, no failures)
- Unit tests pass
- Cross-compiled libevent for `x86_64-w64-mingw32` with the depends flags to confirm the rebased Windows patch applies and compiles
- Ran DATUM Gateway against a regtest node. Without the second commit it gets a 400 on every `getblocktemplate` and never fetches a template; with it, templates are fetched normally and new blocks are followed with no errors
