### PR TITLE
test: unitester escaping

### DIFF
--- a/src/univalue/test/round1.json
+++ b/src/univalue/test/round1.json
@@ -1,1 +1,1 @@
-["\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007f"]
+["\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r\u000e\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007f"]

--- a/src/univalue/test/unitester.cpp
+++ b/src/univalue/test/unitester.cpp
@@ -1,5 +1,6 @@
 // Copyright 2014 BitPay Inc.
-// Copyright (c) 2015-present The Bitcoin Core developers
+// Copyright (c) 2015-2025 The Bitcoin Core developers
+// Copyright (c) 2026-present The Bitcoin Knots developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -72,6 +73,69 @@ static std::string rtrim(std::string s)
     return s;
 }
 
+/**
+ * @brief Canonicalizes JSON string representations for direct byte-level comparisons.
+ *
+ * Normalizes Unicode escape sequences (`\uXXXX`) within a raw JSON string to establish
+ * a consistent canonical form for test assertions. This accounts for variations permitted
+ * by the RFC 8259 / ECMA-404 JSON standards:
+ *  - **Case Insensitivity (RFC 8259 section 7 / ECMA-404 section 9):** Hexadecimal digits
+ *    in `\uXXXX` escapes are case-insensitive on input. All valid `\uXXXX` hex digits are
+ *    normalized to lowercase.
+ *
+ * Malformed or truncated escape sequences (e.g., `\u12` or non-hex characters) are left
+ * untouched to guarantee memory safety.
+ *
+ * @param s The input JSON string to be normalized.
+ * @return std::string A canonicalized copy of the string ready for comparison.
+ */
+
+static std::string canonicalize_json_string(const std::string& s) {
+    std::string result;
+    result.reserve(s.length());
+
+    const size_t len = s.length();
+
+    for (size_t i = 0; i < len; ++i) {
+        // Handle literal backslash pair (\\).
+        // Skip over the second backslash so it isn't misread as the start of a \u sequence.
+        if (s[i] == '\\' && i + 1 < len && s[i + 1] == '\\') {
+            result.push_back(s[i]);
+            result.push_back(s[i + 1]);
+            i += 1; // Advance past the second backslash
+            continue;
+        }
+
+        // Check if we have a \uXXXX sequence with 4 hex digits
+        if (s[i] == '\\' && i + 5 < len && s[i + 1] == 'u') {
+            bool valid_hex = true;
+            for (size_t j = i + 2; j < i + 6; ++j) {
+                const unsigned char h = static_cast<unsigned char>(s[j]);
+                if (!((h >= '0' && h <= '9') || (h >= 'a' && h <= 'f') || (h >= 'A' && h <= 'F'))) {
+                    valid_hex = false;
+                    break;
+                }
+            }
+
+            if (valid_hex) {
+                // Standard normalization: keep \uXXXX but force digits to lowercase
+                result += "\\u";
+                for (size_t j = i + 2; j < i + 6; ++j) {
+                    const char h = s[j];
+                    result.push_back((h >= 'A' && h <= 'F') ? static_cast<char>(h - 'A' + 'a') : h);
+                }
+                i += 5;
+                continue;
+            }
+        }
+
+        // Append normal character
+        result.push_back(s[i]);
+    }
+
+    return result;
+}
+
 static void runtest(std::string filename, const std::string& jdata)
 {
     std::string prefix = filename.substr(0, 4);
@@ -91,8 +155,9 @@ static void runtest(std::string filename, const std::string& jdata)
     }
 
     if (wantRoundTrip) {
-        std::string odata = val.write(0, 0);
-        assert(odata == rtrim(jdata));
+        const std::string idata = canonicalize_json_string(rtrim(jdata));
+        const std::string odata = canonicalize_json_string(val.write(0, 0));
+        assert(idata == odata);
     }
 }
 


### PR DESCRIPTION
# test: Canonicalises JSON string representations for direct byte-level comparisons in unitester.

# The Problem
The existing unitester does not perform case-insensitive comparisons when comparing `\uXXXX` escape sequences, causing it to report cases as failures when they are correct.

# Description
Normalises Unicode escape sequences (`\uXXXX`) within a raw JSON string to establish a consistent canonical form for test assertions. This accounts for variations permitted by the RFC 8259 / ECMA-404 JSON standards:
 - **Case Insensitivity (RFC 8259 §7 / ECMA-404 §9):** Hexadecimal digits in `\uXXXX` escapes are case-insensitive on input. All valid `\uXXXX` hex digits are normalised to lowercase.

`./src/univalue/test/round1.json` has had ``\u000f`` changed to `\u000F` to make the test fail if the fix is not applied.


# Testing

```
cmake -B build-yyjson-off \
  -DRDTS_CONSENT=IMPLICIT \
  -DCMAKE_BUILD_TYPE=Release \
  -DBUILD_BENCH=ON

nice cmake --build build-yyjson-off -j$(nproc)
nice ctest --test-dir build-yyjson-off -R univalue
```

Expected output:
```
Internal ctest changing into directory: /home/odroid/bitcoin/build-yyjson-off
Test project /home/odroid/bitcoin/build-yyjson-off
    Start 3: univalue_test
1/2 Test #3: univalue_test ....................   Passed    0.04 sec
    Start 4: univalue_object_test
2/2 Test #4: univalue_object_test .............   Passed    0.01 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   0.05 sec

```

If you edit `./src/univalue/test/unitester.cpp`, and make canonicalize_json_string() immediately return the input string (so there is no processing):
```
std::string canonicalize_json_string(const std::string& s) {
    return(s);
```

You should get a failed test result.
```
nice ctest --test-dir build-yyjson-off -R univalue
Internal ctest changing into directory: /home/odroid/bitcoin/build-yyjson-off
Test project /home/odroid/bitcoin/build-yyjson-off
    Start 3: univalue_test
1/2 Test #3: univalue_test ....................Subprocess aborted***Exception:   0.18 sec
    Start 4: univalue_object_test
2/2 Test #4: univalue_object_test .............   Passed    0.00 sec

50% tests passed, 1 tests failed out of 2
```
