### PR TITLE
validation: correct inherited RDTS-invalid blocks at startup

### DIFF
--- a/doc/release-notes-rdts-migration.md
+++ b/doc/release-notes-rdts-migration.md
@@ -1,0 +1,15 @@
+Notifications and chain state
+-----------------------------
+
+- A node enforcing the BIP110/RDTS mandatory-signaling rule now corrects chain
+  state inherited from a client that was not enforcing RDTS. Such a data
+  directory can contain blocks that violate the rule; normal startup does not
+  re-validate inherited history, so at startup the node marks every offending
+  block invalid (whether or not on the active chain) and reorganizes to the best
+  valid chain, mirroring the approach used for BIP148. The verdict is derived
+  from the stored block headers, so it requires no additional on-disk data and
+  cannot misfire on a chain that was validated correctly. It covers the
+  mandatory-signaling rule only; output-size and script-push violations are not
+  header-derivable and remain a `-reindex-chainstate` matter. If the block
+  data needed to rewind to an offending block has been pruned, the node refuses
+  to start and asks the operator to `-reindex` rather than run on an invalid chain.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2146,7 +2146,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             do_retry = HasTestOption(args, "reindex_after_failure_noninteractive_yes") ||
             uiInterface.ThreadSafeQuestion(
             error + Untranslated(".\n\n") + _("Do you want to rebuild the databases now?"),
-            error.original + ".\nPlease restart with -reindex or -reindex-chainstate to recover.",
+            error.original + (args.GetIntArg("-prune", 0) ? ".\nPlease restart with -reindex to recover." : ".\nPlease restart with -reindex or -reindex-chainstate to recover."),
             "", CClientUIInterface::MSG_ERROR | CClientUIInterface::BTN_ABORT);
         } else {
             LogPrintf("Automatically running a reindex.\n");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2109,6 +2109,34 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         do_reindex_chainstate,
         kernel_cache_sizes,
         args);
+
+    // A data directory advanced by a client that was not enforcing BIP110/RDTS
+    // can contain blocks that violate RDTS mandatory signaling. Normal startup
+    // does not re-validate inherited history, so correct such state now: mark
+    // the offending blocks invalid and reorganize to the best valid chain. If
+    // the data needed to rewind has been pruned, report it as a load failure so
+    // the reindex prompt below offers recovery, rather than running on (or
+    // partially rewinding) an invalid chain.
+    //
+    // Skip this on any reindex: -reindex and -reindex-chainstate re-connect blocks
+    // through ConnectBlock, which re-enforces the rule and rejects violators during
+    // the rebuild, so the correction is redundant. It is also unsafe there: a
+    // chainstate reindex returns here with the active chain not yet built, and
+    // correcting against an empty chain would fail an internal consistency check.
+    //
+    // The block index is shared, so the invalid marks apply to any background
+    // (assumeutxo) chainstate too; only the active chainstate is reorganized here.
+    // Safe while every snapshot base stays below the RDTS window (as today); a
+    // future snapshot base above the window would need re-review.
+    if (status == ChainstateLoadStatus::SUCCESS && !ShutdownRequested(node) &&
+            !do_reindex && !do_reindex_chainstate) {
+        bilingual_str rdts_error;
+        if (!node.chainman->ActiveChainstate().CorrectRdtsInvalidBlocks(rdts_error)) {
+            status = ChainstateLoadStatus::FAILURE;
+            error = rdts_error;
+        }
+    }
+
     if (status == ChainstateLoadStatus::FAILURE && !do_reindex && !ShutdownRequested(node)) {
         // If reindex=auto, directly start the reindex
         bool fAutoReindex = (args.GetArg("-reindex", "0") == "auto");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5432,6 +5432,128 @@ bool Chainstate::NeedsRedownload() const
     return false;
 }
 
+std::vector<CBlockIndex*> Chainstate::FindRdtsSignalingViolations() const
+{
+    AssertLockHeld(cs_main);
+
+    std::vector<CBlockIndex*> violators;
+
+    const Consensus::Params& params{m_chainman.GetConsensus()};
+    // RDTS is the only Knots deployment that sets a mandatory-signaling
+    // deadline; this is deliberately scoped to it. A future deployment with
+    // max_activation_height set would need its own handling.
+    const Consensus::DeploymentPos dep{Consensus::DEPLOYMENT_REDUCED_DATA};
+    const auto& deployment{params.vDeployments[dep]};
+
+    // Only a configured mandatory-signaling deadline can be violated. A
+    // non-enforcing node leaves max_activation_height at its INT_MAX default,
+    // so it is naturally excluded here.
+    if (deployment.max_activation_height >= std::numeric_limits<int>::max()) return violators;
+
+    // A block must signal only within [max_activation_height - 2P, max_activation_height - P).
+    const int period{static_cast<int>(params.nMinerConfirmationWindow)};
+    const int window_begin{deployment.max_activation_height - (2 * period)};
+    const int window_end{deployment.max_activation_height - period};
+
+    // One pass over the whole block index (not just the active chain, so a
+    // violator on a side branch is corrected too). The cheap height comparison
+    // gates the more expensive versionbits State() lookup. Within the window a
+    // block was required to signal iff the deployment is STARTED for its branch,
+    // the same condition ConnectBlock/ContextualCheckBlockHeaderVolatile applies.
+    // The verdict is re-derived from the stored header, so it does not change as
+    // other blocks are invalidated and one scan suffices.
+    for (auto& [_, index] : m_blockman.m_block_index) {
+        if (index.nStatus & BLOCK_FAILED_MASK) continue;             // already handled
+        if (index.nHeight < window_begin || index.nHeight >= window_end) continue;
+        if (m_chainman.m_versionbitscache.State(index.pprev, params, dep) != ThresholdState::STARTED) continue;
+        const bool signals_top{(index.nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS};
+        const bool signals_bit{(index.nVersion & (uint32_t{1} << deployment.bit)) != 0};
+        if (signals_top && signals_bit) continue;                    // signaled correctly
+        violators.push_back(&index);
+    }
+
+    return violators;
+}
+
+bool Chainstate::CorrectRdtsInvalidBlocks(bilingual_str& error)
+{
+    AssertLockNotHeld(m_chainstate_mutex);
+    AssertLockNotHeld(::cs_main);
+
+    std::vector<CBlockIndex*> violators;
+    {
+        LOCK(cs_main);
+        violators = FindRdtsSignalingViolations();
+    }
+
+    // Invalidate lowest height first: doing so also fails a violator's descendants,
+    // so a higher violator on the same branch is skipped below. This calls
+    // InvalidateBlock only for the topmost violator of each branch, off the single
+    // scan above. Marks persist to the block index, so this is a no-op on every
+    // subsequent startup.
+    std::sort(violators.begin(), violators.end(),
+              [](const CBlockIndex* a, const CBlockIndex* b) { return a->nHeight < b->nHeight; });
+
+    bool invalidated{false};
+    for (CBlockIndex* target : violators) {
+        // m_interrupt here is the shutdown signal, so an interrupt means shutdown:
+        // return success and let the caller's shutdown check exit; any uncorrected
+        // violators are re-scanned on the next start.
+        if (m_chainman.m_interrupt) return true;
+
+        bool needs_reindex{false};
+        {
+            LOCK(cs_main);
+            if (target->nStatus & BLOCK_FAILED_MASK) continue;  // already failed as a descendant
+            // Correcting an active-chain violator disconnects every block from the
+            // tip down to and including it. If any of those has been pruned we
+            // cannot rewind, and a partial rewind would strand good blocks that can
+            // be neither reconnected nor re-downloaded. Refuse to start instead, as
+            // BIP148 did for the analogous case. (Pruning drops a block's data and
+            // undo together, so IsBlockPruned covers both.) Only the active-chain
+            // disconnect needs local data; the reconnect side is safe because
+            // FindMostWorkChain skips candidate chains with missing data.
+            if (m_chain.Contains(target)) {
+                for (const CBlockIndex* b{m_chain.Tip()}; b != target->pprev; b = b->pprev) {
+                    if (m_blockman.IsBlockPruned(*b)) {
+                        needs_reindex = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (needs_reindex) {
+            LogError("RDTS: cannot correct inherited invalid block %s at height %d: required block "
+                     "data has been pruned\n", target->GetBlockHash().ToString(), target->nHeight);
+            error = _("A block that violates the BIP110/RDTS mandatory-signaling rule was inherited from a client that was not enforcing it, and correcting it needs block data that has been pruned");
+            return false;
+        }
+
+        LogPrintf("RDTS: block %s at height %d violates mandatory signaling and was "
+                  "inherited from a non-enforcing client; marking it invalid\n",
+                  target->GetBlockHash().ToString(), target->nHeight);
+
+        BlockValidationState state;
+        if (!InvalidateBlock(state, target) || !state.IsValid()) {
+            LogError("RDTS: failed to invalidate %s: %s\n", target->GetBlockHash().ToString(), state.ToString());
+            error = _("Failed to correct a block that violates the BIP110/RDTS mandatory-signaling rule");
+            return false;
+        }
+        invalidated = true;
+    }
+
+    // Reconnect to the best remaining valid chain once, after all invalidations.
+    if (invalidated) {
+        BlockValidationState state;
+        if (!ActivateBestChain(state) || !state.IsValid()) {
+            LogError("RDTS: failed to activate best chain after correction: %s\n", state.ToString());
+            error = _("Failed to correct a block that violates the BIP110/RDTS mandatory-signaling rule");
+            return false;
+        }
+    }
+    return true;
+}
+
 void Chainstate::ClearBlockIndexCandidates()
 {
     AssertLockHeld(::cs_main);

--- a/src/validation.h
+++ b/src/validation.h
@@ -763,6 +763,33 @@ public:
 
     /** Whether the chain state needs to be redownloaded due to lack of witness data */
     [[nodiscard]] bool NeedsRedownload() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+    /**
+     * Correct chain state inherited from a client that was not enforcing
+     * BIP110/RDTS. Such a data directory can contain blocks that violate RDTS
+     * mandatory signaling; normal startup does not re-validate inherited history,
+     * so an enforcing node would otherwise keep them. This marks every offending
+     * block in the index invalid (whether or not on the active chain) and
+     * reorganizes to the best valid chain, mirroring the approach BIP148 used.
+     * The verdict is re-derived from the stored block header (nVersion), so it
+     * needs no persisted per-block marker and cannot misfire on a chain that was
+     * validated correctly. Only the header-derivable mandatory-signaling rule is
+     * handled; output-size and script-push violations require block data and
+     * remain a -reindex-chainstate matter.
+     *
+     * Returns false if an offending block could not be corrected, setting @p error
+     * to a user-facing reason (the data needed to rewind has been pruned, or the
+     * invalidate/reorg failed); the caller should refuse to start and direct the
+     * operator to -reindex rather than run on an invalid chain.
+     */
+    [[nodiscard]] bool CorrectRdtsInvalidBlocks(bilingual_str& error)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
+        LOCKS_EXCLUDED(::cs_main);
+
+    /** All not-yet-invalid blocks in the index that fail BIP110/RDTS mandatory
+     *  signaling. The verdict is header-derived and independent of other blocks'
+     *  validity, so a single scan is sufficient. @sa CorrectRdtsInvalidBlocks */
+    [[nodiscard]] std::vector<CBlockIndex*> FindRdtsSignalingViolations() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     /** Ensures we have a genesis block in the block tree, possibly writing one to disk. */
     bool LoadGenesisBlock();
 

--- a/test/functional/feature_rdts_migration.py
+++ b/test/functional/feature_rdts_migration.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Knots developers
+# Distributed under the MIT software license.
+"""BIP110/RDTS: at startup, an enforcing node corrects chain state inherited
+from a client that was not enforcing RDTS.
+
+A data directory advanced by a non-enforcing client can contain blocks that
+violate RDTS mandatory signaling. Normal startup does not re-validate inherited
+history, so the enforcing node corrects it: every offending block in the index
+(active chain or side branch) is marked invalid and the node reorganizes to the
+best valid chain, mirroring BIP148.
+
+A mandatory-signaling deadline is set via -vbparams so a window exists on
+regtest:
+    max_activation_height = 576, nMinerConfirmationWindow = 144
+    => mandatory-signaling window = [288, 431]
+
+Cases:
+  A_ACTIVE     inherited non-signaling block on the ACTIVE chain -> auto-reorg to
+               the last valid ancestor at startup (no operator command), block
+               marked invalid, and the correction persists across a restart.
+  A_NONACTIVE  a non-signaling block on a NON-active side branch -> marked invalid
+               at startup while the (valid) active chain is left untouched.
+  A_CLEAN      a fully-signaling chain -> untouched (no false-positive destruction).
+  A_BOUNDARY   non-signaling only just OUTSIDE the window (287, 432) -> untouched.
+  A_STARTED    locked-in exempt non-signaling in-window blocks -> untouched.
+"""
+from test_framework.blocktools import create_block, create_coinbase, add_witness_commitment
+from test_framework.script import CScript, OP_RETURN, OP_NOP
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_node import ErrorMatch
+from test_framework.util import assert_equal
+
+VERSIONBITS_TOP_BITS = 0x20000000
+REDUCED_DATA_BIT = 4
+# start=0, timeout=NO_TIMEOUT, min_act=0, max_act=576, active_duration=1440000, threshold=108
+VB_ENFORCE = '-vbparams=reduced_data:0:9223372036854775807:0:576:1440000:108'
+WINDOW_START = 288  # 576 - 2*144
+WINDOW_END = 431    # 576 - 144 - 1
+CHAIN_TIP = 440
+
+# The pruned case needs the violator >= MIN_BLOCKS_TO_KEEP (288) below the tip.
+# A lower deadline (max_act=432 => window [144, 288)) keeps that chain as short
+# as possible while staying clear of genesis.
+VB_PRUNE = '-vbparams=reduced_data:0:9223372036854775807:0:432:1440000:108'
+PRUNE_VIOLATOR = 144   # 432 - 2*144
+PRUNE_TIP = 432        # violator + MIN_BLOCKS_TO_KEEP
+# A ~64kiB coinbase so each block fills a -fastprune block file (64kiB), making
+# the violator's file independently prunable.
+BIG_SCRIPT = CScript([OP_RETURN] + [OP_NOP] * 70000)
+
+
+class RdtsMigrationTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 8
+        self.setup_clean_chain = True
+        # node0 clean-enforcing; node1/2/3 non-enforcing builders; node4 enforcing
+        # (STARTED-gate oracle); node5 non-enforcing (multi-branch); node6 pruned;
+        # node7 non-enforcing builder for the -reindex-chainstate recovery path.
+        self.extra_args = [[VB_ENFORCE], [], [], [], [VB_ENFORCE], [], ['-prune=1', '-fastprune'], []]
+
+    def setup_network(self):
+        self.setup_nodes()  # driven directly, no connections
+
+    # ---- block helpers -------------------------------------------------
+
+    def make_block(self, node, parent_hash, parent_time, height, signal):
+        block = create_block(int(parent_hash, 16), create_coinbase(height), ntime=parent_time + 1)
+        block.nVersion = VERSIONBITS_TOP_BITS | ((1 << REDUCED_DATA_BIT) if signal else 0)
+        add_witness_commitment(block)
+        block.solve()
+        return block
+
+    def submit_tip(self, node, signal):
+        """Extend the node's active tip by one block."""
+        tip = node.getbestblockhash()
+        blk = self.make_block(node, tip, node.getblockheader(tip)['time'], node.getblockcount() + 1, signal)
+        assert_equal(node.submitblock(blk.serialize().hex()), None)
+        return blk
+
+    def mine_to(self, node, target, signal):
+        while node.getblockcount() < target:
+            self.submit_tip(node, signal)
+
+    def build_bad_active_chain(self, node):
+        """Non-signaling in-window block at WINDOW_START on the active chain."""
+        self.mine_to(node, WINDOW_START - 1, signal=False)
+        bad = self.submit_tip(node, signal=False)   # height WINDOW_START, violator
+        assert_equal(node.getblockcount(), WINDOW_START)
+        self.mine_to(node, CHAIN_TIP, signal=False)
+        return bad
+
+    def submit_big_tip(self, node, signal):
+        """Extend the tip with a ~64kiB block (fills one -fastprune block file)."""
+        tip = node.getbestblockhash()
+        cb = create_coinbase(node.getblockcount() + 1, script_pubkey=BIG_SCRIPT)
+        block = create_block(int(tip, 16), cb, ntime=node.getblockheader(tip)['time'] + 1)
+        block.nVersion = VERSIONBITS_TOP_BITS | ((1 << REDUCED_DATA_BIT) if signal else 0)
+        add_witness_commitment(block)
+        block.solve()
+        assert_equal(node.submitblock(block.serialize().hex()), None)
+
+    def restart(self, i, extra):
+        self.stop_node(i)
+        self.start_node(i, extra_args=extra)
+        return self.nodes[i]
+
+    def chaintip_status(self, node, block_hash):
+        for t in node.getchaintips():
+            if t['hash'] == block_hash:
+                return t['status']
+        return None
+
+    # ---- test ----------------------------------------------------------
+
+    def run_test(self):
+        n_clean, n_active, n_nonactive, n_bound, n_lockin, n_multi, n_prune, n_rc = self.nodes
+
+        # A_CLEAN: fully-signaling chain must be left untouched.
+        self.log.info("A_CLEAN: enforcing node with a fully-signaling chain is untouched")
+        self.mine_to(n_clean, WINDOW_START - 1, signal=False)
+        self.mine_to(n_clean, WINDOW_END, signal=True)
+        self.mine_to(n_clean, CHAIN_TIP, signal=False)
+        tip_before = n_clean.getbestblockhash()
+        n_clean = self.restart(0, [VB_ENFORCE])
+        assert_equal(n_clean.getbestblockhash(), tip_before)
+        assert_equal(n_clean.getblockcount(), CHAIN_TIP)
+        self.log.info("  A_CLEAN CONFIRMED: valid chain not disturbed")
+
+        # A_ACTIVE: inherited non-signaling block on the active chain -> auto-reorg.
+        # Also plant a violator on a non-active side branch, so a SINGLE correction
+        # pass has to handle both an active-chain reorg and a side-branch mark in one
+        # go (mixed case).
+        self.log.info("A_ACTIVE: inherited active-chain violator (+ a non-active one) auto-corrected")
+        bad = self.build_bad_active_chain(n_active)
+        old_tip = n_active.getbestblockhash()             # height CHAIN_TIP, the invalid branch tip
+        assert_equal(old_tip, n_active.getblockhash(CHAIN_TIP))
+        # Non-active side violator off a pre-window ancestor (lower work than main).
+        s_hash = n_active.getblockhash(WINDOW_START - 2)
+        s_t = n_active.getblockheader(s_hash)['time']
+        s287 = self.make_block(n_active, s_hash, s_t + 100, WINDOW_START - 1, signal=False)
+        assert n_active.submitblock(s287.serialize().hex()) in (None, "inconclusive")
+        side_bad = self.make_block(n_active, s287.hash, s287.nTime, WINDOW_START, signal=False)
+        assert n_active.submitblock(side_bad.serialize().hex()) in (None, "inconclusive")
+        assert_equal(n_active.getbestblockhash(), old_tip)                 # still on the active (invalid) tip
+        n_active = self.restart(1, [VB_ENFORCE])          # enforcing, no manual command
+        assert_equal(n_active.getblockcount(), WINDOW_START - 1)
+        assert_equal(n_active.getbestblockhash(), n_active.getblockhash(WINDOW_START - 1))
+        assert_equal(self.chaintip_status(n_active, old_tip), 'invalid')   # active branch invalidated
+        assert n_active.getblock(bad.hash)['confirmations'] < 0            # active violator off the chain
+        assert_equal(self.chaintip_status(n_active, side_bad.hash), 'invalid')  # non-active violator too
+        self.log.info(f"  auto-reorged to height {n_active.getblockcount()}; active and non-active "
+                      f"violators both invalidated in one pass")
+        # persists across another restart
+        n_active = self.restart(1, [VB_ENFORCE])
+        assert_equal(n_active.getblockcount(), WINDOW_START - 1)
+        assert_equal(self.chaintip_status(n_active, old_tip), 'invalid')
+        self.log.info("  A_ACTIVE CONFIRMED: correction persists across restart (idempotent)")
+
+        # A_NONACTIVE: a violator on a lower-work side branch is invalidated,
+        # while the valid active chain is untouched. This is the "non-active
+        # blocks too" requirement.
+        self.log.info("A_NONACTIVE: violator on a non-active side branch is marked invalid")
+        # Valid, most-work main chain.
+        self.mine_to(n_nonactive, WINDOW_START - 1, signal=False)
+        self.mine_to(n_nonactive, WINDOW_END, signal=True)
+        self.mine_to(n_nonactive, CHAIN_TIP, signal=False)
+        main_tip = n_nonactive.getbestblockhash()
+        # Side branch off a pre-window ancestor, ending in a non-signaling
+        # in-window block. Far less work than main -> never active.
+        fork_h = WINDOW_START - 2
+        fork_hash = n_nonactive.getblockhash(fork_h)
+        fork_time = n_nonactive.getblockheader(fork_hash)['time']
+        # Offset the timestamp so the side branch differs from the identical-height
+        # main-chain block (same parent/height/coinbase would otherwise collide).
+        side287 = self.make_block(n_nonactive, fork_hash, fork_time + 100, fork_h + 1, signal=False)
+        # "inconclusive" == accepted as a valid lower-work fork, not the active tip.
+        assert n_nonactive.submitblock(side287.serialize().hex()) in (None, "inconclusive")
+        side_bad = self.make_block(n_nonactive, side287.hash, side287.nTime, fork_h + 2, signal=False)
+        assert n_nonactive.submitblock(side_bad.serialize().hex()) in (None, "inconclusive")  # height WINDOW_START, non-active
+        assert_equal(n_nonactive.getbestblockhash(), main_tip)  # still on main
+        assert_equal(self.chaintip_status(n_nonactive, side_bad.hash), 'valid-headers')
+        n_nonactive = self.restart(2, [VB_ENFORCE])
+        assert_equal(n_nonactive.getbestblockhash(), main_tip)                    # main untouched
+        assert_equal(n_nonactive.getblockcount(), CHAIN_TIP)
+        assert_equal(self.chaintip_status(n_nonactive, side_bad.hash), 'invalid') # side branch corrected
+        self.log.info("  A_NONACTIVE CONFIRMED: non-active violator invalidated, valid active chain kept")
+
+        # A_BOUNDARY: non-signaling only just outside the window -> untouched.
+        self.log.info("A_BOUNDARY: non-signaling only at 287/432 (outside window) is untouched")
+        self.mine_to(n_bound, WINDOW_START - 2, signal=False)
+        self.submit_tip(n_bound, signal=False)             # 287 outside
+        self.mine_to(n_bound, WINDOW_END, signal=True)     # 288..431 signal
+        self.submit_tip(n_bound, signal=False)             # 432 outside
+        self.mine_to(n_bound, CHAIN_TIP, signal=False)
+        bound_tip = n_bound.getbestblockhash()
+        n_bound = self.restart(3, [VB_ENFORCE])
+        assert_equal(n_bound.getbestblockhash(), bound_tip)
+        assert_equal(n_bound.getblockcount(), CHAIN_TIP)
+        self.log.info("  A_BOUNDARY CONFIRMED: out-of-window blocks not corrected")
+
+        # A_STARTED: lock in before the window, then stop signaling. Blocks that
+        # are non-signaling but consensus-legal (exempt) must be untouched. Built
+        # on an ENFORCING node, so its acceptance defines what is legal.
+        self.log.info("A_STARTED: locked-in exempt non-signaling blocks are untouched")
+        self.mine_to(n_lockin, WINDOW_START - 1 - 144, signal=False)  # ..143
+        self.mine_to(n_lockin, WINDOW_START - 1, signal=True)         # 144..287 signal -> lock in
+        exempt = 0
+        while n_lockin.getblockcount() < WINDOW_END:
+            tip = n_lockin.getbestblockhash()
+            blk = self.make_block(n_lockin, tip, n_lockin.getblockheader(tip)['time'],
+                                  n_lockin.getblockcount() + 1, signal=False)
+            if n_lockin.submitblock(blk.serialize().hex()) is None:
+                exempt += 1                              # accepted while non-signaling => legal/exempt
+            else:
+                self.submit_tip(n_lockin, signal=True)   # still must-signal at this height
+        assert exempt > 0, "expected some in-window blocks to be signaling-exempt after lock-in"
+        self.mine_to(n_lockin, CHAIN_TIP, signal=False)
+        lockin_tip = n_lockin.getbestblockhash()
+        n_lockin = self.restart(4, [VB_ENFORCE])
+        assert_equal(n_lockin.getbestblockhash(), lockin_tip)
+        assert_equal(n_lockin.getblockcount(), CHAIN_TIP)
+        self.log.info(f"  A_STARTED CONFIRMED: {exempt} exempt non-signaling blocks left intact")
+
+        # A_MULTI: two independent non-active violating branches on one node must
+        # BOTH be invalidated -- this exercises the multi-pass correction loop.
+        self.log.info("A_MULTI: two non-active violating branches -> both invalidated (multi-pass)")
+        self.mine_to(n_multi, WINDOW_START - 1, signal=False)
+        self.mine_to(n_multi, WINDOW_END, signal=True)
+        self.mine_to(n_multi, CHAIN_TIP, signal=False)
+        main_tip2 = n_multi.getbestblockhash()          # valid, most-work, active
+        # Branch A off height 286.
+        a_hash = n_multi.getblockhash(WINDOW_START - 2)
+        a_t = n_multi.getblockheader(a_hash)['time']
+        a287 = self.make_block(n_multi, a_hash, a_t + 100, WINDOW_START - 1, signal=False)
+        assert n_multi.submitblock(a287.serialize().hex()) in (None, "inconclusive")
+        a288 = self.make_block(n_multi, a287.hash, a287.nTime, WINDOW_START, signal=False)
+        assert n_multi.submitblock(a288.serialize().hex()) in (None, "inconclusive")
+        # Branch B off height 285 (a distinct fork point, lower work than main).
+        b_hash = n_multi.getblockhash(WINDOW_START - 3)
+        b_t = n_multi.getblockheader(b_hash)['time']
+        b286 = self.make_block(n_multi, b_hash, b_t + 200, WINDOW_START - 2, signal=False)
+        assert n_multi.submitblock(b286.serialize().hex()) in (None, "inconclusive")
+        b287 = self.make_block(n_multi, b286.hash, b286.nTime, WINDOW_START - 1, signal=False)
+        assert n_multi.submitblock(b287.serialize().hex()) in (None, "inconclusive")
+        b288 = self.make_block(n_multi, b287.hash, b287.nTime, WINDOW_START, signal=False)
+        assert n_multi.submitblock(b288.serialize().hex()) in (None, "inconclusive")
+        assert_equal(n_multi.getbestblockhash(), main_tip2)
+        n_multi = self.restart(5, [VB_ENFORCE])
+        assert_equal(n_multi.getbestblockhash(), main_tip2)                     # valid main kept
+        assert_equal(self.chaintip_status(n_multi, a288.hash), 'invalid')       # branch A corrected
+        assert_equal(self.chaintip_status(n_multi, b288.hash), 'invalid')       # branch B corrected
+        self.log.info("  A_MULTI CONFIRMED: both violating branches invalidated, valid main kept")
+
+        # A_PRUNED: the violator sits below the prune horizon, so the data needed to
+        # rewind to it is gone. The node must FAIL CLOSED (refuse to start, ask for
+        # -reindex) rather than partially rewind and strand good blocks.
+        self.log.info("A_PRUNED: violator's data pruned -> node offers reindex, fails closed if declined")
+        # All non-signaling (avoids early lock-in); the lowest in-window violator
+        # is at height PRUNE_VIOLATOR (blocks below the window are exempt anyway).
+        for _ in range(PRUNE_TIP):
+            self.submit_big_tip(n_prune, signal=False)
+        assert_equal(n_prune.getblockcount(), PRUNE_TIP)
+        pruned_to = n_prune.pruneblockchain(PRUNE_VIOLATOR)            # prune up to & including the violator
+        assert pruned_to >= PRUNE_VIOLATOR, f"pruneblockchain only reached {pruned_to}"
+        self.stop_node(6)
+        # A daemon can't answer the "rebuild now?" prompt, so it declines and fails
+        # closed with the recovery message rather than partially rewinding.
+        self.nodes[6].assert_start_raises_init_error(
+            extra_args=['-prune=1', '-fastprune', VB_PRUNE],
+            expected_msg="A block that violates the BIP110/RDTS mandatory-signaling rule",
+            match=ErrorMatch.PARTIAL_REGEX)
+        # When the prompt is approved (here via the test option), the node takes the
+        # reindex path instead of aborting. (A full re-sync of the pruned data needs
+        # peers; offline we only confirm the reindex path is taken and the node no
+        # longer holds the violator.)
+        self.start_node(6, extra_args=['-prune=1', '-fastprune', VB_PRUNE,
+                                       '-test=reindex_after_failure_noninteractive_yes'])
+        assert self.nodes[6].getblockcount() < PRUNE_TIP  # rebuilt, no longer on the invalid tip
+        self.stop_node(6)
+        self.log.info("  A_PRUNED CONFIRMED: prompts to rebuild; declined -> fail closed, approved -> reindex")
+
+        # A_REINDEX_CHAINSTATE: an operator whose startup correction failed for a
+        # transient reason is pointed at -reindex-chainstate (on a non-pruned node).
+        # The startup correction is skipped on reindex; recovery comes entirely from
+        # the rebuild, which re-connects blocks through ConnectBlock and re-enforces
+        # the mandatory-signaling rule, so the violator is rejected and the enforcing
+        # node still comes up on the valid chain.
+        self.log.info("A_REINDEX_CHAINSTATE: enforcing node recovers a violator via -reindex-chainstate")
+        bad_rc = self.build_bad_active_chain(n_rc)         # violator at WINDOW_START, tip at CHAIN_TIP
+        rc_bad_tip = n_rc.getbestblockhash()
+        assert_equal(n_rc.getblockcount(), CHAIN_TIP)
+        n_rc = self.restart(7, [VB_ENFORCE, '-reindex-chainstate'])
+        assert_equal(n_rc.getblockcount(), WINDOW_START - 1)                    # reorged to last valid ancestor
+        assert_equal(n_rc.getbestblockhash(), n_rc.getblockhash(WINDOW_START - 1))
+        assert_equal(self.chaintip_status(n_rc, rc_bad_tip), 'invalid')         # violating branch invalidated
+        assert n_rc.getblock(bad_rc.hash)['confirmations'] < 0                  # violator off the active chain
+        self.stop_node(7)
+        self.log.info("  A_REINDEX_CHAINSTATE CONFIRMED: -reindex-chainstate recovers to the valid chain")
+
+        self.log.info("")
+        self.log.info("RESULT: enforcing node auto-corrects inherited RDTS-invalid history on both "
+                      "the active chain (reorg) and non-active branches (mark invalid), persists the "
+                      "correction, and never disturbs a chain that was validated correctly.")
+
+
+if __name__ == '__main__':
+    RdtsMigrationTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -153,6 +153,7 @@ BASE_SCRIPTS = [
     'p2p_feefilter.py',
     'feature_csv_activation.py',
     'feature_reduced_data_utxo_height.py',
+    'feature_rdts_migration.py',
     'p2p_sendheaders.py',
     'feature_config_args.py',
     'wallet_listtransactions.py --legacy-wallet',


### PR DESCRIPTION
A data directory advanced by a client that was not enforcing BIP110/RDTS can contain blocks that violate RDTS mandatory signaling. Normal startup does not re-validate inherited history, so an enforcing node would otherwise keep them.

At startup the node now corrects this automatically, like BIP148: it marks every offending block in the index invalid (whether or not on the active chain) and reorganizes to the best valid chain.

- The verdict is re-derived from the stored block header (`nVersion`), so it needs no persisted per-block marker and cannot misfire on a chain that was validated correctly.
- Covers the active chain (reorg to the last valid ancestor) and non-active side branches (marked invalid so they are never activated).
- If the block data needed to rewind to an offending block has been pruned, the node refuses to start and asks for `-reindex` rather than perform a partial rewind that would strand good blocks.
- Mandatory-signaling only; output-size and script-push violations are not header-derivable and remain a `-reindex-chainstate` matter.

The pruned fail-closed path feeds the existing "rebuild the databases now?" prompt, which suggested either `-reindex` or `-reindex-chainstate`. A pruned node rejects `-reindex-chainstate` ("Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead."), so a second commit makes that suggestion pruned-aware: with pruning enabled the prompt offers `-reindex` only. This also fixes the generic chainstate-load-failure message on any pruned node.

Functional test `feature_rdts_migration.py` covers active-chain auto-reorg (idempotent across restart), non-active branch invalidation, clean/boundary/locked-in chains left untouched, multiple violating branches (multi-pass), and the pruned fail-closed path.
