### PR TITLE
Fix spawning Tor subprocess when datadir contains spaces

### DIFF
--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -728,7 +728,10 @@ std::string TorController::LaunchTor()
     }
 
     try {
-        m_process = new subprocess::Popen(m_execute + " -f " + fs::PathToString(tor_config_filepath), subprocess::input{subprocess::PIPE}, subprocess::close_fds{true});
+        std::vector<std::string> tor_argv = subprocess::util::split(m_execute);
+        tor_argv.emplace_back("-f");
+        tor_argv.emplace_back(fs::PathToString(tor_config_filepath));
+        m_process = new subprocess::Popen(tor_argv, subprocess::input{subprocess::PIPE}, subprocess::close_fds{true});
     } catch (...) {
         LogDebug(BCLog::TOR, "tor: Failed to execute Tor process\n");
         throw;


### PR DESCRIPTION
Bugfix, it resolve the issue #351

### Motivation & Problem
Spawning the Tor subprocess fails when the data directory path contains spaces:
1. `subprocess::Popen` was initialized with a concatenated command string, causing internal `util::split()` to split paths containing spaces into invalid separate arguments.
2. The autogenerated Tor configuration file wrote `DataDirectory` and `ControlPortWriteToFile` paths without quotes, causing Tor's config parser to fail on paths with spaces.

### Solution
- Pass arguments as `std::vector<std::string>` to `subprocess::Popen` so paths with spaces are passed monolithically to the OS process without string splitting.
- Enclose `DataDirectory` and `ControlPortWriteToFile` paths in double quotes in `generated_config`.
- Add `subprocess_vector_args_with_spaces` unit test in `torcontrol_tests.cpp`.