### PR TITLE
defaults: Enable rejecttokens by default.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -874,6 +874,7 @@ void InitParameterInteraction(ArgsManager& args)
         args.SoftSetArg("-permitbarepubkey", "1");
         args.SoftSetArg("-permitbaremultisig", "1");
         args.SoftSetArg("-rejectparasites", "0");
+        args.SoftSetArg("-rejecttokens", "0");
         args.SoftSetArg("-subdustfeepenalty", "0");
         args.SoftSetArg("-datacarriercost", "0.25");
         args.SoftSetArg("-datacarrierfullcount", "0");

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -65,7 +65,7 @@ static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP_STRICT{20};
 /** Default for -datacarriercost (multiplied by WITNESS_SCALE_FACTOR) */
 static constexpr unsigned int DEFAULT_WEIGHT_PER_DATA_BYTE{4};
 /** Default for -rejecttokens */
-static constexpr bool DEFAULT_REJECT_TOKENS{false};
+static constexpr bool DEFAULT_REJECT_TOKENS{true};
 /** Default for -subdustfeepenalty */
 static constexpr bool DEFAULT_SUBDUSTFEEPENALTY{true};
 


### PR DESCRIPTION
# Problem Being Solved

Bitcoin is being attacked more and more with non-financial data.

rejecttokens blocks abuse from tokens like runes, ordinals and inscriptions.  Currently, it defaults to off.  This change makes it default to on.

There is a similar option called rejectparasites, which also defaults to on, and blocks transactions that embed arbitrary non-monetary data.

After this change, both of these options together provide broad protection from the majority of non-financial data from entering the mempool.

# Related

These options work by storing the filtered transaction in a pool called the extrapool (sometimes also referred to as the "orphanage"), instead of the mempool.  This is required so that when the node is notified that a new block has been solved, it can reconstruct the block without having to fetch large numbers of transactions from other nodes.

Pull request https://github.com/bitcoinknots/bitcoin/pull/313 allows for the extrapool to be persisted, in the same way that the mempool can be persisted, across restarts.