### PR TITLE
validation: check the block index after InvalidateBlock repairs it

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3465,8 +3465,6 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pinde
         to_mark_failed = invalid_walk_tip;
     }
 
-    m_chainman.CheckBlockIndex();
-
     {
         LOCK(cs_main);
         if (m_chain.Contains(to_mark_failed)) {
@@ -3495,6 +3493,13 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pinde
 
         InvalidChainFound(to_mark_failed);
     }
+
+    // Check the block index only after the block above has restored it. The
+    // disconnect loop releases cs_main between iterations, so a block that
+    // arrives in that window is absent from the candidate set precalculated
+    // before the loop, and the block above is what puts it back. Checking any
+    // earlier asserts on the very inconsistency it exists to repair.
+    m_chainman.CheckBlockIndex();
 
     // Only notify about a new block tip if the active chain was modified.
     if (pindex_was_in_chain) {


### PR DESCRIPTION
`InvalidateBlock` precalculates what belongs in `setBlockIndexCandidates`, then releases `cs_main` on each iteration of its disconnect loop. A block arriving in that window is missed, which is what the correction near the end of the function exists to fix ("If any new blocks somehow arrived while we were disconnecting..."). `CheckBlockIndex()` ran before that correction, so it asserted on the inconsistency the correction repairs:

```
Assertion `c->setBlockIndexCandidates.count(pindex)' failed.
```

This is the intermittent `feature_pruning.py` failure in `previous releases, depends DEBUG`. Locally that job fails ~4/5 runs; with the call moved, 5/5 pass.

Based on `branch-26` so it merges forward. Core master has the same ordering.
