### PR TITLE
rpc: expose v2 header fields in blockheaderToJSON

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -190,7 +190,24 @@ UniValue blockheaderToJSON(const CBlockIndex& tip, const CBlockIndex& blockindex
     result.pushKV("target", GetTarget(blockindex, pow_limit).GetHex());
     result.pushKV("difficulty", GetDifficulty(blockindex));
     result.pushKV("chainwork", blockindex.nChainWork.GetHex());
-    result.pushKV("nTx", blockindex.nTx);
+    if (blockindex.nTx > 0) {
+        result.pushKV("nTx", blockindex.nTx);
+    } else if (blockindex.m_header_v2) {
+        // The block itself hasn't been seen yet, but a v2 header commits to
+        // the number of transactions in it.
+        result.pushKV("nTx", (uint64_t)blockindex.m_txcount);
+    }
+    result.pushKV("header_version", blockindex.m_header_v2 ? 2 : 0);
+    if (blockindex.m_header_v2) {
+        result.pushKV("nonce2", strprintf("%08x", blockindex.m_nonce2));
+        result.pushKV("nonce3", strprintf("%08x", blockindex.m_nonce3));
+        result.pushKV("extranonce", HexStr(blockindex.m_extranonce));
+        result.pushKV("time_offset", (uint64_t)blockindex.m_time_offset);
+        result.pushKV("header_flags", blockindex.m_flags);
+        result.pushKV("xor_key_mask_clear_bits", blockindex.m_xor_key_mask_clear_bits);
+        result.pushKV("xor_key", HexStr(blockindex.m_xor_key));
+        result.pushKV("mm_rhs", HexStr(blockindex.m_mm_rhs));
+    }
 
     if (blockindex.pprev)
         result.pushKV("previousblockhash", blockindex.pprev->GetBlockHash().GetHex());
@@ -793,7 +810,16 @@ static RPCHelpMan getblockheader()
                             {RPCResult::Type::STR_HEX, "target", "The difficulty target"},
                             {RPCResult::Type::NUM, "difficulty", "The difficulty"},
                             {RPCResult::Type::STR_HEX, "chainwork", "Expected number of hashes required to produce the current chain"},
-                            {RPCResult::Type::NUM, "nTx", "The number of transactions in the block"},
+                            {RPCResult::Type::NUM, "nTx", /*optional=*/true, "The number of transactions in the block; for entries where only the header has been seen this is the count committed in the v2 header, and it is omitted when unknown"},
+                            {RPCResult::Type::NUM, "header_version", "2 for a BLAKE2b v2 header, 0 otherwise"},
+                            {RPCResult::Type::STR_HEX, "nonce2", /*optional=*/true, "The second nonce (only present for v2 headers)"},
+                            {RPCResult::Type::STR_HEX, "nonce3", /*optional=*/true, "The third nonce (only present for v2 headers)"},
+                            {RPCResult::Type::STR_HEX, "extranonce", /*optional=*/true, "The 128-bit extranonce (only present for v2 headers)"},
+                            {RPCResult::Type::NUM, "time_offset", /*optional=*/true, "The offset subtracted from the block time on the wire, per header flags bit 2 (only present for v2 headers)"},
+                            {RPCResult::Type::NUM, "header_flags", /*optional=*/true, "The header flags: bits 0-1 ASIC profile, bit 2 time offset in use (only present for v2 headers)"},
+                            {RPCResult::Type::NUM, "xor_key_mask_clear_bits", /*optional=*/true, "The number of high bits cleared in the proof-of-work XOR mask (only present for v2 headers)"},
+                            {RPCResult::Type::STR_HEX, "xor_key", /*optional=*/true, "The 128-bit proof-of-work XOR key (only present for v2 headers)"},
+                            {RPCResult::Type::STR_HEX, "mm_rhs", /*optional=*/true, "The merge-mining hook right-hand side (only present for v2 headers)"},
                             {RPCResult::Type::STR_HEX, "previousblockhash", /*optional=*/true, "The hash of the previous block (if available)"},
                             {RPCResult::Type::STR_HEX, "nextblockhash", /*optional=*/true, "The hash of the next block (if available)"},
                         }},
@@ -972,7 +998,16 @@ static RPCHelpMan getblock()
                     {RPCResult::Type::STR_HEX, "target", "The difficulty target"},
                     {RPCResult::Type::NUM, "difficulty", "The difficulty"},
                     {RPCResult::Type::STR_HEX, "chainwork", "Expected number of hashes required to produce the chain up to this block (in hex)"},
-                    {RPCResult::Type::NUM, "nTx", "The number of transactions in the block"},
+                    {RPCResult::Type::NUM, "nTx", /*optional=*/true, "The number of transactions in the block; for entries where only the header has been seen this is the count committed in the v2 header, and it is omitted when unknown"},
+                    {RPCResult::Type::NUM, "header_version", "2 for a BLAKE2b v2 header, 0 otherwise"},
+                    {RPCResult::Type::STR_HEX, "nonce2", /*optional=*/true, "The second nonce (only present for v2 headers)"},
+                    {RPCResult::Type::STR_HEX, "nonce3", /*optional=*/true, "The third nonce (only present for v2 headers)"},
+                    {RPCResult::Type::STR_HEX, "extranonce", /*optional=*/true, "The 128-bit extranonce (only present for v2 headers)"},
+                    {RPCResult::Type::NUM, "time_offset", /*optional=*/true, "The offset subtracted from the block time on the wire, per header flags bit 2 (only present for v2 headers)"},
+                    {RPCResult::Type::NUM, "header_flags", /*optional=*/true, "The header flags: bits 0-1 ASIC profile, bit 2 time offset in use (only present for v2 headers)"},
+                    {RPCResult::Type::NUM, "xor_key_mask_clear_bits", /*optional=*/true, "The number of high bits cleared in the proof-of-work XOR mask (only present for v2 headers)"},
+                    {RPCResult::Type::STR_HEX, "xor_key", /*optional=*/true, "The 128-bit proof-of-work XOR key (only present for v2 headers)"},
+                    {RPCResult::Type::STR_HEX, "mm_rhs", /*optional=*/true, "The merge-mining hook right-hand side (only present for v2 headers)"},
                     {RPCResult::Type::STR_HEX, "previousblockhash", /*optional=*/true, "The hash of the previous block (if available)"},
                     {RPCResult::Type::STR_HEX, "nextblockhash", /*optional=*/true, "The hash of the next block (if available)"},
                 }},

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -190,12 +190,13 @@ UniValue blockheaderToJSON(const CBlockIndex& tip, const CBlockIndex& blockindex
     result.pushKV("target", GetTarget(blockindex, pow_limit).GetHex());
     result.pushKV("difficulty", GetDifficulty(blockindex));
     result.pushKV("chainwork", blockindex.nChainWork.GetHex());
+    result.pushKV("nTx", blockindex.nTx);
     if (blockindex.nTx > 0) {
-        result.pushKV("nTx", blockindex.nTx);
+        result.pushKV("txcount", blockindex.nTx);
     } else if (blockindex.m_header_v2) {
         // The block itself hasn't been seen yet, but a v2 header commits to
         // the number of transactions in it.
-        result.pushKV("nTx", (uint64_t)blockindex.m_txcount);
+        result.pushKV("txcount", (uint64_t)blockindex.m_txcount);
     }
     result.pushKV("header_version", blockindex.m_header_v2 ? 2 : 0);
     if (blockindex.m_header_v2) {
@@ -810,7 +811,8 @@ static RPCHelpMan getblockheader()
                             {RPCResult::Type::STR_HEX, "target", "The difficulty target"},
                             {RPCResult::Type::NUM, "difficulty", "The difficulty"},
                             {RPCResult::Type::STR_HEX, "chainwork", "Expected number of hashes required to produce the current chain"},
-                            {RPCResult::Type::NUM, "nTx", /*optional=*/true, "The number of transactions in the block; for entries where only the header has been seen this is the count committed in the v2 header, and it is omitted when unknown"},
+                            {RPCResult::Type::NUM, "nTx", "The number of transactions in the block, or 0 if only the block header is available (DEPRECATED)"},
+                            {RPCResult::Type::NUM, "txcount", /*optional=*/true, "The number of transactions in the block; for entries where only the header has been seen this is the count committed in the v2 header, and it is omitted when unknown"},
                             {RPCResult::Type::NUM, "header_version", "2 for a BLAKE2b v2 header, 0 otherwise"},
                             {RPCResult::Type::STR_HEX, "nonce2", /*optional=*/true, "The second nonce (only present for v2 headers)"},
                             {RPCResult::Type::STR_HEX, "nonce3", /*optional=*/true, "The third nonce (only present for v2 headers)"},
@@ -998,7 +1000,8 @@ static RPCHelpMan getblock()
                     {RPCResult::Type::STR_HEX, "target", "The difficulty target"},
                     {RPCResult::Type::NUM, "difficulty", "The difficulty"},
                     {RPCResult::Type::STR_HEX, "chainwork", "Expected number of hashes required to produce the chain up to this block (in hex)"},
-                    {RPCResult::Type::NUM, "nTx", /*optional=*/true, "The number of transactions in the block; for entries where only the header has been seen this is the count committed in the v2 header, and it is omitted when unknown"},
+                    {RPCResult::Type::NUM, "nTx", "The number of transactions in the block, or 0 if only the block header is available (DEPRECATED)"},
+                    {RPCResult::Type::NUM, "txcount", /*optional=*/true, "The number of transactions in the block; for entries where only the header has been seen this is the count committed in the v2 header, and it is omitted when unknown"},
                     {RPCResult::Type::NUM, "header_version", "2 for a BLAKE2b v2 header, 0 otherwise"},
                     {RPCResult::Type::STR_HEX, "nonce2", /*optional=*/true, "The second nonce (only present for v2 headers)"},
                     {RPCResult::Type::STR_HEX, "nonce3", /*optional=*/true, "The third nonce (only present for v2 headers)"},

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -169,6 +169,15 @@ static const CBlockIndex* ParseHashOrHeight(const UniValue& param, ChainstateMan
     }
 }
 
+//! Hex-encode a 32-bit header field in wire byte order, ie the same bytes in
+//! the same order as they appear in the serialised header.
+static std::string HeaderFieldHex(const uint32_t field)
+{
+    DataStream ss{};
+    ss << field;
+    return HexStr(ss);
+}
+
 UniValue blockheaderToJSON(const CBlockIndex& tip, const CBlockIndex& blockindex, const uint256 pow_limit)
 {
     // Serialize passed information without accessing chain state of the active chain!
@@ -200,8 +209,8 @@ UniValue blockheaderToJSON(const CBlockIndex& tip, const CBlockIndex& blockindex
     }
     result.pushKV("header_version", blockindex.m_header_v2 ? 2 : 0);
     if (blockindex.m_header_v2) {
-        result.pushKV("nonce2", strprintf("%08x", blockindex.m_nonce2));
-        result.pushKV("nonce3", strprintf("%08x", blockindex.m_nonce3));
+        result.pushKV("nonce2", HeaderFieldHex(blockindex.m_nonce2));
+        result.pushKV("nonce3", HeaderFieldHex(blockindex.m_nonce3));
         result.pushKV("extranonce", HexStr(blockindex.m_extranonce));
         result.pushKV("time_offset", (uint64_t)blockindex.m_time_offset);
         result.pushKV("header_flags", blockindex.m_flags);
@@ -814,8 +823,8 @@ static RPCHelpMan getblockheader()
                             {RPCResult::Type::NUM, "nTx", "The number of transactions in the block, or 0 if only the block header is available (DEPRECATED)"},
                             {RPCResult::Type::NUM, "txcount", /*optional=*/true, "The number of transactions in the block; for entries where only the header has been seen this is the count committed in the v2 header, and it is omitted when unknown"},
                             {RPCResult::Type::NUM, "header_version", "2 for a BLAKE2b v2 header, 0 otherwise"},
-                            {RPCResult::Type::STR_HEX, "nonce2", /*optional=*/true, "The second nonce (only present for v2 headers)"},
-                            {RPCResult::Type::STR_HEX, "nonce3", /*optional=*/true, "The third nonce (only present for v2 headers)"},
+                            {RPCResult::Type::STR_HEX, "nonce2", /*optional=*/true, "The second nonce, in wire byte order (only present for v2 headers)"},
+                            {RPCResult::Type::STR_HEX, "nonce3", /*optional=*/true, "The third nonce, in wire byte order (only present for v2 headers)"},
                             {RPCResult::Type::STR_HEX, "extranonce", /*optional=*/true, "The 128-bit extranonce (only present for v2 headers)"},
                             {RPCResult::Type::NUM, "time_offset", /*optional=*/true, "The offset subtracted from the block time on the wire, per header flags bit 2 (only present for v2 headers)"},
                             {RPCResult::Type::NUM, "header_flags", /*optional=*/true, "The header flags: bits 0-1 ASIC profile, bit 2 time offset in use (only present for v2 headers)"},
@@ -1003,8 +1012,8 @@ static RPCHelpMan getblock()
                     {RPCResult::Type::NUM, "nTx", "The number of transactions in the block, or 0 if only the block header is available (DEPRECATED)"},
                     {RPCResult::Type::NUM, "txcount", /*optional=*/true, "The number of transactions in the block; for entries where only the header has been seen this is the count committed in the v2 header, and it is omitted when unknown"},
                     {RPCResult::Type::NUM, "header_version", "2 for a BLAKE2b v2 header, 0 otherwise"},
-                    {RPCResult::Type::STR_HEX, "nonce2", /*optional=*/true, "The second nonce (only present for v2 headers)"},
-                    {RPCResult::Type::STR_HEX, "nonce3", /*optional=*/true, "The third nonce (only present for v2 headers)"},
+                    {RPCResult::Type::STR_HEX, "nonce2", /*optional=*/true, "The second nonce, in wire byte order (only present for v2 headers)"},
+                    {RPCResult::Type::STR_HEX, "nonce3", /*optional=*/true, "The third nonce, in wire byte order (only present for v2 headers)"},
                     {RPCResult::Type::STR_HEX, "extranonce", /*optional=*/true, "The 128-bit extranonce (only present for v2 headers)"},
                     {RPCResult::Type::NUM, "time_offset", /*optional=*/true, "The offset subtracted from the block time on the wire, per header flags bit 2 (only present for v2 headers)"},
                     {RPCResult::Type::NUM, "header_flags", /*optional=*/true, "The header flags: bits 0-1 ASIC profile, bit 2 time offset in use (only present for v2 headers)"},

--- a/test/functional/feature_powchange.py
+++ b/test/functional/feature_powchange.py
@@ -222,8 +222,8 @@ class PowChangeTest(BitcoinTestFramework):
         assert_equal(mm_json["time_offset"], merge_mined_block.m_time_offset)
         assert_equal(len(mm_json["nonce2"]), 8)
         assert_equal(len(mm_json["nonce3"]), 8)
-        assert_equal(mm_json["nonce2"], f"{merge_mined_block.m_nonce2:08x}")
-        assert_equal(mm_json["nonce3"], f"{merge_mined_block.m_nonce3:08x}")
+        assert_equal(mm_json["nonce2"], merge_mined_block.m_nonce2.to_bytes(4, "little").hex())
+        assert_equal(mm_json["nonce3"], merge_mined_block.m_nonce3.to_bytes(4, "little").hex())
 
         invalid_txcount = create_block(
             merge_mined_block.sha256,

--- a/test/functional/feature_powchange.py
+++ b/test/functional/feature_powchange.py
@@ -20,6 +20,17 @@ from test_framework.util import assert_equal, assert_raises_rpc_error
 from test_framework.wallet import MiniWallet
 
 CHANGE_HEIGHT = 20
+V2_HEADER_KEYS = (
+    "header_version",
+    "nonce2",
+    "nonce3",
+    "extranonce",
+    "time_offset",
+    "header_flags",
+    "xor_key_mask_clear_bits",
+    "xor_key",
+    "mm_rhs",
+)
 
 
 class PowChangeTest(BitcoinTestFramework):
@@ -167,6 +178,14 @@ class PowChangeTest(BitcoinTestFramework):
                 lambda: node.submitheader(hexdata=CBlockHeader(invalid_flags).serialize().hex()),
             )
 
+        self.log.info("Verbose getblockheader exposes the v2 header fields")
+        post_json = node.getblockheader(post_hash, True)
+        for key in V2_HEADER_KEYS:
+            assert key in post_json, f"missing {key} in verbose v2 header"
+        assert_equal(post_json["header_version"], 2)
+        pre_json = node.getblockheader(pre_hash, True)
+        assert_equal(pre_json["header_version"], 0)
+
         # A null XOR key disables anti-withholding regardless of how many mask
         # bits the pool requests to clear.
         assert_equal(post_header.m_xor_key, 0)
@@ -185,8 +204,26 @@ class PowChangeTest(BitcoinTestFramework):
         merge_mined_block.m_xor_key = 0x0123456789abcdef0123456789abcdef
         merge_mined_block.m_xor_key_mask_clear_bits = 255
         merge_mined_block.m_mm_rhs = 0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
+        merge_mined_block.m_extranonce = 0x00112233445566778899aabbccddeeff
+        merge_mined_block.m_nonce2 = 0xdeadbeef
+        merge_mined_block.m_nonce3 = 0xfeedface
         merge_mined_block.solve()
         assert_equal(node.submitblock(merge_mined_block.serialize().hex()), None)
+
+        # The blob fields are emitted in wire (forward) byte order, so the
+        # expected hex is the block's own value serialised little-endian.
+        mm_json = node.getblockheader(node.getbestblockhash(), True)
+        assert_equal(mm_json["header_version"], 2)
+        assert_equal(mm_json["extranonce"], merge_mined_block.m_extranonce.to_bytes(16, "little").hex())
+        assert_equal(mm_json["xor_key"], merge_mined_block.m_xor_key.to_bytes(16, "little").hex())
+        assert_equal(mm_json["mm_rhs"], merge_mined_block.m_mm_rhs.to_bytes(32, "little").hex())
+        assert_equal(mm_json["xor_key_mask_clear_bits"], merge_mined_block.m_xor_key_mask_clear_bits)
+        assert_equal(mm_json["header_flags"], merge_mined_block.m_flags)
+        assert_equal(mm_json["time_offset"], merge_mined_block.m_time_offset)
+        assert_equal(len(mm_json["nonce2"]), 8)
+        assert_equal(len(mm_json["nonce3"]), 8)
+        assert_equal(mm_json["nonce2"], f"{merge_mined_block.m_nonce2:08x}")
+        assert_equal(mm_json["nonce3"], f"{merge_mined_block.m_nonce3:08x}")
 
         invalid_txcount = create_block(
             merge_mined_block.sha256,
@@ -235,6 +272,44 @@ class PowChangeTest(BitcoinTestFramework):
         generated_header = self.get_header(generated["hash"])
         assert_equal(len(generated_block["tx"]), 2)
         assert_equal(generated_header.m_txcount, 2)
+
+        self.log.info("Header-only entries take nTx from the v2 header, or omit it")
+        # Submitting only the header leaves an index entry with no block body,
+        # so any transaction count can come only from the header itself. The
+        # count below deliberately differs from the block's own transaction
+        # list, which the node never sees.
+        v2_header_only = create_block(
+            merge_mined_block.sha256,
+            create_coinbase(CHANGE_HEIGHT + 2),
+            merge_mined_block.nTime + 2,
+            height=CHANGE_HEIGHT + 2,
+            header_v2=True,
+        )
+        v2_header_only.m_txcount = 3
+        v2_header_only.solve()
+        assert_equal(node.submitheader(hexdata=CBlockHeader(v2_header_only).serialize().hex()), None)
+        v2_header_only_json = node.getblockheader(v2_header_only.hash, True)
+        assert_equal(v2_header_only_json["header_version"], 2)
+        assert_equal(v2_header_only_json["nTx"], 3)
+
+        # A v1 header commits to no count, so nTx is omitted entirely until the
+        # block itself arrives.
+        v1_header_only = create_block(
+            int(pre_parent_hash, 16),
+            create_coinbase(CHANGE_HEIGHT - 1),
+            pre_parent["time"] + 2,
+            height=CHANGE_HEIGHT - 1,
+            header_v2=False,
+        )
+        v1_header_only.solve()
+        assert_equal(node.submitheader(hexdata=CBlockHeader(v1_header_only).serialize().hex()), None)
+        v1_header_only_json = node.getblockheader(v1_header_only.hash, True)
+        assert_equal(v1_header_only_json["header_version"], 0)
+        assert "nTx" not in v1_header_only_json
+
+        # Fully downloaded blocks keep reporting their actual count.
+        assert_equal(node.getblockheader(pre_hash, True)["nTx"], 1)
+        assert_equal(node.getblockheader(post_hash, True)["nTx"], 1)
 
 
 if __name__ == "__main__":

--- a/test/functional/feature_powchange.py
+++ b/test/functional/feature_powchange.py
@@ -290,7 +290,8 @@ class PowChangeTest(BitcoinTestFramework):
         assert_equal(node.submitheader(hexdata=CBlockHeader(v2_header_only).serialize().hex()), None)
         v2_header_only_json = node.getblockheader(v2_header_only.hash, True)
         assert_equal(v2_header_only_json["header_version"], 2)
-        assert_equal(v2_header_only_json["nTx"], 3)
+        assert_equal(v2_header_only_json["nTx"], 0)
+        assert_equal(v2_header_only_json["txcount"], 3)
 
         # A v1 header commits to no count, so nTx is omitted entirely until the
         # block itself arrives.
@@ -305,7 +306,8 @@ class PowChangeTest(BitcoinTestFramework):
         assert_equal(node.submitheader(hexdata=CBlockHeader(v1_header_only).serialize().hex()), None)
         v1_header_only_json = node.getblockheader(v1_header_only.hash, True)
         assert_equal(v1_header_only_json["header_version"], 0)
-        assert "nTx" not in v1_header_only_json
+        assert_equal(v1_header_only_json["nTx"], 0)
+        assert "txcount" not in v1_header_only_json
 
         # Fully downloaded blocks keep reporting their actual count.
         assert_equal(node.getblockheader(pre_hash, True)["nTx"], 1)


### PR DESCRIPTION
Wallet backends, explorers, and scripts that consume the verbose JSON
(rather than re-parsing raw header hex) currently cannot see any of
the v2 header fields.

Verbose `getblockheader`/`getblock` responses emit only the v1 header
fields for v2 headers, while raw hex mode already returns the full
serialized header. This adds the v2 fields to blockheaderToJSON,
emitted only when m_header_v2 is set, so the existing v1 fields are
unchanged. `header_version` is emitted for every header, as 0 for v1.

The blob fields (extranonce, xor_key, mm_rhs) are emitted with HexStr
in wire byte order rather than GetHex, which would reverse them.
nonce2/nonce3 are emitted as hex via the same strprintf idiom as the
existing `bits` field; they are not combined with nNonce, since the
ASIC profiles order the nonce fields differently and no concatenation
is profile-independent.

nTx is now sourced from the v2 header's txcount when only the header
has been seen, and omitted entirely when no count is known (v1
header-only entries). Note that m_txcount is a commitment rather than
a verified count until the block body arrives — CheckMerkleRoot only
runs on full blocks.

The header height is still not emitted, since height is already
present from the block index.

feature_powchange.py asserts the exact field values from a block
carrying non-zero extranonce, xor_key, mm_rhs and nonces (it would
fail against the previous GetHex ordering), plus header-only entries
for both header versions. Built and ran the test locally — passes,
with rpcdoccheck active. header_flags and time_offset are still only
asserted against zero; exercising a non-zero time offset means
reworking the block's time setup, happy to add it if wanted.