### PR TITLE
contrib: reject divergent verify-commits history

### DIFF
--- a/contrib/verify-commits/verify-commits.py
+++ b/contrib/verify-commits/verify-commits.py
@@ -13,6 +13,14 @@ import time
 
 GIT = os.getenv('GIT', 'git')
 
+def is_ancestor(older, newer, root_name):
+    """Return whether older is an ancestor of newer, rejecting Git errors."""
+    result = subprocess.run([GIT, "merge-base", "--is-ancestor", older, newer])
+    if result.returncode not in (0, 1):
+        print(f'Failed to determine ancestry between "{older}" and "{newer}" for the {root_name} (git merge-base exited with {result.returncode}).', file=sys.stderr)
+        sys.exit(1)
+    return result.returncode == 0
+
 def tree_sha512sum(commit='HEAD'):
     """Calculate the Tree-sha512 for the commit.
 
@@ -112,12 +120,13 @@ def main():
         logging.debug("verify-commits: [in-progress] processing commit {}".format(current_commit[:8]))
 
         if current_commit == verified_root:
+            # Ensure the trusted root identifies an existing commit.
+            is_ancestor(verified_root, current_commit, "trusted Git root")
             print('There is a valid path from "{}" to {} where all commits are signed!'.format(initial_commit, verified_root))
             sys.exit(0)
         else:
             # Make sure this commit isn't older than trusted roots
-            check_root_older_res = subprocess.run([GIT, "merge-base", "--is-ancestor", verified_root, current_commit])
-            if check_root_older_res.returncode != 0:
+            if not is_ancestor(verified_root, current_commit, "trusted Git root"):
                 print(f"\"{current_commit}\" predates the trusted root, stopping!")
                 sys.exit(0)
 
@@ -128,8 +137,7 @@ def main():
                 no_sha1 = False
             else:
                 # Skip the tree check if we are older than the trusted root
-                check_root_older_res = subprocess.run([GIT, "merge-base", "--is-ancestor", verified_sha512_root, current_commit])
-                if check_root_older_res.returncode != 0:
+                if not is_ancestor(verified_sha512_root, current_commit, "trusted Tree-SHA512 root"):
                     print(f"\"{current_commit}\" predates the trusted SHA512 root, disabling tree verification.")
                     verify_tree = False
                     no_sha1 = False

--- a/contrib/verify-commits/verify-commits.py
+++ b/contrib/verify-commits/verify-commits.py
@@ -21,6 +21,15 @@ def is_ancestor(older, newer, root_name):
         sys.exit(1)
     return result.returncode == 0
 
+def predates(commit, root, root_name):
+    """Return whether commit is provably older than root, rejecting divergent history."""
+    if is_ancestor(root, commit, root_name):
+        return False
+    elif is_ancestor(commit, root, root_name):
+        return True
+    print(f'"{commit}" diverges from the {root_name} "{root}", refusing to verify.', file=sys.stderr)
+    sys.exit(1)
+
 def tree_sha512sum(commit='HEAD'):
     """Calculate the Tree-sha512 for the commit.
 
@@ -124,23 +133,19 @@ def main():
             is_ancestor(verified_root, current_commit, "trusted Git root")
             print('There is a valid path from "{}" to {} where all commits are signed!'.format(initial_commit, verified_root))
             sys.exit(0)
-        else:
-            # Make sure this commit isn't older than trusted roots
-            if not is_ancestor(verified_root, current_commit, "trusted Git root"):
-                print(f"\"{current_commit}\" predates the trusted root, stopping!")
-                sys.exit(0)
+        elif predates(current_commit, verified_root, "trusted Git root"):
+            print(f"\"{current_commit}\" predates the trusted root, stopping!")
+            sys.exit(0)
 
         if verify_tree:
             if current_commit == verified_sha512_root:
                 print("All Tree-SHA512s matched up to {}".format(verified_sha512_root), file=sys.stderr)
                 verify_tree = False
                 no_sha1 = False
-            else:
-                # Skip the tree check if we are older than the trusted root
-                if not is_ancestor(verified_sha512_root, current_commit, "trusted Tree-SHA512 root"):
-                    print(f"\"{current_commit}\" predates the trusted SHA512 root, disabling tree verification.")
-                    verify_tree = False
-                    no_sha1 = False
+            elif predates(current_commit, verified_sha512_root, "trusted Tree-SHA512 root"):
+                print(f"\"{current_commit}\" predates the trusted SHA512 root, disabling tree verification.")
+                verify_tree = False
+                no_sha1 = False
 
 
         os.environ['BITCOIN_VERIFY_COMMITS_ALLOW_SHA1'] = "0" if no_sha1 else "1"


### PR DESCRIPTION
Backport of bitcoin/bitcoin#35980.

**Problem:** `verify-commits.py` checks a Git commit's history for trusted
signatures and tree hashes back to configured roots. The documented workflow
runs this check after fetching a commit and before checkout, proceeding only
when the script succeeds. A commit that is an ancestor of a configured root is
intentionally accepted without checking earlier history. The script also takes
this success path after Git errors or for divergent commits, even though
neither establishes that relationship.

**Fix:** Require Git to prove the ancestor relationship before taking this
success path.

Reproducers match upstream: on the old code, a nonexistent commit and a
divergent sibling of the trusted root both exit 0; with this change, both exit
non-zero.
