### PR TITLE
qt: Fix MSVC C4305 in MempoolStats::drawChart

### DIFF
--- a/src/qt/mempoolstats.cpp
+++ b/src/qt/mempoolstats.cpp
@@ -243,7 +243,7 @@ void MempoolStats::drawChart()
     int bottom = ui->graphicsView->size().height()-GRAPH_PADDING_BOTTOM;
     qreal maxwidth = ui->graphicsView->size().width()-GRAPH_PADDING_LEFT-GRAPH_PADDING_RIGHT;
     qreal maxheightG = ui->graphicsView->size().height()-GRAPH_PADDING_TOP-GRAPH_PADDING_TOP_LABEL-LABEL_HEIGHT;
-    float paddingTopSizeFactor = 1.2;
+    float paddingTopSizeFactor = 1.2f;
     qreal step = maxwidth/(double)vSamples.size();
 
     // make sure we skip samples that would be drawn narrower then 1px


### PR DESCRIPTION
## What
Initialises `paddingTopSizeFactor` in `MempoolStats::drawChart` from `1.2f` instead of `1.2`. One character; the value is unchanged.

## Why
MSVC 19.44 flags the double-to-float initialisation as C4305, and the Win64 native CI job builds with `/WX`, so every branch that builds the GUI in that job fails: `__base_29_pre_blake2b` on 2026-08-21, `__base_29_blake2` and #359 on 2026-08-22. `29.x-knots` only avoids it because its copy of the job passes `-DBUILD_GUI=OFF`. `mempoolstats.cpp` is Knots-only, so Core never sees it.

## How I tested
Read the failing job logs for the three branches; each shows exactly this one warning promoted to `error C2220` and nothing else in the GUI.

I do not have an MSVC toolchain here, so I ran the upstream `ci.yml` on a throwaway branch in my fork instead: `__base_29_pre_blake2b` plus this commit, which is the same configuration that fails upstream (Win64 native builds the GUI there). The Win64 native job built clean, `mempoolstats.cpp` compiles with no C4305 and no C2220, and the unit tests passed. The only failure in that job was `tool_cli_completion.py`, which is the checked-in completion files being out of date on that base (#365), not this change. Run: https://github.com/jasonsopko/bitcoinknots/actions/runs/32955315952 (job 98135597692).

The Win64 native job on this PR itself will not exercise the fix, since `29.x-knots` builds that job with `-DBUILD_GUI=OFF`.

## Risk and rollback
None to behaviour; the literal was already rounded to float. Revert if anything at all is wrong with it.
