### PR TITLE
policy: Count outputs whose hash or key is data as data carrier bytes

### DIFF
--- a/doc/release-notes-data-outputs.md
+++ b/doc/release-notes-data-outputs.md
@@ -1,0 +1,10 @@
+Policy
+------
+
+- Outputs whose hash or key field is data rather than a hash or key now count
+  as data carrier bytes, so under the default settings a transaction carrying
+  them is rejected with `txn-datacarrier-nonstandard`. This covers payloads
+  spread over P2WSH or taproot outputs at the dust threshold (the OLGA layout,
+  whatever magic it uses), taproot outputs whose key is not on the curve, and
+  any hash with one byte value repeated eight times or six times in a row.
+  Lightning anchor outputs, which come in pairs, are unaffected.

--- a/src/node/psbt.cpp
+++ b/src/node/psbt.cpp
@@ -146,7 +146,7 @@ PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
 
         if (success) {
             CTransaction ctx = CTransaction(mtx);
-            size_t size(GetVirtualTransactionSize(GetTransactionWeight(ctx) + CalculateExtraTxWeight(ctx, view, ::g_weight_per_data_byte), GetTransactionSigOpCost(ctx, view, STANDARD_SCRIPT_VERIFY_FLAGS), ::nBytesPerSigOp));
+            size_t size(GetVirtualTransactionSize(GetTransactionWeight(ctx) + CalculateExtraTxWeight(ctx, view, ::g_weight_per_data_byte, DataOutputBytes(ctx)), GetTransactionSigOpCost(ctx, view, STANDARD_SCRIPT_VERIFY_FLAGS), ::nBytesPerSigOp));
             result.estimated_vsize = size;
             // Estimate fee rate
             CFeeRate feerate(fee, size);

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -15,6 +15,7 @@
 #include <policy/feerate.h>
 #include <policy/settings.h>
 #include <primitives/transaction.h>
+#include <pubkey.h>
 #include <script/interpreter.h>
 #include <script/script.h>
 #include <script/solver.h>
@@ -27,7 +28,9 @@
 #include <array>
 #include <cstddef>
 #include <limits>
+#include <map>
 #include <optional>
+#include <set>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -633,7 +636,114 @@ std::pair<CScript, unsigned int> GetScriptForTransactionInput(CScript prevScript
     return std::make_pair(CScript(), 0);
 }
 
-std::pair<size_t, size_t> DatacarrierBytes(const CTransaction& tx, const CCoinsViewCache& view)
+namespace {
+
+/** The hash or x-only key of a single-hash output type; empty for any other script. */
+std::vector<unsigned char> OutputProgram(const CScript& script, TxoutType& type)
+{
+    std::vector<std::vector<unsigned char>> solutions;
+    type = Solver(script, solutions);
+    switch (type) {
+    case TxoutType::PUBKEYHASH:
+    case TxoutType::SCRIPTHASH:
+    case TxoutType::WITNESS_V0_KEYHASH:
+    case TxoutType::WITNESS_V0_SCRIPTHASH:
+    case TxoutType::WITNESS_V1_TAPROOT:
+        return solutions[0];
+    default:
+        return {};
+    }
+}
+
+/**
+ * A hash or x-only key is uniformly random. One byte value turning up
+ * DATA_OUTPUT_BYTE_MULTIPLICITY times has probability 1.3e-10 in 32 random
+ * bytes and 1.7e-12 in 20; a run of DATA_OUTPUT_BYTE_RUN identical bytes
+ * 2.5e-11 and 1.4e-11. Length prefixes, headers, padding and plain text all
+ * trip one or the other.
+ */
+bool ProgramLooksLikeData(const std::vector<unsigned char>& program)
+{
+    unsigned int counts[256]{};
+    unsigned int run{0};
+    unsigned char last{0};
+    for (const unsigned char b : program) {
+        if (++counts[b] >= DATA_OUTPUT_BYTE_MULTIPLICITY) return true;
+        run = (run && b == last) ? run + 1 : 1;
+        if (run >= DATA_OUTPUT_BYTE_RUN) return true;
+        last = b;
+    }
+    return false;
+}
+
+} // namespace
+
+std::vector<size_t> DataOutputBytes(const CTransaction& tx)
+{
+    const size_t n{tx.vout.size()};
+    std::vector<size_t> program_size(n, 0);
+    std::vector<TxoutType> types(n, TxoutType::NONSTANDARD);
+    std::vector<bool> at_dust(n, false);
+    std::vector<bool> data(n, false);
+    std::vector<bool> covered(n, false);
+    // Measured against the default dust rate: encoders sit on the network-wide
+    // floor, and a node with a higher -dustrelayfee rejects them as dust anyway.
+    const CFeeRate dust_rate{DUST_RELAY_TX_FEE};
+    std::map<TxoutType, std::set<std::vector<unsigned char>>> dust_programs;
+    unsigned int curve_checks{0};
+
+    for (size_t i{0}; i < n; ++i) {
+        const CTxOut& txout{tx.vout[i]};
+        if (covered[i]) continue;
+        if (const size_t olga_bytes{txout.scriptPubKey.IsOLGA(n - i)}; olga_bytes) {
+            // The OLGA detector counts this header and its chunks already
+            const size_t olga_outputs{olga_bytes / (WITNESS_V0_SCRIPTHASH_SIZE + /* script length */ 1 + /* amount */ 8)};
+            for (size_t j{i}; j < std::min(n, i + olga_outputs); ++j) covered[j] = true;
+            continue;
+        }
+        const auto program{OutputProgram(txout.scriptPubKey, types[i])};
+        if (program.empty()) continue;
+        program_size[i] = program.size();
+        if (ProgramLooksLikeData(program)) {
+            data[i] = true;
+        } else if (types[i] == TxoutType::WITNESS_V1_TAPROOT && curve_checks < DATA_OUTPUT_CURVE_CHECKS) {
+            // Not a point on the curve: nobody can ever spend this. The check
+            // costs a field square root, so only the first
+            // DATA_OUTPUT_CURVE_CHECKS taproot outputs get it. A whitened
+            // chunk is off the curve half the time, so a payload trips this
+            // within its first few outputs and the sibling rule marks the rest.
+            ++curve_checks;
+            if (!XOnlyPubKey{program}.IsFullyValid()) data[i] = true;
+        }
+        if (program.size() == WITNESS_V0_SCRIPTHASH_SIZE && txout.nValue <= GetDustThreshold(txout, dust_rate)) {
+            at_dust[i] = true;
+            dust_programs[types[i]].insert(program);
+        }
+    }
+
+    // A payload is spread over several outputs, and its other chunks may be
+    // whitened, so anything caught marks its siblings of the same type and
+    // value. Separately, DATA_OUTPUT_DUST_RUN or more distinct same-type
+    // 32-byte outputs at the dust threshold are data on their own: Lightning
+    // anchor outputs come in pairs, padding repeats one script, and nothing
+    // else pays that amount to several scripts at once.
+    std::set<std::pair<TxoutType, CAmount>> data_groups;
+    for (size_t i{0}; i < n; ++i) {
+        if (data[i]) data_groups.emplace(types[i], tx.vout[i].nValue);
+    }
+    std::vector<size_t> ret(n, 0);
+    for (size_t i{0}; i < n; ++i) {
+        if (!program_size[i]) continue;
+        const bool sibling{data_groups.count({types[i], tx.vout[i].nValue}) > 0};
+        const bool dust_run{at_dust[i] && dust_programs[types[i]].size() >= DATA_OUTPUT_DUST_RUN};
+        if (data[i] || sibling || dust_run) {
+            ret[i] = program_size[i] + /* script length */ 1 + /* amount */ 8;
+        }
+    }
+    return ret;
+}
+
+std::pair<size_t, size_t> DatacarrierBytes(const CTransaction& tx, const CCoinsViewCache& view, const std::vector<size_t>& data_outputs)
 {
     std::pair<size_t, size_t> ret{0, 0};
 
@@ -648,13 +758,14 @@ std::pair<size_t, size_t> DatacarrierBytes(const CTransaction& tx, const CCoinsV
         const CTxOut& txout = tx.vout[--i];
         const auto dcb = txout.scriptPubKey.DatacarrierBytes(tx.vout.size() - i);
         ret.first += dcb.first;
-        ret.second += dcb.second;
+        // An OLGA header counts its whole payload, so keep the larger figure
+        ret.second += std::max(dcb.second, data_outputs[i]);
     }
 
     return ret;
 }
 
-int32_t CalculateExtraTxWeight(const CTransaction& tx, const CCoinsViewCache& view, const unsigned int weight_per_data_byte)
+int32_t CalculateExtraTxWeight(const CTransaction& tx, const CCoinsViewCache& view, const unsigned int weight_per_data_byte, const std::vector<size_t>& data_outputs)
 {
     int64_t mod_weight{0};
 
@@ -672,7 +783,7 @@ int32_t CalculateExtraTxWeight(const CTransaction& tx, const CCoinsViewCache& vi
             for (size_t i{tx.vout.size()}; i; ) {
                 const CTxOut& txout = tx.vout[--i];
                 const auto dcb = txout.scriptPubKey.DatacarrierBytes(tx.vout.size() - i);
-                mod_weight += int64_t(dcb.first + dcb.second) * (weight_per_data_byte - WITNESS_SCALE_FACTOR);
+                mod_weight += int64_t(std::max(dcb.first + dcb.second, data_outputs[i])) * (weight_per_data_byte - WITNESS_SCALE_FACTOR);
             }
         }
     }

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -241,8 +241,25 @@ static inline int64_t GetVirtualTransactionInputSize(const CTxIn& tx)
 
 std::pair<CScript, unsigned int> GetScriptForTransactionInput(CScript prevScript, const CTxIn&);
 
-std::pair<size_t, size_t> DatacarrierBytes(const CTransaction& tx, const CCoinsViewCache& view);
+/** A byte value seen this many times in one hash or key marks the output as data */
+static constexpr unsigned int DATA_OUTPUT_BYTE_MULTIPLICITY{8};
+/** A run of identical bytes this long in one hash or key marks the output as data */
+static constexpr unsigned int DATA_OUTPUT_BYTE_RUN{6};
+/** Distinct same-type 32-byte outputs at the dust threshold are data from this many up */
+static constexpr unsigned int DATA_OUTPUT_DUST_RUN{3};
+/** Taproot outputs per transaction whose key is checked to be on the curve */
+static constexpr unsigned int DATA_OUTPUT_CURVE_CHECKS{64};
 
-int32_t CalculateExtraTxWeight(const CTransaction& tx, const CCoinsViewCache& view, const unsigned int weight_per_data_byte);
+/**
+ * Find outputs whose hash or key field carries data rather than a hash or key.
+ * Returns, per output, the bytes it spends on that data (program, script
+ * length and amount, as counted for OLGA), or 0 for a real output or one the
+ * OLGA detector already counts.
+ */
+std::vector<size_t> DataOutputBytes(const CTransaction& tx);
+
+std::pair<size_t, size_t> DatacarrierBytes(const CTransaction& tx, const CCoinsViewCache& view, const std::vector<size_t>& data_outputs);
+
+int32_t CalculateExtraTxWeight(const CTransaction& tx, const CCoinsViewCache& view, const unsigned int weight_per_data_byte, const std::vector<size_t>& data_outputs);
 
 #endif // BITCOIN_POLICY_POLICY_H

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -1423,4 +1423,139 @@ BOOST_AUTO_TEST_CASE(spends_witness_prog)
     }
 }
 
+BOOST_AUTO_TEST_CASE(tx_DataOutputBytes)
+{
+    // Block 965,224, tx f93ee9d2a8d6fc0dce7889732d8e288ca64dacfe4c94c6cd76eb85037daea09c:
+    // an "ACME" payload in four P2WSH outputs at 330 sat (OLGA framing with a
+    // different magic), then a taproot and two P2WPKH change outputs.
+    CMutableTransaction acme_mtx;
+    BOOST_REQUIRE(DecodeHexTx(acme_mtx, "02000000000104478044ee1b430fea5cb8ff1671b670ef9c5b9ae32eea5baef589514ec0a899e60800000000fdffffffbfc7b0134900db70018a0df2fad0f1e5e142213697e8117900f3a8c5937961eb0200000000fdffffffa5296edb74af3c092e4242f47ebb49e6935b84b5ff8b555dc1df205342a17f570200000000fdffffffb37dc44d0fda93e76e10a567b6e30ff16bc0dd84795210b5de9c70ce61026d3a0000000000fdffffff074a01000000000000220020007741434d4501001400789c0160009fff0110000c464f524745544d454b4e4f4a0100000000000022002054020400080000000000000001030800010004100000050800010006080001004a0100000000000022002007100009746578742f68746d6c08110020780f09eb3c8c53dc0a91ed8777c5194a01000000000000220020d06576f8bfe44a149acd6a56bcc81dca9ef91f18abe4cf51a6000000000000001e24000000000000225120f76c46bc64b22b4643971b7b6f93a552bd99b62ed2903fe7903ba74c8a9938df7803000000000000160014b9034eaf3a6cadd9b8687bdc95fa4e2e696ad349d403000000000000160014f05ca0933738059e830756042263a8d8182b9f24024830450221008bc36479a37702f5abc206931f39efcde9d1f98561ebe3733e97478205c4168a022032a6ba41e4609d7be2dd6120a2f24a10160c7caab3a7721b80b13c1e008e453401210273756d05687e8d9a4002940e915bf699c587553859e88a5b5870c5dce6f87f2f0247304402203a2c81569bef2606deccc47c5968b5f07c3a69fa2e6a060098f78be002d96f3702206a10ffda52252ba0c05c3d9ae92181e3d7806e3de5eb390c9bd6c2e508584c8b01210273756d05687e8d9a4002940e915bf699c587553859e88a5b5870c5dce6f87f2f02483045022100edd2b635984b47243124c6aa4bb30b25940f1bfba3d80af0207574a70911a69902206907be25d22a94746bf49d72f61c17a154cce0beb46f13e2e920da028cfeef2601210273756d05687e8d9a4002940e915bf699c587553859e88a5b5870c5dce6f87f2f02473044022018898be34c777e2b8618fde94260a239085a60fe43b82a2e7d46f7f4476f43e50220373634c96189ee47fa639a134599fd31d8872c421f0f75532caec035e07eb6ff01210273756d05687e8d9a4002940e915bf699c587553859e88a5b5870c5dce6f87f2f00000000"));
+    const CTransaction acme{acme_mtx};
+    const std::vector<size_t> acme_expect{41, 41, 41, 41, 0, 0, 0};
+    const auto acme_bytes{DataOutputBytes(acme)};
+    BOOST_CHECK_EQUAL_COLLECTIONS(acme_bytes.begin(), acme_bytes.end(), acme_expect.begin(), acme_expect.end());
+
+    // The whole-transaction count sees the same 164 bytes; the P2WPKH inputs add nothing.
+    CCoinsView coins_dummy;
+    CCoinsViewCache coins(&coins_dummy);
+    const CScript acme_prevout_spk{CScript() << OP_0 << "f05ca0933738059e830756042263a8d8182b9f24"_hex};
+    for (const CTxIn& txin : acme.vin) {
+        coins.AddCoin(txin.prevout, Coin{CTxOut{1000, acme_prevout_spk}, 1, false}, false);
+    }
+    const auto acme_dcb{DatacarrierBytes(acme, coins, acme_bytes)};
+    BOOST_CHECK_EQUAL(acme_dcb.first, 0U);
+    BOOST_CHECK_EQUAL(acme_dcb.second, 164U);
+    BOOST_CHECK_EQUAL(CalculateExtraTxWeight(acme, coins, 2 * WITNESS_SCALE_FACTOR, acme_bytes), 164 * WITNESS_SCALE_FACTOR);
+
+    // An OLGA header that also trips a byte tell still counts its whole
+    // payload (0x64 = 100 bytes, so four outputs), once: the detector covers
+    // header and chunks, so DataOutputBytes leaves them all to it
+    std::vector<unsigned char> stamp_header{0x00, 0x64, 's', 't', 'a', 'm', 'p', ':'};
+    stamp_header.resize(32, 0);
+    CMutableTransaction olga_mtx;
+    for (const auto& program : {stamp_header, "e9f85819906b6bc0b5f5d902c68cd2298679883ce2b3f8552b029f462c0a0d17"_hex_v_u8, "becb6d3c0662dca214c45cde70e4ce022ade14bac12bfed3aa4811b5b3bde49f"_hex_v_u8, "e2c8d6303cf2cad3a00e0ec1b61aa1355c32dca119c357f5e7ad499781052e3f"_hex_v_u8}) {
+        olga_mtx.vout.emplace_back(olga_mtx.vout.empty() ? 330 : 1000, CScript() << OP_0 << program);
+    }
+    const CTransaction olga{olga_mtx};
+    const std::vector<size_t> olga_expect{0, 0, 0, 0};
+    const auto olga_bytes{DataOutputBytes(olga)};
+    BOOST_CHECK_EQUAL_COLLECTIONS(olga_bytes.begin(), olga_bytes.end(), olga_expect.begin(), olga_expect.end());
+    BOOST_CHECK_EQUAL(DatacarrierBytes(olga, coins, olga_bytes).second, 164U);
+    BOOST_CHECK_EQUAL(CalculateExtraTxWeight(olga, coins, 2 * WITNESS_SCALE_FACTOR, olga_bytes), 164 * WITNESS_SCALE_FACTOR);
+    // The same stamp with its chunks at the threshold, the real layout: still
+    // 164, not 164 plus three chunks caught by the dust run
+    for (CTxOut& txout : olga_mtx.vout) txout.nValue = 330;
+    const CTransaction olga_dust{olga_mtx};
+    const auto olga_dust_bytes{DataOutputBytes(olga_dust)};
+    BOOST_CHECK_EQUAL_COLLECTIONS(olga_dust_bytes.begin(), olga_dust_bytes.end(), olga_expect.begin(), olga_expect.end());
+    BOOST_CHECK_EQUAL(DatacarrierBytes(olga_dust, coins, olga_dust_bytes).second, 164U);
+
+    // Random 32-byte hashes and x-only keys (on and off the curve)
+    const std::vector<unsigned char> hash_a{"e9f85819906b6bc0b5f5d902c68cd2298679883ce2b3f8552b029f462c0a0d17"_hex_v_u8};
+    const std::vector<unsigned char> hash_b{"becb6d3c0662dca214c45cde70e4ce022ade14bac12bfed3aa4811b5b3bde49f"_hex_v_u8};
+    const std::vector<unsigned char> hash_c{"e2c8d6303cf2cad3a00e0ec1b61aa1355c32dca119c357f5e7ad499781052e3f"_hex_v_u8};
+    const std::vector<unsigned char> hash_d{"af6adc4480e64dd58e59424f43b6144267d1c4347a58ad0f09013fb9053b307b"_hex_v_u8};
+    const std::vector<unsigned char> hash_e{"02c7539d864d18c81557338387d5300f60cb8cc75054c2cfc985ddc401269122"_hex_v_u8};
+    const std::vector<unsigned char> key_on_a{"9f537de0a7f7403067880d3d62d3f8d20889c4f77b74b612406d7d5ce0a9b206"_hex_v_u8};
+    const std::vector<unsigned char> key_on_b{"4d6abe64a78cd5dcb98a719490753a84a061274cc6f7ecefea0aedad967676ba"_hex_v_u8};
+    const std::vector<unsigned char> key_off{"4420f4cd273fe68ccc6df6aaf1bd40d6f879884882386754e2c2e55cfad0b0bb"_hex_v_u8};
+    const auto p2wsh = [](const std::vector<unsigned char>& program) { return CScript() << OP_0 << program; };
+    const auto p2tr = [](const std::vector<unsigned char>& key) { return CScript() << OP_1 << key; };
+    const auto check = [](const CMutableTransaction& mtx, const std::vector<size_t>& expect) {
+        const auto got{DataOutputBytes(CTransaction{mtx})};
+        BOOST_CHECK_EQUAL_COLLECTIONS(got.begin(), got.end(), expect.begin(), expect.end());
+    };
+    CMutableTransaction t;
+
+    // A Lightning commitment: two 330-sat anchors, to_local, to_remote, a small HTLC
+    t.vout = {CTxOut{330, p2wsh(hash_a)}, CTxOut{330, p2wsh(hash_b)}, CTxOut{50000, p2wsh(hash_c)}, CTxOut{70000, p2wsh(hash_d)}, CTxOut{400, p2wsh(hash_e)}};
+    check(t, {0, 0, 0, 0, 0});
+
+    // A third P2WSH output at the dust threshold makes a data run
+    t.vout = {CTxOut{330, p2wsh(hash_a)}, CTxOut{330, p2wsh(hash_b)}, CTxOut{330, p2wsh(hash_c)}, CTxOut{100000, p2wsh(hash_d)}};
+    check(t, {41, 41, 41, 0});
+    // One sat above the threshold breaks it
+    t.vout[2].nValue = 331;
+    check(t, {0, 0, 0, 0});
+    // The run counts distinct scripts: padding or consolidation that repeats
+    // one script at the threshold is not a spread payload
+    t.vout = {CTxOut{330, p2wsh(hash_a)}, CTxOut{330, p2wsh(hash_a)}, CTxOut{330, p2wsh(hash_a)}, CTxOut{330, p2wsh(hash_b)}};
+    check(t, {0, 0, 0, 0});
+    t.vout.emplace_back(330, p2wsh(hash_c));
+    check(t, {41, 41, 41, 41, 41});
+    // Taproot runs count the same way, mixed types do not add up
+    t.vout = {CTxOut{330, p2tr(key_on_a)}, CTxOut{330, p2tr(key_on_b)}, CTxOut{330, p2tr(key_off)}};
+    check(t, {41, 41, 41});
+    t.vout = {CTxOut{330, p2wsh(hash_a)}, CTxOut{330, p2wsh(hash_b)}, CTxOut{330, p2tr(key_on_a)}};
+    check(t, {0, 0, 0});
+
+    // A taproot key that is not on the curve can never be spent
+    t.vout = {CTxOut{100000, p2tr(key_off)}};
+    check(t, {41});
+    t.vout = {CTxOut{100000, p2tr(key_on_a)}};
+    check(t, {0});
+    // Only the first DATA_OUTPUT_CURVE_CHECKS taproot outputs are checked
+    t.vout.assign(DATA_OUTPUT_CURVE_CHECKS - 1, CTxOut{1000, p2tr(key_on_a)});
+    t.vout.emplace_back(2000, p2tr(key_off));
+    std::vector<size_t> capped(DATA_OUTPUT_CURVE_CHECKS, 0);
+    capped.back() = 41;
+    check(t, capped);
+    t.vout.insert(t.vout.begin(), CTxOut{1000, p2tr(key_on_b)});
+    capped.assign(DATA_OUTPUT_CURVE_CHECKS + 1, 0);
+    check(t, capped);
+
+    // Eight of one byte value trips the multiplicity tell, seven do not
+    std::vector<unsigned char> program{hash_a};
+    for (size_t k{0}; k < 8; ++k) program[4 * k] = 0x5a;
+    t.vout = {CTxOut{100000, p2wsh(program)}};
+    check(t, {41});
+    program = hash_a;
+    for (size_t k{0}; k < 7; ++k) program[4 * k] = 0x5a;
+    t.vout = {CTxOut{100000, p2wsh(program)}};
+    check(t, {0});
+
+    // Six identical bytes in a row trip the run tell, five do not
+    std::vector<unsigned char> run6{hash_b};
+    std::fill(run6.begin() + 10, run6.begin() + 16, 0x77);
+    t.vout = {CTxOut{100000, p2wsh(run6)}};
+    check(t, {41});
+    program = hash_b;
+    std::fill(program.begin() + 10, program.begin() + 15, 0x77);
+    t.vout = {CTxOut{100000, p2wsh(program)}};
+    check(t, {0});
+
+    // A caught chunk marks its siblings of the same type and value, nothing else
+    t.vout = {CTxOut{1000, p2wsh(hash_c)}, CTxOut{1000, p2wsh(run6)}, CTxOut{1000, p2wsh(hash_d)}, CTxOut{2000, p2wsh(hash_e)}, CTxOut{1000, p2tr(key_on_a)}};
+    check(t, {41, 41, 41, 0, 0});
+
+    // 20-byte hashes get the same tells: the all-zero burn address is data, and
+    // a random hash at the same value is marked as its sibling, at another value not
+    const CScript burn{CScript() << OP_0 << std::vector<unsigned char>(20, 0)};
+    const CScript p2wpkh{CScript() << OP_0 << std::vector<unsigned char>(hash_a.begin(), hash_a.begin() + 20)};
+    t.vout = {CTxOut{294, burn}, CTxOut{294, p2wpkh}};
+    check(t, {29, 29});
+    t.vout = {CTxOut{294, burn}, CTxOut{500, p2wpkh}};
+    check(t, {29, 0});
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1055,8 +1055,13 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, reason);
     }
 
+    // Outputs whose hash or key is data, for the datacarrier checks and the extra weight
+    std::vector<size_t> data_outputs(tx.vout.size(), 0);
+    if (m_pool.m_opts.datacarrier_fullcount || !m_pool.m_opts.accept_non_std_datacarrier || ::g_weight_per_data_byte > WITNESS_SCALE_FACTOR) {
+        data_outputs = DataOutputBytes(tx);
+    }
     if (m_pool.m_opts.datacarrier_fullcount || !m_pool.m_opts.accept_non_std_datacarrier) {
-        const auto dcb = DatacarrierBytes(tx, m_view);
+        const auto dcb = DatacarrierBytes(tx, m_view, data_outputs);
         if (dcb.second > 0 && !(m_pool.m_opts.accept_non_std_datacarrier || ignore_rejects.count("txn-datacarrier-nonstandard"))) {
             return state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, "txn-datacarrier-nonstandard");
         }
@@ -1093,7 +1098,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // Set entry_sequence to 0 when rejectmsg_zero_mempool_entry_seq is used; this allows txs from a block
     // reorg to be marked earlier than any child txs that were already in the mempool.
     const uint64_t entry_sequence = args.m_ignore_rejects.count(rejectmsg_zero_mempool_entry_seq) ? 0 : m_pool.GetSequence();
-    int32_t extra_weight = CalculateExtraTxWeight(*ptx, m_view, ::g_weight_per_data_byte);
+    int32_t extra_weight = CalculateExtraTxWeight(*ptx, m_view, ::g_weight_per_data_byte, data_outputs);
     if (!m_subpackage.m_changeset) {
         m_subpackage.m_changeset = m_pool.GetChangeSet();
     }

--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -19,6 +19,7 @@ from test_framework.script import (
     OP_RETURN,
     taproot_construct,
 )
+from test_framework.script_util import program_to_witness_script
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.test_node import TestNode
 from test_framework.util import assert_raises_rpc_error
@@ -29,12 +30,13 @@ from random import randbytes
 
 class DataCarrierTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 4
+        self.num_nodes = 5
         self.extra_args = [
             ["-acceptnonstddatacarrier=1", "-datacarrierfullcount"],
             ["-datacarrier=0"],
             ["-datacarrier=1", f"-datacarriersize={MAX_OP_RETURN_RELAY - 1}"],
             ["-datacarrier=1", "-datacarriersize=2", "-acceptnonstddatacarrier=1", "-datacarrierfullcount"],
+            ["-corepolicy=0"],  # Knots defaults: non-OP_RETURN data carriers are rejected outright
         ]
 
     def test_null_data_transaction(self, node: TestNode, data, success: bool) -> None:
@@ -92,6 +94,20 @@ class DataCarrierTest(BitcoinTestFramework):
                                     self.wallet.sendrawtransaction, from_node=node, tx_hex=tx_hex)
 
 
+    def test_data_output_transaction(self, node: TestNode, outputs, reject_reason) -> None:
+        """Send a self-transfer with extra (value, scriptPubKey) outputs; reject_reason None means it must be accepted."""
+        tx = self.wallet.create_self_transfer(fee_rate=0, confirmed_only=True)["tx"]
+        for value, script in outputs:
+            tx.vout.append(CTxOut(nValue=value, scriptPubKey=script))
+        tx.vout[0].nValue -= sum(value for value, _ in outputs) + tx.get_vsize()  # 1 sat/vbyte
+        tx_hex = tx.serialize().hex()
+
+        if reject_reason is None:
+            self.wallet.sendrawtransaction(from_node=node, tx_hex=tx_hex)
+            assert tx.rehash() in node.getrawmempool(True), f'{tx_hex} not in mempool'
+        else:
+            assert_raises_rpc_error(-26, reject_reason, self.wallet.sendrawtransaction, from_node=node, tx_hex=tx_hex)
+
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])
 
@@ -140,6 +156,39 @@ class DataCarrierTest(BitcoinTestFramework):
 
         self.log.info("Testing an OPNet transaction (just pushing 'op') with -datacarriersize=2.")
         self.test_opnet_transaction(node=self.nodes[3], success=False)
+
+        def p2wsh(program):
+            return program_to_witness_script(0, program)
+
+        # The cases below spend confirmed coins only, so a transaction one node
+        # accepted is never the parent of one sent to another node
+        self.generate(self.nodes[0], 1, sync_fun=self.sync_blocks)
+        self.wallet.rescan_utxos()
+
+        self.log.info("Testing three P2WSH outputs at the dust threshold (an OLGA-style payload, whatever its magic).")
+        dust_run = [(330, p2wsh(randbytes(32))) for _ in range(3)]
+        self.test_data_output_transaction(node=self.nodes[4], outputs=dust_run, reject_reason="txn-datacarrier-nonstandard")
+        # Counted as 3 * 41 bytes where non-standard carriers are accepted
+        self.test_data_output_transaction(node=self.nodes[0], outputs=dust_run, reject_reason="txn-datacarrier-exceeded")
+
+        self.log.info("Testing that three outputs at the dust threshold to one script are still standard.")
+        same_script = p2wsh(randbytes(32))
+        self.test_data_output_transaction(node=self.nodes[4], outputs=[(330, same_script)] * 3, reject_reason=None)
+
+        self.log.info("Testing that a pair of anchor-sized P2WSH outputs is still standard.")
+        anchors = [(330, p2wsh(randbytes(32))) for _ in range(2)] + [(10000, p2wsh(randbytes(32)))]
+        self.test_data_output_transaction(node=self.nodes[4], outputs=anchors, reject_reason=None)
+
+        self.log.info("Testing a taproot output whose key is not on the curve.")
+        off_curve = bytes.fromhex("4420f4cd273fe68ccc6df6aaf1bd40d6f879884882386754e2c2e55cfad0b0bb")
+        self.test_data_output_transaction(node=self.nodes[4], outputs=[(10000, program_to_witness_script(1, off_curve))], reject_reason="txn-datacarrier-nonstandard")
+
+        self.log.info("Testing P2WSH outputs whose hash is padded data.")
+        padded = [(10000, p2wsh(randbytes(24) + bytes(8))) for _ in range(2)]
+        self.test_data_output_transaction(node=self.nodes[4], outputs=padded[:1], reject_reason="txn-datacarrier-nonstandard")
+        # Two of them are 82 bytes, inside the default -datacarriersize where non-standard carriers are accepted
+        self.test_data_output_transaction(node=self.nodes[0], outputs=padded, reject_reason=None)
+        self.test_data_output_transaction(node=self.nodes[3], outputs=padded, reject_reason="txn-datacarrier-exceeded")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What
Outputs whose hash or key field is data rather than a hash or key are counted as data carrier bytes, so the default policy rejects the transaction as `txn-datacarrier-nonstandard`. No new option: `-acceptnonstddatacarrier`, `-datacarriersize`, `-datacarriercost` and `-corepolicy` keep their meaning.

Three tells, each on its own enough:

- One byte value repeated eight times in a 32-byte program, or six times in a row. For uniformly random bytes that is 1.3e-10 and 2.5e-11 per output (1.7e-12 and 1.4e-11 for 20-byte hashes). Length prefixes, headers, padding and text all trip it.
- A taproot output whose key is not on the curve. Nobody can spend it. Checked for the first 64 taproot outputs of a transaction, which bounds the cost.
- Three or more distinct same-type 32-byte outputs at the dust threshold. Lightning anchors come in pairs, and padding repeats one script.

A caught output also marks its siblings of the same type and value, so whitening the other chunks of a payload does not help. The per-output count is computed once in `PreChecks` and feeds both the datacarrier check and `-datacarriercost`. Outputs the OLGA detector already covers return 0 from it, so a stamp is counted once.

## Why
`IsOLGA` keys on the literal `stamp:`. The same framing with `ACME` in its place, a 2-byte length then a zlib record, has put 102 transactions and 759 permanently unspendable outputs on the chain since block 957497, mostly 4 to 6 P2WSH outputs at 330 sat each, one with 175. The three since the fork (963236, 963341, 965224) were mined by Knots miners, so this is what default policy passes today. A second magic string would last until the next rename.

This is one round of a longer game, and the tree already plays it: `-rejectparasites` and `-rejecttokens` in 2024, OLGA in 2025, OPNet in March, Counterparty in August. The encoder can adapt to this one too. The point is what adapting costs: whitening every chunk and leaving the dust floor, against a hundred lines here. Stamps took over a year to move from bare multisig to OLGA, and this encoder copied OLGA and changed one word. On a chain mined by Knots nodes, a merged filter also keeps these out of blocks, not only out of a mempool.

## How I tested
- Unit: `transaction_tests/tx_DataOutputBytes` runs the real 965224 transaction through `DataOutputBytes` and `DatacarrierBytes` (164 bytes, the four P2WSH outputs), then a Lightning commitment shape, dust runs of P2WSH and taproot, a run that repeats one script (not data), an off-curve key, the 64-output cap on the curve check, an OLGA header that also trips a byte tell and a stamp with its chunks at the threshold (each counts the payload once), the multiplicity and run boundaries (8 vs 7, 6 vs 5), sibling marking, and the all-zero P2WPKH burn address. Existing `script_DataCarrierBytes` and the OLGA cases in `test_IsStandard` unchanged.
- Functional: `mempool_datacarrier.py` gains the dust run (rejected by default, `txn-datacarrier-exceeded` at 123 bytes where non-standard carriers are accepted), three 330-sat outputs to one script (accepted), the anchor pair (accepted), an off-curve taproot key, and padded hashes (82 bytes, inside the default size where accepted). The framework starts every node with `-corepolicy`, which soft-sets `-acceptnonstddatacarrier=1` and `-datacarrierfullcount=0`, so none of the existing nodes ran the Knots default; a fifth node with `-corepolicy=0` now does.
- Full unit suite (19.7M assertions) and mempool_accept, mempool_dust, mempool_ephemeral_dust, mempool_truc, mempool_limit, mempool_package_limits, mempool_sigoplimit, feature_rbf, feature_anchors, feature_blocksxor, p2p_segwit, p2p_1p1c_network all pass on x86_64 Linux, no wallet, no GUI, zero build warnings. The same commit cherry-picks onto v29.4.1.knots20260508 with only an include conflict, builds clean, and passes the same tests there.
- Corpus: a Python mirror of the function over all 102 ACME transactions: every output caught, by the run tell in 93 and the multiplicity tell in 11, the dust-run rule never the only reason. Over ten blocks (7,575 transactions, 2,019 32-byte and 16,833 20-byte outputs) the tells flagged four outputs, all 330-sat P2WSH data from a different encoder. Over 73 blocks (961481 to 961553, 332,878 transactions) the defaults newly reject five transactions: an ACME payload, a P2PKH to a hash with nine `0xff` bytes, an eight-output run of 330-sat taproot outputs, and two runestone transactions that `-rejecttokens` (on by default as of 29.4.1) rejects anyway.
- Cost: 2,300 taproot outputs in one transaction take 0.67 ms in `DataOutputBytes` on a Release build, against 0.37 ms for the same shape as P2WSH. Without the cap it was 10.1 ms.

## Risk and rollback
Relay and mining policy only, no consensus change. A false positive means a transaction does not relay through Knots nodes; the tells are set where random data trips them once in ten billion outputs, and no payment output in the corpus did. The one deliberate widening is the dust run: in the ten blocks two transactions carried runs of 330-sat taproot outputs (23 and 5), and in the 73 blocks one more (8), and those would now be rejected. Backing out is reverting one commit; `-acceptnonstddatacarrier=1` with a larger `-datacarriersize` restores relay for an operator without a rebuild.

## Still unsure about
Whether taproot belongs in the dust-run rule. Leaving it out keeps 330-sat taproot batches relaying but hands the next encoder a free move to P2TR. I kept it in.
