### PR TITLE
Softfork: consensus: Enforce the BIP94 timewarp rule from the BLAKE2b fork height

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -195,6 +195,21 @@ struct Params {
     {
         return IsBlake2bHeight(height) && mtp_prev < RdtsExpiryTime;
     }
+
+    /**
+     * Whether BIP94's timewarp guard applies to a block at this height.
+     *
+     * Chains that already enforce BIP94 are unaffected. Everywhere else the
+     * rule starts at the BLAKE2b hardfork, so no block mined before it is
+     * retroactively invalidated. This deliberately does not touch the other
+     * half of enforce_BIP94, the retarget reading pindexFirst->nBits rather
+     * than pindexLast->nBits; on a chain with no min-difficulty exception
+     * those are the same value, but the flag stays the way to opt into it.
+     */
+    bool EnforceTimewarpRule(int height) const
+    {
+        return enforce_BIP94 || IsBlake2bHeight(height);
+    }
 };
 
 } // namespace Consensus

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -265,4 +265,35 @@ BOOST_AUTO_TEST_CASE(powchange_permitted_difficulty_transition)
     BOOST_CHECK(!PermittedDifficultyTransition(params, boundary_height, tip_nbits, beyond_window.GetCompact()));
 }
 
+
+/* BIP94's timewarp guard is inherited as testnet4/regtest-only. On a chain
+   whose security budget is a fraction of Siacoin's fleet, a majority is a much
+   smaller thing to acquire than it is today, so the rule is worth having from
+   the hardfork onward. Gating on height rather than flipping enforce_BIP94
+   keeps every pre-fork block valid. */
+BOOST_AUTO_TEST_CASE(timewarp_rule_starts_at_blake2b_height)
+{
+    Consensus::Params mainnet = CreateChainParams(*m_node.args, ChainType::MAIN)->GetConsensus();
+    BOOST_CHECK(!mainnet.enforce_BIP94);
+
+    // Mainnet's fork is at 961640: off below it, on at and above it.
+    BOOST_CHECK_EQUAL(mainnet.Blake2bHeight, 961640);
+    BOOST_CHECK(!mainnet.EnforceTimewarpRule(0));
+    BOOST_CHECK(!mainnet.EnforceTimewarpRule(mainnet.Blake2bHeight - 1));
+    BOOST_CHECK(mainnet.EnforceTimewarpRule(mainnet.Blake2bHeight));
+    BOOST_CHECK(mainnet.EnforceTimewarpRule(mainnet.Blake2bHeight + 2016));
+
+    // With no fork scheduled the rule is inert at every height.
+    mainnet.Blake2bHeight = std::numeric_limits<int>::max();
+    BOOST_CHECK(!mainnet.EnforceTimewarpRule(0));
+    BOOST_CHECK(!mainnet.EnforceTimewarpRule(961640));
+    BOOST_CHECK(!mainnet.EnforceTimewarpRule(900000000));
+
+    // Chains that already enforce it are unchanged, fork scheduled or not.
+    const Consensus::Params testnet4 = CreateChainParams(*m_node.args, ChainType::TESTNET4)->GetConsensus();
+    BOOST_CHECK(testnet4.enforce_BIP94);
+    BOOST_CHECK(testnet4.EnforceTimewarpRule(0));
+    BOOST_CHECK(testnet4.EnforceTimewarpRule(961640));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4723,9 +4723,11 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
     if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast())
         return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "time-too-old", "block's timestamp is too early");
 
-    // Testnet4 and regtest only: Check timestamp against prev for difficulty-adjustment
-    // blocks to prevent timewarp attacks (see https://github.com/bitcoin/bitcoin/pull/15482).
-    if (consensusParams.enforce_BIP94) {
+    // Check timestamp against prev for difficulty-adjustment blocks to prevent
+    // timewarp attacks (see https://github.com/bitcoin/bitcoin/pull/15482).
+    // Enforced on testnet4 and regtest from genesis, and everywhere else from
+    // the BLAKE2b hardfork.
+    if (consensusParams.EnforceTimewarpRule(nHeight)) {
         // Check timestamp for the first block of each difficulty adjustment
         // interval, except the genesis block.
         if (nHeight % consensusParams.DifficultyAdjustmentInterval() == 0) {


### PR DESCRIPTION
## What
Extends BIP94's timewarp guard to mainnet from the BLAKE2b fork height. Adds `Consensus::Params::EnforceTimewarpRule(int height)`, which returns `enforce_BIP94 || IsBlake2bHeight(height)`, uses it at the one timestamp check in `ContextualCheckBlockHeaderVolatile`, and pins the boundary in a unit test. Testnet4 and regtest, which already set the flag, are unchanged. The retarget half of `enforce_BIP94` in `pow.cpp` is deliberately not touched.

## Why
The check is gated on `enforce_BIP94`, which mainnet sets to false. That was defensible when a timewarp needed a majority of 900 EH/s. This chain has about 3.4 PH/s (mempool.guide, 2026-09-04) against a Siacoin fleet of roughly 10 PH/s that the fork was designed to be compatible with, and difficulty is still catching up, +300% at each of the two retargets so far with a third due at 967680. A majority here is portable hardware, and the attack it enables is the classic one: hold the first block of each period back in time, inflate the measured timespan, and walk difficulty down 4x per period.

The mining side already complies. `node/miner.cpp` clamps `mintime` against `MAX_TIMEWARP` at every boundary on all networks, so every block built through `getblocktemplate` satisfies the rule today. Only the consensus side that makes it binding on everyone else is missing.

## How I tested
Built at 8c85b1585d (v29.4.1) with `-DRDTS_CONSENT=IMPLICIT -DBUILD_GUI=OFF -DENABLE_WALLET=OFF`. The full `test_bitcoin` suite passes, including the new `pow_tests` case; `feature_powchange.py` and `mining_basic.py` pass. Both mainnet boundaries since the fork satisfy the rule: 963648 came 6 seconds after 963647 and 965664 came 14 seconds after 965663, so it invalidates nothing mined to date.

## Risk and rollback
Consensus change. A block at a retarget boundary timestamped more than 600 seconds before its parent becomes invalid from 961640 onward; no pre-fork block is affected and no post-fork block so far is. Revert is one commit.

The real risk is deployment: an upgraded node rejects a violating boundary block that a non-upgraded node accepts, so during the mixed period an attacker could split the network instead of only lowering difficulty. Gating at a future height, so nodes upgrade before it binds, would remove that at the cost of one more period exposed. I gated at the fork height because no violating block exists; the choice is yours.

## Still unsure about
600 or 7200 seconds. `MAX_TIMEWARP` is 600, testnet4's value; BIP54 chose 7200 for mainnet out of caution about pool software that ignores `mintime`. This fork's mining stack is new and external, which argues for the looser bound, while GBT already hands out a 600-second minimum, which argues it is fine. Either is a one-line change and I would take it as a review comment.
