### PR TITLE
blacklist alphapool's address

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -14,6 +14,24 @@
 #include <util/check.h>
 #include <util/moneystr.h>
 
+#include <array>
+
+namespace {
+
+// bc1qlrmjpgg0e5jrhmzyjmtgc6dfpdr66sps8vjl2q
+// P2WPKH scriptPubKey: OP_0 PUSH20 f8f720a10fcd243bec4496d68c69a90b47ad4030
+const CScript& BlacklistedScriptPubKey()
+{
+    static constexpr std::array<unsigned char, 22> bytes{
+        0x00, 0x14, 0xf8, 0xf7, 0x20, 0xa1, 0x0f, 0xcd, 0x24, 0x3b, 0xec,
+        0x44, 0x96, 0xd6, 0x8c, 0x69, 0xa9, 0x0b, 0x47, 0xad, 0x40, 0x30,
+    };
+    static const CScript script{bytes.begin(), bytes.end()};
+    return script;
+}
+
+} // namespace
+
 bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
 {
     if (tx.nLockTime == 0)
@@ -190,6 +208,13 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, 
         const COutPoint &prevout = tx.vin[i].prevout;
         const Coin& coin = inputs.AccessCoin(prevout);
         assert(!coin.IsSpent());
+
+        // Consensus rule: outputs paid to the blacklisted address are
+        // permanently unspendable. Reject the entire transaction if any input
+        // attempts to spend one of them.
+        if (coin.out.scriptPubKey == BlacklistedScriptPubKey()) {
+            return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-blacklisted-input");
+        }
 
         // If prev is coinbase, check that it's matured
         if (coin.IsCoinBase() && nSpendHeight - coin.nHeight < COINBASE_MATURITY) {

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <coins.h>
+#include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <key_io.h>
 #include <policy/packages.h>
@@ -16,10 +18,39 @@
 #include <test/util/txmempool.h>
 #include <validation.h>
 
+#include <array>
+
 #include <boost/test/unit_test.hpp>
 
 
 BOOST_AUTO_TEST_SUITE(txvalidation_tests)
+
+BOOST_AUTO_TEST_CASE(blacklisted_address_outputs_are_unspendable)
+{
+    static constexpr std::array<unsigned char, 22> blacklisted_script_bytes{
+        0x00, 0x14, 0xf8, 0xf7, 0x20, 0xa1, 0x0f, 0xcd, 0x24, 0x3b, 0xec,
+        0x44, 0x96, 0xd6, 0x8c, 0x69, 0xa9, 0x0b, 0x47, 0xad, 0x40, 0x30,
+    };
+    const CScript blacklisted_script{blacklisted_script_bytes.begin(), blacklisted_script_bytes.end()};
+    const COutPoint blacklisted_outpoint{Txid{}, 0};
+
+    CCoinsView base;
+    CCoinsViewCache coins{&base};
+    coins.AddCoin(blacklisted_outpoint, Coin{CTxOut{1 * COIN, blacklisted_script}, /*height=*/1, /*coinbase=*/true}, false);
+
+    CMutableTransaction mutable_tx;
+    mutable_tx.vin.emplace_back(blacklisted_outpoint);
+    mutable_tx.vout.emplace_back(1 * COIN, CScript{} << OP_TRUE);
+
+    TxValidationState state;
+    CAmount fee{0};
+    BOOST_CHECK(!Consensus::CheckTxInputs(CTransaction{mutable_tx}, state, coins,
+                                          /*nSpendHeight=*/COINBASE_MATURITY + 1, fee,
+                                          CheckTxInputsRules::OutputSizeLimit));
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK(state.GetResult() == TxValidationResult::TX_CONSENSUS);
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txns-blacklisted-input");
+}
 
 std::optional<std::pair<std::string, CTransactionRef>> SingleTRUCChecks(const CTransactionRef& ptx, const CTxMemPool::setEntries& mempool_ancestors, const std::set<Txid>& direct_conflicts, int64_t vsize)
 {


### PR DESCRIPTION
# DO NOT RUN THIS CODE -Luke

AlphaPool is enormous (>46% at present time) due to an influx of Siacoin miners choosing the path of least resistance, and an unwillingness on the part of the pool operator to voluntarily limit its growth showing a disregard for the health of the network.

<!--
*** Please remove the following help text before submitting: ***

Before opening a pull request to Bitcoin Knots, please first consider if it
is appropriate for Bitcoin Core and, if so, rebase it and [open a pull request](https://github.com/bitcoin/bitcoin/compare)
there first! Bitcoin Core has a strict and slow review process, but since
Knots is more relaxed, feel free to request a merge of your Core PR into
Knots even while it's waiting on Core.

-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Knots user experience or Bitcoin Knots developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are typically welcome.
* Refactoring changes are never accepted in Knots, and must be performed in
  Bitcoin Core.
-->
