### PR TITLE
Consensus: Extended coinbase maturity temporary softfork (expires with RDTS)

### DIFF
--- a/doc/release-notes-extended-coinbase-maturity.md
+++ b/doc/release-notes-extended-coinbase-maturity.md
@@ -1,0 +1,40 @@
+### Extended coinbase maturity (temporary softfork)
+
+Coinbase outputs created while this deployment is active can only be spent
+once buried under 6480 blocks (45 days of ten-minute blocks),
+instead of the usual 100. The rule applies to every block from the first one
+whose parent's median-time-past reaches the deployment's start time, and
+expires together with RDTS: from the first block whose parent's
+median-time-past reaches the RDTS expiry (2027-09-01 00:00 UTC on mainnet)
+every coinbase output is again spendable after 100 confirmations, including
+those created during the window that had not yet reached 6480.
+
+Only outputs created inside the window are affected. A coinbase output created
+before activation keeps the 100-block rule throughout, so activating the
+deployment cannot lock an output that was already spendable. The 100-block
+rule continues to apply to every coinbase output at all times.
+
+The start time is not yet scheduled on mainnet or testnet4 in this release
+(see `src/kernel/chainparams.cpp`); the deployment does nothing until it is.
+
+Miners: block rewards mined inside the window cannot be spent for 6480 blocks
+(or until the RDTS expiry, whichever comes first). Pools that pay their miners
+directly from coinbase outputs pass this delay through to those miners. A
+non-upgraded miner that spends its own reward at 100 confirmations produces a
+block that upgraded nodes reject.
+
+Wallet: rewards subject to the rule are reported as immature (in
+`getbalances` `immature`, `listtransactions` category `immature` and the
+GUI) until they can be spent, and are not selected for spending before then,
+so the wallet never creates a transaction the network would reject.
+
+`getdeploymentinfo` reports the deployment as `extended_coinbase_maturity`, a
+`flagday` entry with `start_time`, `expiry_time` (the RDTS expiry), `active`
+(for the next block) and, once the queried chain's median-time-past has reached
+the start time, `height`, the activation height on that chain. It is omitted
+on chains where the deployment is not scheduled. `getblocktemplate` lists
+`extended_coinbase_maturity` in `rules` while the deployment is active; no
+client-side support is required.
+
+On regtest the deployment is scheduled with `-extendedcoinbasematurity=<time>`,
+which requires `-rdtsexpiry` and must precede it.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -93,6 +93,20 @@ void ReadRegTestArgs(const ArgsManager& args, CChainParams::RegTestOptions& opti
         options.rdts_expiry_time = expiry;
     }
 
+    if (const auto arg{args.GetArg("-extendedcoinbasematurity", "")}; !arg.empty()) {
+        // The rule expires with RDTS: without an RDTS expiry, or with a start
+        // at or after it, it could never apply, which is indistinguishable
+        // from not scheduling it at all.
+        if (!options.rdts_expiry_time) {
+            throw std::runtime_error("-extendedcoinbasematurity requires -rdtsexpiry=<time> (the rule expires with RDTS).");
+        }
+        int64_t start;
+        if (!ParseInt64(arg, &start) || start >= *options.rdts_expiry_time) {
+            throw std::runtime_error(strprintf("Invalid start (%s) for -extendedcoinbasematurity=<time>: must precede the RDTS expiry (%d).", arg, *options.rdts_expiry_time));
+        }
+        options.extended_coinbase_maturity_start_time = start;
+    }
+
     if (const auto arg{args.GetArg("-blake2b_headline")}; arg) {
         if (!options.activation_heights.contains(Consensus::BuriedDeployment::DEPLOYMENT_BLAKE2B)) {
             throw std::runtime_error("-blake2b_headline requires -testactivationheight=blake2b@<height>");

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -6,6 +6,7 @@
 #include <chainparamsbase.h>
 
 #include <common/args.h>
+#include <consensus/consensus.h>
 #include <tinyformat.h>
 #include <util/chaintype.h>
 
@@ -18,6 +19,7 @@ void SetupChainParamsBaseOptions(ArgsManager& argsman)
                  "This is intended for regression testing tools and app development. Equivalent to -chain=regtest.", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-testactivationheight=name@height.", "Set the activation height of 'name' (segwit, bip34, dersig, cltv, csv, blake2b). (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-rdtsexpiry=<time>", "Schedule the RDTS expiry: RDTS rules apply to blocks from the blake2b activation height until the parent block's median-time-past reaches <time>. Requires -testactivationheight=blake2b@<height>. (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
+    argsman.AddArg("-extendedcoinbasematurity=<time>", strprintf("Schedule the extended coinbase maturity soft fork: coinbase outputs created from the first block whose parent's median-time-past reaches <time> need %d confirmations to be spent, until the RDTS expiry. Requires -rdtsexpiry, which <time> must precede. (regtest-only)", EXTENDED_COINBASE_MATURITY), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-blake2b_headline=<headline>", "Specify consensus-critical proof-of-time news headline. Requires -testactivationheight=blake2b@<height>. (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-testnet", "Use the testnet3 chain. Equivalent to -chain=test. Support for testnet3 is deprecated and will be removed in an upcoming release. Consider moving to testnet4 now by using -testnet4.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-testnet4", "Use the testnet4 chain. Equivalent to -chain=testnet4.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -19,6 +19,9 @@ static const unsigned int REDUCED_DATA_MAX_BLOCK_WEIGHT = 800000;
 static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
+/** Coinbase maturity applied by the temporary extended-maturity soft fork to coinbase outputs created
+ *  while it is active: 45 days of ten-minute blocks (see Consensus::Params::ExtendedCoinbaseMaturityActiveAt) */
+static const int EXTENDED_COINBASE_MATURITY = 6480;
 
 static const int WITNESS_SCALE_FACTOR = 4;
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -123,6 +123,22 @@ struct Params {
      * behaviour is unchanged on chains that do not set it.
      */
     int64_t RdtsExpiryTime{std::numeric_limits<int64_t>::min()};
+    /**
+     * Extended coinbase maturity, a temporary soft fork: while it is active,
+     * coinbase outputs created since it activated can only be spent once
+     * buried under EXTENDED_COINBASE_MATURITY blocks rather than
+     * COINBASE_MATURITY. It is active for a block when the parent's
+     * median-time-past has reached this start time and not yet the RDTS
+     * expiry (see ExtendedCoinbaseMaturityActiveAt): it expires with RDTS,
+     * after which every coinbase output is again spendable at
+     * COINBASE_MATURITY. Outputs created before activation are never
+     * affected, so activating cannot lock an output that was already
+     * spendable.
+     *
+     * The default leaves the deployment unscheduled (the start follows every
+     * median-time-past).
+     */
+    int64_t ExtendedCoinbaseMaturityStartTime{std::numeric_limits<int64_t>::max()};
     /** Don't warn about unknown BIP 9 activations below this height.
      * This prevents us from warning about the CSV and segwit activations. */
     int MinBIP9WarningHeight;
@@ -194,6 +210,14 @@ struct Params {
     bool RdtsActiveAt(int height, int64_t mtp_prev) const
     {
         return IsBlake2bHeight(height) && mtp_prev < RdtsExpiryTime;
+    }
+
+    /** Whether the extended coinbase maturity rule applies to a block whose
+     *  parent has the given median-time-past. It expires with RDTS, so it is
+     *  never active on a chain with no RDTS expiry. */
+    bool ExtendedCoinbaseMaturityActiveAt(int64_t mtp_prev) const
+    {
+        return mtp_prev >= ExtendedCoinbaseMaturityStartTime && mtp_prev < RdtsExpiryTime;
     }
 };
 

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -172,7 +172,12 @@ bool Consensus::CheckOutputSizes(const CTransaction& tx, TxValidationState& stat
     return true;
 }
 
-bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee, const CheckTxInputsRules rules)
+int Consensus::RequiredCoinbaseMaturity(int coinbase_height, int extended_maturity_start_height)
+{
+    return coinbase_height >= extended_maturity_start_height ? EXTENDED_COINBASE_MATURITY : COINBASE_MATURITY;
+}
+
+bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee, const CheckTxInputsRules rules, const int extended_maturity_start_height)
 {
     // are the actual inputs available?
     if (!inputs.HaveInputs(tx)) {
@@ -192,9 +197,12 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, 
         assert(!coin.IsSpent());
 
         // If prev is coinbase, check that it's matured
-        if (coin.IsCoinBase() && nSpendHeight - coin.nHeight < COINBASE_MATURITY) {
-            return state.Invalid(TxValidationResult::TX_PREMATURE_SPEND, "bad-txns-premature-spend-of-coinbase",
-                strprintf("tried to spend coinbase at depth %d", nSpendHeight - coin.nHeight));
+        if (coin.IsCoinBase()) {
+            const int maturity{RequiredCoinbaseMaturity(coin.nHeight, extended_maturity_start_height)};
+            if (nSpendHeight - coin.nHeight < maturity) {
+                return state.Invalid(TxValidationResult::TX_PREMATURE_SPEND, "bad-txns-premature-spend-of-coinbase",
+                    strprintf("tried to spend coinbase at depth %d (maturity %d)", nSpendHeight - coin.nHeight, maturity));
+            }
         }
 
         // Check for negative or overflow input values

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -50,12 +50,23 @@ namespace Consensus {
 bool CheckOutputSizes(const CTransaction& tx, TxValidationState& state);
 
 /**
+ * Number of blocks a coinbase output created at coinbase_height must be buried
+ * under before it may be spent: EXTENDED_COINBASE_MATURITY for outputs created
+ * at or after extended_maturity_start_height, COINBASE_MATURITY otherwise.
+ * Callers pass ExtendedCoinbaseMaturityStartHeight() (validation.h) for the
+ * spending block, which is std::numeric_limits<int>::max() (no output
+ * qualifies) whenever the extended-maturity soft fork is not active for it.
+ */
+int RequiredCoinbaseMaturity(int coinbase_height, int extended_maturity_start_height);
+
+/**
  * Check whether all inputs of this transaction are valid (no double spends and amounts)
  * This does not modify the UTXO set. This does not check scripts and sigs.
  * @param[out] txfee Set to the transaction fee if successful.
+ * @param[in] extended_maturity_start_height See RequiredCoinbaseMaturity.
  * Preconditions: tx.IsCoinBase() is false.
  */
-[[nodiscard]] bool CheckTxInputs(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee, CheckTxInputsRules rules);
+[[nodiscard]] bool CheckTxInputs(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee, CheckTxInputsRules rules, int extended_maturity_start_height);
 } // namespace Consensus
 
 /** Auxiliary functions for transaction validation (ideally should not be exposed) */

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -144,6 +144,12 @@ public:
     //! pruned), and contains transactions.
     virtual bool haveBlockOnDisk(int height) = 0;
 
+    //! Number of blocks a coinbase output created at the given height must
+    //! be buried under before it can be spent in the block following the
+    //! current chain tip: COINBASE_MATURITY, or EXTENDED_COINBASE_MATURITY
+    //! while the temporary extended-maturity soft fork applies to it.
+    virtual int coinbaseMaturity(int coinbase_height) = 0;
+
     virtual bool pruneLockExists(const std::string& name) const = 0;
     virtual bool updatePruneLock(const std::string& name, const node::PruneLockInfo& lock_info, bool sync=false) = 0;
     virtual bool deletePruneLock(const std::string& name) = 0;

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -131,6 +131,10 @@ public:
         // reaching ACTIVE, and that deployment has been removed.)
         consensus.RdtsExpiryTime = 1819756800; // September 1st, 2027 00:00 UTC
 
+        // Extended coinbase maturity (temporary soft fork, expires with RDTS
+        // above): the start time is set at release cut. Unscheduled until then.
+        // consensus.ExtendedCoinbaseMaturityStartTime = ...;
+
         consensus.nMinimumChainWork = uint256{"00000000000000000000000000000000000000013e00277374c9f9eeadc70200"};
         consensus.defaultAssumeValid = uint256{"0000000000000078ed1e20cac1acf78df6d1060c78059fb6331e17141c881fc8"}; // 964264
 
@@ -403,6 +407,7 @@ public:
 
         consensus.Blake2bHeight = 150308;
         consensus.RdtsExpiryTime = 1791903600; // October 13th, 2026 15:00:00 UTC
+        // Extended coinbase maturity: unscheduled until release cut (see mainnet).
 
         consensus.nMinimumChainWork = uint256{"0000000000000000000000000000000000000000000001d6dce8651b6094e4c1"};
         consensus.defaultAssumeValid = uint256{"0000000000003ed4f08dbdf6f7d6b271a6bcffce25675cb40aa9fa43179a89f3"}; // 72600
@@ -663,6 +668,13 @@ public:
         // default, so regtest behaviour is unchanged.
         if (opts.rdts_expiry_time) {
             consensus.RdtsExpiryTime = *opts.rdts_expiry_time;
+        }
+
+        // Optionally schedule the extended coinbase maturity soft fork (see
+        // -extendedcoinbasematurity). It expires with RDTS, so it requires the
+        // RDTS expiry scheduled above.
+        if (opts.extended_coinbase_maturity_start_time) {
+            consensus.ExtendedCoinbaseMaturityStartTime = *opts.extended_coinbase_maturity_start_time;
         }
 
         for (const auto& [deployment_pos, version_bits_params] : opts.version_bits_parameters) {

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -170,6 +170,11 @@ public:
         //! height until the parent block's median-time-past reaches this
         //! value (see -rdtsexpiry). Requires a blake2b activation height.
         std::optional<int64_t> rdts_expiry_time{};
+        //! If set, the extended coinbase maturity rule applies to blocks
+        //! whose parent's median-time-past has reached this value, until the
+        //! RDTS expiry (see -extendedcoinbasematurity). Requires
+        //! rdts_expiry_time, which it must precede.
+        std::optional<int64_t> extended_coinbase_maturity_start_time{};
         std::optional<std::vector<unsigned char>> blake2b_headline{};
     };
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -10,7 +10,9 @@
 #include <chainparamsbase.h>
 #include <common/args.h>
 #include <common/pcp.h>
+#include <consensus/consensus.h>
 #include <consensus/merkle.h>
+#include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <deploymentstatus.h>
 #include <external_signer.h>
@@ -580,6 +582,13 @@ public:
         LOCK(::cs_main);
         const CBlockIndex* block{chainman().ActiveChain()[height]};
         return block && ((block->nStatus & BLOCK_HAVE_DATA) != 0) && block->nTx > 0;
+    }
+    int coinbaseMaturity(int coinbase_height) override
+    {
+        LOCK(::cs_main);
+        const CBlockIndex* tip{chainman().ActiveChain().Tip()};
+        if (!tip) return COINBASE_MATURITY;
+        return Consensus::RequiredCoinbaseMaturity(coinbase_height, ExtendedCoinbaseMaturityStartHeight(chainman().GetConsensus(), *tip));
     }
     bool pruneLockExists(const std::string& name) const override
     {

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -329,7 +329,12 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
 
     if (wtx.is_coinbase)
     {
-        quint32 numBlocksToMaturity = COINBASE_MATURITY +  1;
+        // While still maturing, the wallet's count reflects the maturity that
+        // actually applies (the temporary extended maturity soft fork may
+        // require more than COINBASE_MATURITY); once mature, show the default.
+        quint32 numBlocksToMaturity = status.blocks_to_maturity > 0 && status.is_in_main_chain
+            ? status.blocks_to_maturity + status.depth_in_main_chain
+            : COINBASE_MATURITY + 1;
         strHTML += "<br>" + tr("Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to \"not accepted\" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.").arg(QString::number(numBlocksToMaturity)) + "<br>";
     }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1913,10 +1913,11 @@ RPCHelpMan getblockchaininfo()
 namespace {
 const std::vector<RPCResult> RPCHelpForDeployment{
     {RPCResult::Type::STR, "type", "one of \"buried\", \"bip9\", \"flagday\""},
-    {RPCResult::Type::NUM, "height", /*optional=*/true, "height of the first block which enforces the rules (only for \"buried\" and \"flagday\" types, or \"bip9\" type with \"active\" status; for \"flagday\" this is the BLAKE2b hardfork height)"},
+    {RPCResult::Type::NUM, "height", /*optional=*/true, "height of the first block which enforces the rules (only for \"buried\" and \"flagday\" types, or \"bip9\" type with \"active\" status; for \"reduced_data\" this is the BLAKE2b hardfork height; for \"extended_coinbase_maturity\" it is the activation height on the queried block's chain, present once that chain's median time past has reached start_time)"},
     {RPCResult::Type::NUM, "height_end", /*optional=*/true, "height of the last block which enforces the rules (only for \"bip9\" type with \"active\" status and temporary deployments)"},
     {RPCResult::Type::BOOL, "active", "true if the rules are enforced for the mempool and the next block (the mempool applies the RDTS rules regardless of this flag)"},
-    {RPCResult::Type::NUM_TIME, "expiry_time", /*optional=*/true, "median time past at and after which the rules are no longer enforced (only for \"flagday\" type; a block is past expiry when its parent's median time past has reached this value)"},
+    {RPCResult::Type::NUM_TIME, "start_time", /*optional=*/true, "median time past at and after which the rules are enforced (only for the \"extended_coinbase_maturity\" flag-day deployment; a block enforces the rules when its parent's median time past has reached this value)"},
+    {RPCResult::Type::NUM_TIME, "expiry_time", /*optional=*/true, "median time past at and after which the rules are no longer enforced (only for \"flagday\" type; a block is past expiry when its parent's median time past has reached this value; \"extended_coinbase_maturity\" shares the \"reduced_data\" expiry)"},
     {RPCResult::Type::OBJ, "bip9", /*optional=*/true, "status of bip9 softforks (only for \"bip9\" type)",
     {
         {RPCResult::Type::NUM, "bit", /*optional=*/true, "the bit (0-28) in the block version field used to signal this softfork (only for \"started\" and \"locked_in\" status)"},
@@ -1940,26 +1941,51 @@ const std::vector<RPCResult> RPCHelpForDeployment{
     }},
 };
 
-// RDTS (a flag-day deployment, not a versionbits one): rules apply to every
-// block from the BLAKE2b hardfork height until the parent block's
-// median-time-past reaches RdtsExpiryTime. Reported as-of the queried block,
-// with "active" meaning the next block, like the versionbits entries. Omitted
-// entirely when unscheduled (plain regtest), as NEVER_ACTIVE deployments are.
-void RdtsFlagDayDescPushBack(const CBlockIndex* blockindex, UniValue& softforks, const ChainstateManager& chainman)
+// Flag-day deployments (not versionbits ones): rules apply to every block
+// from an activation point until the parent block's median-time-past reaches
+// an expiry. Reported as-of the queried block, with "active" meaning the next
+// block, like the versionbits entries. Omitted entirely when unscheduled
+// (plain regtest), as NEVER_ACTIVE deployments are.
+void FlagDayDescPushBack(UniValue& softforks, const std::string& name, std::optional<int> height, std::optional<int64_t> start_time, int64_t expiry_time, bool active_next)
 {
-    const Consensus::Params& params{chainman.GetConsensus()};
-    if (params.Blake2bHeight == std::numeric_limits<int>::max() ||
-        params.RdtsExpiryTime == std::numeric_limits<int64_t>::min()) return;
+    if (expiry_time == std::numeric_limits<int64_t>::min()) return;
 
     UniValue rv(UniValue::VOBJ);
     rv.pushKV("type", "flagday");
-    rv.pushKV("height", params.RdtsActivationHeight());
-    rv.pushKV("expiry_time", params.RdtsExpiryTime);
+    if (height) rv.pushKV("height", *height);
+    if (start_time) rv.pushKV("start_time", *start_time);
+    rv.pushKV("expiry_time", expiry_time);
+    rv.pushKV("active", active_next);
+    softforks.pushKV(name, std::move(rv));
+}
+
+// RDTS: from the BLAKE2b hardfork height until RdtsExpiryTime.
+void RdtsFlagDayDescPushBack(const CBlockIndex* blockindex, UniValue& softforks, const ChainstateManager& chainman)
+{
+    const Consensus::Params& params{chainman.GetConsensus()};
+    if (params.Blake2bHeight == std::numeric_limits<int>::max()) return;
     // "active" describes the NEXT block, as the versionbits entries do, so the
     // queried block is that block's parent and its median-time-past is exactly
     // the parent median-time-past RdtsActiveAt expects.
-    rv.pushKV("active", params.RdtsActiveAt(blockindex->nHeight + 1, blockindex->GetMedianTimePast()));
-    softforks.pushKV("reduced_data", std::move(rv));
+    FlagDayDescPushBack(softforks, "reduced_data", params.RdtsActivationHeight(), std::nullopt, params.RdtsExpiryTime,
+                        params.RdtsActiveAt(blockindex->nHeight + 1, blockindex->GetMedianTimePast()));
+}
+
+// Extended coinbase maturity: from the block whose parent's median-time-past
+// reaches ExtendedCoinbaseMaturityStartTime until the RDTS expiry (it expires
+// with RDTS). The activation height depends on the chain, so it is reported
+// once the queried block's chain has determined it.
+void ExtendedCoinbaseMaturityDescPushBack(const CBlockIndex* blockindex, UniValue& softforks, const ChainstateManager& chainman)
+{
+    const Consensus::Params& params{chainman.GetConsensus()};
+    if (params.ExtendedCoinbaseMaturityStartTime == std::numeric_limits<int64_t>::max()) return;
+    const int64_t mtp{blockindex->GetMedianTimePast()};
+    std::optional<int> height;
+    if (mtp >= params.ExtendedCoinbaseMaturityStartTime) {
+        height = MedianTimePastActivationHeight(*blockindex, params.ExtendedCoinbaseMaturityStartTime);
+    }
+    FlagDayDescPushBack(softforks, "extended_coinbase_maturity", height, params.ExtendedCoinbaseMaturityStartTime, params.RdtsExpiryTime,
+                        params.ExtendedCoinbaseMaturityActiveAt(mtp));
 }
 
 UniValue DeploymentInfo(const CBlockIndex* blockindex, const ChainstateManager& chainman)
@@ -1973,6 +1999,7 @@ UniValue DeploymentInfo(const CBlockIndex* blockindex, const ChainstateManager& 
     SoftForkDescPushBack(blockindex, softforks, chainman, Consensus::DEPLOYMENT_TESTDUMMY);
     SoftForkDescPushBack(blockindex, softforks, chainman, Consensus::DEPLOYMENT_TAPROOT);
     RdtsFlagDayDescPushBack(blockindex, softforks, chainman);
+    ExtendedCoinbaseMaturityDescPushBack(blockindex, softforks, chainman);
     return softforks;
 }
 } // anon namespace

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1082,6 +1082,12 @@ static UniValue TemplateToJSON(const Consensus::Params& consensusParams, const C
     if (rdts_active) {
         aRules.push_back("reduced_data");
     }
+    // Extended coinbase maturity (a flag-day deployment expiring with RDTS).
+    // Enforced during transaction selection; advertised unprefixed like
+    // "reduced_data", as clients need no special support for it.
+    if (pindexPrev != nullptr && consensusParams.ExtendedCoinbaseMaturityActiveAt(pindexPrev->GetMedianTimePast())) {
+        aRules.push_back("extended_coinbase_maturity");
+    }
 
     result.pushKV("version", block_header.GetCompleteVersion());
     result.pushKV("rules", std::move(aRules));

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -256,7 +256,7 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                     // It is not allowed to call CheckTxInputs if CheckTransaction failed
                     return;
                 }
-                if (Consensus::CheckTxInputs(transaction, state, coins_view_cache, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, std::numeric_limits<int>::max()), tx_fee_out, CheckTxInputsRules::OutputSizeLimit)) {
+                if (Consensus::CheckTxInputs(transaction, state, coins_view_cache, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, std::numeric_limits<int>::max()), tx_fee_out, CheckTxInputsRules::OutputSizeLimit, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, std::numeric_limits<int>::max()))) {
                     assert(MoneyRange(tx_fee_out));
                 }
             },

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -4,7 +4,9 @@
 
 #include <chainparams.h>
 #include <consensus/amount.h>
+#include <consensus/consensus.h>
 #include <consensus/merkle.h>
+#include <consensus/tx_verify.h>
 #include <core_io.h>
 #include <hash.h>
 #include <net.h>
@@ -13,7 +15,9 @@
 #include <util/chaintype.h>
 #include <validation.h>
 
+#include <limits>
 #include <string>
+#include <vector>
 
 #include <test/util/setup_common.h>
 
@@ -396,6 +400,89 @@ BOOST_AUTO_TEST_CASE(block_malleation)
         }
         BOOST_CHECK(is_mutated(block, /*check_witness_root=*/true));
     }
+}
+
+//! A chain of `length` block indexes with skip pointers, block i stamped `times[i]`.
+static std::vector<CBlockIndex> MakeTimedChain(const std::vector<int64_t>& times)
+{
+    std::vector<CBlockIndex> chain(times.size());
+    for (size_t i = 0; i < times.size(); ++i) {
+        chain[i].nHeight = i;
+        chain[i].nTime = times[i];
+        chain[i].pprev = i == 0 ? nullptr : &chain[i - 1];
+        chain[i].BuildSkip();
+    }
+    return chain;
+}
+
+BOOST_AUTO_TEST_CASE(median_time_past_activation_height)
+{
+    // Consensus keeps median-time-past non-decreasing along a chain (a block's
+    // time must exceed its parent's median); non-decreasing times reproduce
+    // that here, with plateaus to exercise the "first block whose parent
+    // reached it" boundary.
+    std::vector<int64_t> times;
+    int64_t t{1000};
+    for (int i = 0; i < 300; ++i) {
+        times.push_back(t);
+        if (i % 7 == 0) t += 10; // plateaus of equal times, then a jump
+    }
+    const auto chain{MakeTimedChain(times)};
+    const CBlockIndex& tip{chain.back()};
+
+    // Brute force: the first height whose parent's median-time-past is >= start.
+    const auto expected = [&](int64_t start) {
+        for (int h = 1; h <= tip.nHeight; ++h) {
+            if (chain[h - 1].GetMedianTimePast() >= start) return h;
+        }
+        return tip.nHeight + 1;
+    };
+    for (int64_t start = times.front() - 5; start <= tip.GetMedianTimePast(); ++start) {
+        BOOST_CHECK_EQUAL(MedianTimePastActivationHeight(tip, start), expected(start));
+        // The same answer from any ancestor whose median-time-past has reached it.
+        for (int h : {tip.nHeight / 2, tip.nHeight - 1}) {
+            if (chain[h].GetMedianTimePast() >= start) {
+                BOOST_CHECK_EQUAL(MedianTimePastActivationHeight(chain[h], start), expected(start));
+            }
+        }
+    }
+    // A start the genesis block already satisfies activates at height 1.
+    BOOST_CHECK_EQUAL(MedianTimePastActivationHeight(tip, times.front()), 1);
+    BOOST_CHECK_EQUAL(MedianTimePastActivationHeight(chain[0], times.front()), 1);
+}
+
+BOOST_AUTO_TEST_CASE(extended_coinbase_maturity_start_height)
+{
+    std::vector<int64_t> times;
+    for (int i = 0; i < 200; ++i) times.push_back(1000 + 10 * i);
+    const auto chain{MakeTimedChain(times)};
+
+    Consensus::Params params{};
+    constexpr int inactive{std::numeric_limits<int>::max()};
+    // Unscheduled (defaults): never active, whatever the time.
+    BOOST_CHECK_EQUAL(ExtendedCoinbaseMaturityStartHeight(params, chain.back()), inactive);
+    // Start without an RDTS expiry: still never active (it expires with RDTS).
+    params.ExtendedCoinbaseMaturityStartTime = chain[50].GetMedianTimePast();
+    BOOST_CHECK_EQUAL(ExtendedCoinbaseMaturityStartHeight(params, chain.back()), inactive);
+    params.RdtsExpiryTime = chain[150].GetMedianTimePast();
+
+    // Block 51 is the first whose parent (50) has reached the start; block
+    // 151 the first whose parent has reached the expiry.
+    BOOST_CHECK_EQUAL(ExtendedCoinbaseMaturityStartHeight(params, chain[49]), inactive);
+    BOOST_CHECK_EQUAL(ExtendedCoinbaseMaturityStartHeight(params, chain[50]), 51);
+    BOOST_CHECK_EQUAL(ExtendedCoinbaseMaturityStartHeight(params, chain[100]), 51);
+    BOOST_CHECK_EQUAL(ExtendedCoinbaseMaturityStartHeight(params, chain[149]), 51);
+    BOOST_CHECK_EQUAL(ExtendedCoinbaseMaturityStartHeight(params, chain[150]), inactive);
+    BOOST_CHECK_EQUAL(ExtendedCoinbaseMaturityStartHeight(params, chain.back()), inactive);
+
+    // The maturity a spend in the block after chain[100] requires: outputs
+    // from the activation height on are extended, earlier ones are not, and
+    // nothing is once the rule is inactive.
+    const int start{ExtendedCoinbaseMaturityStartHeight(params, chain[100])};
+    BOOST_CHECK_EQUAL(Consensus::RequiredCoinbaseMaturity(50, start), COINBASE_MATURITY);
+    BOOST_CHECK_EQUAL(Consensus::RequiredCoinbaseMaturity(51, start), EXTENDED_COINBASE_MATURITY);
+    BOOST_CHECK_EQUAL(Consensus::RequiredCoinbaseMaturity(100, start), EXTENDED_COINBASE_MATURITY);
+    BOOST_CHECK_EQUAL(Consensus::RequiredCoinbaseMaturity(51, inactive), COINBASE_MATURITY);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -877,9 +877,10 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
         TxValidationState dummy_state; // Not used. CheckTxInputs() should always pass
         CAmount txfee = 0;
         assert(!tx.IsCoinBase());
-        // Skip output size checks (CheckTxInputsRules::None), as these transactions already passed
-        // output size limits at mempool acceptance; this check only verifies UTXO consistency
-        assert(Consensus::CheckTxInputs(tx, dummy_state, mempoolDuplicate, spendheight, txfee, CheckTxInputsRules::None));
+        // Skip output size checks (CheckTxInputsRules::None) and the extended coinbase
+        // maturity rule, as these transactions already passed both at mempool acceptance;
+        // this check only verifies UTXO consistency
+        assert(Consensus::CheckTxInputs(tx, dummy_state, mempoolDuplicate, spendheight, txfee, CheckTxInputsRules::None, std::numeric_limits<int>::max()));
         for (const auto& input: tx.vin) mempoolDuplicate.SpendCoin(input.prevout);
         AddCoins(mempoolDuplicate, tx, std::numeric_limits<int>::max());
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -272,6 +272,34 @@ bool CheckSequenceLocksAtTip(CBlockIndex* tip,
     return EvaluateSequenceLocks(index, {lock_points.height, lock_points.time});
 }
 
+int MedianTimePastActivationHeight(const CBlockIndex& tip, int64_t start_time)
+{
+    assert(tip.GetMedianTimePast() >= start_time);
+    // Binary search over the ancestors for the lowest height whose
+    // median-time-past has reached start_time; the block after it is the first
+    // whose parent's has. Valid because a block's time must exceed its parent's
+    // median-time-past, which keeps median-time-past non-decreasing along a chain.
+    int lo{0};
+    int hi{tip.nHeight};
+    while (lo < hi) {
+        const int mid{lo + (hi - lo) / 2};
+        if (Assert(tip.GetAncestor(mid))->GetMedianTimePast() >= start_time) {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+    return lo + 1;
+}
+
+int ExtendedCoinbaseMaturityStartHeight(const Consensus::Params& params, const CBlockIndex& block_prev)
+{
+    if (!params.ExtendedCoinbaseMaturityActiveAt(block_prev.GetMedianTimePast())) {
+        return std::numeric_limits<int>::max();
+    }
+    return MedianTimePastActivationHeight(block_prev, params.ExtendedCoinbaseMaturityStartTime);
+}
+
 // Returns the script flags which should be checked for a given block
 static unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const ChainstateManager& chainman);
 
@@ -432,13 +460,18 @@ void Chainstate::MaybeUpdateMempoolForReorg(
         }
 
         // If the transaction spends any coinbase outputs, it must be mature.
+        // The required maturity depends on the new tip too: the extended
+        // coinbase maturity rule may apply to the next block again after a
+        // reorg back across its expiry, or its window may start at a different
+        // height on the new branch (see ExtendedCoinbaseMaturityStartHeight).
         if (it->GetSpendsCoinbase()) {
+            const auto mempool_spend_height{m_chain.Tip()->nHeight + 1};
+            const int extended_maturity_start_height{ExtendedCoinbaseMaturityStartHeight(m_chainman.GetConsensus(), *m_chain.Tip())};
             for (const CTxIn& txin : tx.vin) {
                 if (m_mempool->exists(GenTxid::Txid(txin.prevout.hash))) continue;
                 const Coin& coin{CoinsTip().AccessCoin(txin.prevout)};
                 assert(!coin.IsSpent());
-                const auto mempool_spend_height{m_chain.Tip()->nHeight + 1};
-                if (coin.IsCoinBase() && mempool_spend_height - coin.nHeight < COINBASE_MATURITY) {
+                if (coin.IsCoinBase() && mempool_spend_height - coin.nHeight < Consensus::RequiredCoinbaseMaturity(coin.nHeight, extended_maturity_start_height)) {
                     return true;
                 }
             }
@@ -1015,7 +1048,11 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // The mempool holds txs for the next block, so pass height+1 to CheckTxInputs
     const auto block_height_current = m_active_chainstate.m_chain.Height();
     const auto block_height_next = block_height_current + 1;
-    if (!Consensus::CheckTxInputs(tx, state, m_view, block_height_next, ws.m_base_fees, CheckTxInputsRules::OutputSizeLimit)) {
+    // The extended coinbase maturity rule (see ExtendedCoinbaseMaturityStartHeight)
+    // is likewise evaluated for the next block, whose parent is the tip.
+    const int extended_maturity_start_height{ExtendedCoinbaseMaturityStartHeight(
+        m_active_chainstate.m_chainman.GetConsensus(), *m_active_chainstate.m_chain.Tip())};
+    if (!Consensus::CheckTxInputs(tx, state, m_view, block_height_next, ws.m_base_fees, CheckTxInputsRules::OutputSizeLimit, extended_maturity_start_height)) {
         return false; // state filled in by CheckTxInputs
     }
 
@@ -2993,6 +3030,13 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     const CheckTxInputsRules chk_input_rules{reduced_data_active ? CheckTxInputsRules::OutputSizeLimit : CheckTxInputsRules::None};
 
+    // Extended coinbase maturity (see ExtendedCoinbaseMaturityStartHeight): a
+    // temporary soft fork that expires with RDTS. While it is active for this
+    // block, coinbase outputs created since its activation on this chain must
+    // be buried under EXTENDED_COINBASE_MATURITY blocks; earlier outputs keep
+    // COINBASE_MATURITY. When inactive no output qualifies.
+    const int extended_maturity_start_height{ExtendedCoinbaseMaturityStartHeight(params.GetConsensus(), *pindex->pprev)};
+
     // Check generation tx output sizes if REDUCED_DATA is active
     if (chk_input_rules.test(CheckTxInputsRules::OutputSizeLimit)) {
         TxValidationState tx_state;
@@ -3020,7 +3064,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         {
             CAmount txfee = 0;
             TxValidationState tx_state;
-            if (!Consensus::CheckTxInputs(tx, tx_state, view, pindex->nHeight, txfee, chk_input_rules)) {
+            if (!Consensus::CheckTxInputs(tx, tx_state, view, pindex->nHeight, txfee, chk_input_rules, extended_maturity_start_height)) {
                 // Any transaction validation failure in ConnectBlock is a block consensus failure
                 state.Invalid(BlockValidationResult::BLOCK_CONSENSUS,
                               tx_state.GetRejectReason(),

--- a/src/validation.h
+++ b/src/validation.h
@@ -347,6 +347,26 @@ std::optional<LockPoints> CalculateLockPointsAtTip(
 bool CheckSequenceLocksAtTip(CBlockIndex* tip,
                              const LockPoints& lock_points);
 
+/**
+ * The activation height, on the chain ending at `tip`, of a deployment
+ * scheduled by median-time-past: the height of the first block whose parent's
+ * median-time-past is at least `start_time`. Median-time-past never decreases
+ * along a chain, so the blocks it activates for form a suffix of the chain.
+ * Requires tip.GetMedianTimePast() >= start_time, so that the answer is at most
+ * tip.nHeight + 1 (the block built on `tip`).
+ */
+int MedianTimePastActivationHeight(const CBlockIndex& tip, int64_t start_time);
+
+/**
+ * Extended coinbase maturity (see Consensus::Params::ExtendedCoinbaseMaturityActiveAt).
+ * For the block built on `block_prev`, the height from which coinbase outputs
+ * are subject to EXTENDED_COINBASE_MATURITY when spent in it: the deployment's
+ * activation height on that chain, or std::numeric_limits<int>::max() when the
+ * rule is not active for that block, so that no output qualifies (see
+ * Consensus::RequiredCoinbaseMaturity).
+ */
+int ExtendedCoinbaseMaturityStartHeight(const Consensus::Params& params, const CBlockIndex& block_prev);
+
 void LimitMempoolSize(CTxMemPool&, CCoinsViewCache&);
 
 /**

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3646,7 +3646,16 @@ int CWallet::GetTxBlocksToMaturity(const CWalletTx& wtx) const
     }
     int chain_depth = GetTxDepthInMainChain(wtx);
     assert(chain_depth >= 0); // coinbase tx should not be conflicted
-    return std::max(0, (COINBASE_MATURITY+1) - chain_depth);
+    int maturity{COINBASE_MATURITY};
+    // A confirmed coinbase may be subject to the temporary extended maturity
+    // soft fork; outputs already buried deeper than that are mature under
+    // either rule, so only ask the chain about the ones that could differ.
+    if (chain_depth <= EXTENDED_COINBASE_MATURITY && HaveChain()) {
+        if (auto* conf = wtx.state<TxStateConfirmed>()) {
+            maturity = chain().coinbaseMaturity(conf->confirmed_block_height);
+        }
+    }
+    return std::max(0, (maturity + 1) - chain_depth);
 }
 
 bool CWallet::IsTxImmatureCoinBase(const CWalletTx& wtx) const

--- a/test/functional/feature_extended_coinbase_maturity.py
+++ b/test/functional/feature_extended_coinbase_maturity.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Knots developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the extended coinbase maturity temporary soft fork.
+
+While the deployment is active, coinbase outputs created since it activated
+need EXTENDED_COINBASE_MATURITY confirmations instead of COINBASE_MATURITY.
+It activates for the first block whose parent's median-time-past reaches
+-extendedcoinbasematurity and expires with RDTS (-rdtsexpiry).
+
+Covered:
+- option validation (requires -rdtsexpiry, must precede it)
+- activation height derived from median-time-past; getdeploymentinfo/getblocktemplate
+- grandfathering: a coinbase from the block before activation keeps the 100-block rule
+- an in-window coinbase is rejected at depth >= 100 by the mempool and in a block
+- spendable at exactly EXTENDED_COINBASE_MATURITY; the reorg filter evicts it one block earlier
+- hard expiry: a still-locked coinbase becomes spendable once the parent MTP reaches
+  the expiry, and a reorg back across the expiry evicts the spend again
+- the wallet reports the reward as immature while locked
+- -reindex reproduces the chain and derives the same activation height
+"""
+
+from test_framework.blocktools import (
+    COINBASE_MATURITY,
+    add_witness_commitment,
+    create_block,
+)
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet import MiniWallet
+
+EXTENDED_COINBASE_MATURITY = 6480  # 45 days of ten-minute blocks
+BLAKE2B_HEIGHT = 120
+# Mock clock: pre-activation blocks are stamped from T0, the window opens once
+# the median-time-past reaches START, and RDTS (with it, this rule) expires at
+# EXPIRY. Block times creep by one second per block, so START and EXPIRY leave
+# room for the blocks mined before each.
+T0 = 1_600_000_000
+START = T0 + 10_000
+EXPIRY = START + 50_000
+REJECT = 'bad-txns-premature-spend-of-coinbase'
+
+
+class ExtendedCoinbaseMaturityTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.rpc_timeout = 240
+        self.base_args = [
+            f'-testactivationheight=blake2b@{BLAKE2B_HEIGHT}',
+            f'-rdtsexpiry={EXPIRY}',
+            f'-extendedcoinbasematurity={START}',
+        ]
+        self.extra_args = [self.base_args]
+
+    def mine(self, count):
+        """Mine count blocks to the MiniWallet, keeping the mock clock within
+        the two-hour future window of the creeping block times."""
+        node = self.nodes[0]
+        while count > 0:
+            chunk = min(count, 1000)
+            self.mocktime = max(self.mocktime, node.getblockheader(node.getbestblockhash())['time']) + chunk
+            node.setmocktime(self.mocktime)
+            self.generate(self.wallet, chunk, sync_fun=self.no_op)
+            count -= chunk
+
+    def mtp(self, height):
+        node = self.nodes[0]
+        return node.getblockheader(node.getblockhash(height))['mediantime']
+
+    def coinbase_utxo(self, height):
+        node = self.nodes[0]
+        txid = node.getblock(node.getblockhash(height))['tx'][0]
+        return self.wallet.get_utxo(txid=txid)
+
+    def assert_spend_rejected(self, tx_hex):
+        node = self.nodes[0]
+        assert_equal(node.testmempoolaccept([tx_hex])[0]['reject-reason'], REJECT)
+        assert_raises_rpc_error(-26, REJECT, node.sendrawtransaction, tx_hex)
+
+    def submit_block_with(self, tx_hex):
+        """Mine a block carrying tx_hex ourselves and return submitblock's verdict."""
+        node = self.nodes[0]
+        tmpl = node.getblocktemplate({'rules': ['segwit', 'blake2b']})
+        block = create_block(tmpl=tmpl, txlist=[tx_hex])
+        add_witness_commitment(block)
+        block.solve()
+        return node.submitblock(block.serialize().hex())
+
+    def assert_deploymentinfo(self, *, active, height=None):
+        info = self.nodes[0].getdeploymentinfo()['deployments']['extended_coinbase_maturity']
+        assert_equal(info['type'], 'flagday')
+        assert_equal(info['start_time'], START)
+        assert_equal(info['expiry_time'], EXPIRY)
+        assert_equal(info['active'], active)
+        assert_equal(info.get('height'), height)
+
+    def assert_gbt_rule(self, *, active):
+        tmpl = self.nodes[0].getblocktemplate({'rules': ['segwit', 'blake2b']})
+        assert_equal('extended_coinbase_maturity' in tmpl['rules'], active)
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("Option validation")
+        self.stop_node(0)
+        node.assert_start_raises_init_error(
+            extra_args=[f'-testactivationheight=blake2b@{BLAKE2B_HEIGHT}', f'-extendedcoinbasematurity={START}'],
+            expected_msg='Error: -extendedcoinbasematurity requires -rdtsexpiry=<time> (the rule expires with RDTS).')
+        node.assert_start_raises_init_error(
+            extra_args=[f'-testactivationheight=blake2b@{BLAKE2B_HEIGHT}', f'-rdtsexpiry={EXPIRY}', f'-extendedcoinbasematurity={EXPIRY}'],
+            expected_msg=f'Error: Invalid start ({EXPIRY}) for -extendedcoinbasematurity=<time>: must precede the RDTS expiry ({EXPIRY}).')
+        self.start_node(0)
+        node.add_p2p_connection(P2PInterface())  # getblocktemplate needs a peer
+
+        self.wallet = MiniWallet(node)
+        self.mocktime = T0
+        node.setmocktime(self.mocktime)
+
+        self.log.info("Before activation: the 100-block rule applies")
+        self.generate(self.wallet, 200, sync_fun=self.no_op)  # crosses the BLAKE2b fork
+        assert_greater_than(START, self.mtp(200))
+        self.assert_deploymentinfo(active=False)
+        self.assert_gbt_rule(active=False)
+        spend = self.wallet.create_self_transfer(utxo_to_spend=self.coinbase_utxo(201 - COINBASE_MATURITY))
+        node.sendrawtransaction(spend['hex'])
+        self.generate(self.wallet, 1, sync_fun=self.no_op)
+
+        self.log.info("Activation: the first block whose parent's median-time-past reaches the start time")
+        self.mocktime = START
+        node.setmocktime(self.mocktime)
+        while self.mtp(node.getblockcount()) < START:
+            self.assert_deploymentinfo(active=False)
+            self.generate(self.wallet, 1, sync_fun=self.no_op)
+        activation = node.getblockcount() + 1
+        self.log.info(f"  activation height {activation}")
+        self.assert_deploymentinfo(active=True, height=activation)
+        self.assert_gbt_rule(active=True)
+        self.generate(self.wallet, 1, sync_fun=self.no_op)  # block `activation`, the first in the window
+        self.assert_deploymentinfo(active=True, height=activation)
+        grandfathered = self.coinbase_utxo(activation - 1)
+        locked = self.coinbase_utxo(activation)
+
+        self.log.info("Inside the window: pre-activation coinbases keep the 100-block rule")
+        self.mine(COINBASE_MATURITY)  # tip = activation + 100
+        spend = self.wallet.create_self_transfer(utxo_to_spend=grandfathered)
+        node.sendrawtransaction(spend['hex'])
+        self.generate(node, 1, sync_fun=self.no_op)  # tip = activation + 101
+        assert_equal(node.getrawmempool(), [])
+
+        self.log.info("Inside the window: an in-window coinbase is locked past 100 confirmations")
+        locked_spend = self.wallet.create_self_transfer(utxo_to_spend=locked)
+        self.assert_spend_rejected(locked_spend['hex'])
+        assert_equal(self.submit_block_with(locked_spend['hex']), REJECT)
+        assert_equal(node.getblockcount(), activation + 101)
+
+        if self.is_wallet_compiled():
+            self.log.info("Wallet: an in-window reward stays immature past 100 confirmations")
+            node.createwallet('miner')
+            wallet_rpc = node.get_wallet_rpc('miner')
+            self.mocktime += 1
+            node.setmocktime(self.mocktime)
+            self.generatetoaddress(node, 1, wallet_rpc.getnewaddress(), sync_fun=self.no_op)
+            reward_height = node.getblockcount()
+            self.mine(COINBASE_MATURITY + 10)
+            balances = wallet_rpc.getbalances()['mine']
+            assert_greater_than(balances['immature'], 0)
+            assert_equal(balances['trusted'], 0)
+            assert_equal(wallet_rpc.listunspent(), [])
+            reward = wallet_rpc.listtransactions()[0]
+            assert_equal(reward['category'], 'immature')
+            assert_equal(reward['blockheight'], reward_height)
+
+        self.log.info("-reindex reproduces the chain and the activation height")
+        tip = node.getbestblockhash()
+        self.restart_node(0, extra_args=self.base_args + ['-reindex'])
+        node.setmocktime(self.mocktime)
+        node.add_p2p_connection(P2PInterface())
+        self.wait_until(lambda: node.getbestblockhash() == tip)
+        self.assert_deploymentinfo(active=True, height=activation)
+        self.assert_gbt_rule(active=True)
+        self.assert_spend_rejected(locked_spend['hex'])
+
+        self.log.info(f"Spendable at exactly {EXTENDED_COINBASE_MATURITY} confirmations")
+        self.mine(activation + EXTENDED_COINBASE_MATURITY - 2 - node.getblockcount())
+        assert_equal(node.getblockcount(), activation + EXTENDED_COINBASE_MATURITY - 2)
+        # Still one block short: the next block would give it depth 6479
+        self.assert_spend_rejected(locked_spend['hex'])
+        self.mine(1)
+        self.assert_deploymentinfo(active=True, height=activation)
+        node.sendrawtransaction(locked_spend['hex'])
+        assert_equal(node.getrawmempool(), [locked_spend['txid']])
+        self.generate(node, 1, sync_fun=self.no_op)
+        mature_block = node.getbestblockhash()
+        assert_equal(node.getblockcount(), activation + EXTENDED_COINBASE_MATURITY)
+        assert locked_spend['txid'] in node.getblock(mature_block)['tx']
+
+        self.log.info("A reorg below the maturity boundary evicts the spend from the mempool")
+        node.invalidateblock(mature_block)
+        assert_equal(node.getrawmempool(), [locked_spend['txid']])  # still exactly mature for the next block
+        boundary_block = node.getbestblockhash()
+        node.invalidateblock(boundary_block)
+        assert_equal(node.getrawmempool(), [])
+        node.reconsiderblock(boundary_block)
+        assert_equal(node.getbestblockhash(), mature_block)
+        assert_equal(node.getrawmempool(), [])
+
+        self.log.info("Hard expiry: the rule ends once the parent's median-time-past reaches the RDTS expiry")
+        # An in-window coinbase still well short of 6480 confirmations (and
+        # early enough that regtest's 150-block halvings leave it a value)
+        still_locked = self.coinbase_utxo(activation + 1000)
+        still_locked_spend = self.wallet.create_self_transfer(utxo_to_spend=still_locked)
+        self.assert_spend_rejected(still_locked_spend['hex'])
+        self.mocktime = EXPIRY
+        node.setmocktime(self.mocktime)
+        self.generate(node, 5, sync_fun=self.no_op)  # five of the last eleven blocks at EXPIRY: median still below it
+        assert_greater_than(EXPIRY, self.mtp(node.getblockcount()))
+        self.assert_deploymentinfo(active=True, height=activation)
+        self.assert_gbt_rule(active=True)
+        self.assert_spend_rejected(still_locked_spend['hex'])
+        self.generate(node, 1, sync_fun=self.no_op)  # the sixth: the median reaches EXPIRY
+        assert_equal(self.mtp(node.getblockcount()), EXPIRY)
+        last_active_tip = node.getbestblockhash()
+        self.assert_deploymentinfo(active=False, height=activation)
+        self.assert_gbt_rule(active=False)
+        node.sendrawtransaction(still_locked_spend['hex'])
+        self.generate(node, 1, sync_fun=self.no_op)
+        expired_block = node.getbestblockhash()
+        assert still_locked_spend['txid'] in node.getblock(expired_block)['tx']
+
+        self.log.info("A reorg back across the expiry evicts the spend from the mempool")
+        node.invalidateblock(expired_block)
+        assert_equal(node.getrawmempool(), [still_locked_spend['txid']])  # parent MTP still at EXPIRY
+        node.invalidateblock(last_active_tip)
+        self.assert_deploymentinfo(active=True, height=activation)
+        assert_equal(node.getrawmempool(), [])
+        node.reconsiderblock(last_active_tip)
+        assert_equal(node.getbestblockhash(), expired_block)
+        assert_equal(node.getrawmempool(), [])
+
+
+if __name__ == '__main__':
+    ExtendedCoinbaseMaturityTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -98,6 +98,7 @@ BASE_SCRIPTS = [
     'rpc_combinerawtransaction_unified.py --descriptors',
     'feature_taproot.py',
     'feature_reduced_data_temporary_deployment.py',
+    'feature_extended_coinbase_maturity.py',
     'feature_bip9_max_activation_height.py',
     'feature_rdts.py',
     'feature_rdts_ignore_rejects.py',


### PR DESCRIPTION
Temporarily extend coinbase maturity to 26280 blocks (~6 months, could be as little as 2 months depending on hashrate), to deter opportunistic mining and give honest miners an edge. Expires with RDTS. Mainnet/testnet params unset for now, activates with a flag day as soon as the community agrees.

Edit: Changed 6 months to 45 days based on community polls